### PR TITLE
Fixed hardcoded RCD refill/full message

### DIFF
--- a/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDAmmoSystem.cs
@@ -49,11 +49,11 @@ public sealed partial class RCDAmmoSystem : EntitySystem
         var count = Math.Min(charges.MaxCharges - current, comp.Charges);
         if (count <= 0)
         {
-            _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-full"), target, user);
+            _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-full", ("device", Name(target))), target, user); // Starlight: name the actual device (RCD/RPD/RPLD)
             return;
         }
 
-        _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-refilled"), target, user);
+        _popup.PopupClient(Loc.GetString("rcd-ammo-component-after-interact-refilled", ("device", Name(target))), target, user); // Starlight: name the actual device (RCD/RPD/RPLD)
         _sharedCharges.AddCharges(target, count);
         comp.Charges -= count;
         Dirty(uid, comp);

--- a/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
@@ -1,3 +1,5 @@
 rcd-ammo-component-on-examine = It holds {$charges} charges.
+# Starlight-start: name the actual device, since the RPD and RPLD share these messages
 rcd-ammo-component-after-interact-full = The {$device} is full!
 rcd-ammo-component-after-interact-refilled = You refill the {$device}.
+# Starlight-end

--- a/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-ammo-component.ftl
@@ -1,3 +1,3 @@
 rcd-ammo-component-on-examine = It holds {$charges} charges.
-rcd-ammo-component-after-interact-full = The RCD is full!
-rcd-ammo-component-after-interact-refilled = You refill the RCD.
+rcd-ammo-component-after-interact-full = The {$device} is full!
+rcd-ammo-component-after-interact-refilled = You refill the {$device}.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Fix RCD/RPD/RPLD refill popups stating "RCD" instead of the actual device name.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

bugfix

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/8f06d11a-19bb-4b22-9539-727d0243b053


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- tweak: When refilling RPD, RPLD or experimental variants of them, the correct name now displays.