### PR TITLE
Allow RCD to build airlocks and firelocks on top of each other

### DIFF
--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -147,6 +147,7 @@ public enum RcdConstructionRule : byte
     MustBuildOnSubfloor,        // Can only be built on exposed subfloor (e.g. catwalks on lattice or hull plating)
     IsWindow,                   // The entity is a window and can be built on grilles
     IsCatwalk,                  // The entity is a catwalk
+    IsAirlock,                  // The entity is an airlock and can be built on tiles occupied by firelocks
 }
 
 public enum RcdRotation : byte

--- a/Content.Shared/RCD/RCDPrototype.cs
+++ b/Content.Shared/RCD/RCDPrototype.cs
@@ -148,6 +148,7 @@ public enum RcdConstructionRule : byte
     IsWindow,                   // The entity is a window and can be built on grilles
     IsCatwalk,                  // The entity is a catwalk
     IsAirlock,                  // The entity is an airlock and can be built on tiles occupied by firelocks
+    IsFirelock,                 // The entity is a firelock and can be built on tiles occupied by airlocks
 }
 
 public enum RcdRotation : byte

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -37,6 +37,7 @@ using Content.Shared._Starlight.Atmos;
 using Content.Shared._Starlight.Atmos.Components;
 using Content.Shared.Prototypes;
 using Content.Shared._Starlight.Plumbing.Components;
+using Content.Shared.Doors.Components;
 // Starlight End
 
 namespace Content.Shared.RCD.Systems;
@@ -640,6 +641,7 @@ public sealed partial class RCDSystem : EntitySystem
         // Check rule: The tile is unoccupied
         var isWindow = prototype.ConstructionRules.Contains(RcdConstructionRule.IsWindow);
         var isCatwalk = prototype.ConstructionRules.Contains(RcdConstructionRule.IsCatwalk);
+        var isAirlock = prototype.ConstructionRules.Contains(RcdConstructionRule.IsAirlock); // Starlight: airlocks can be built over firelocks
         // Starlight Start: RPLD
         var isPlumbingMachinePlacement = component.IsRPLD
             && prototype.Prototype != null
@@ -653,6 +655,10 @@ public sealed partial class RCDSystem : EntitySystem
         {
             if (isWindow && HasComp<SharedCanBuildWindowOnTopComponent>(ent))
                 continue;
+            // Starlight Start: Airlocks can be built on a tile that already holds a firelock (any variant)
+            if (isAirlock && HasComp<FirelockComponent>(ent))
+                continue;
+            // Starlight End
             // Starlight Start: RPLD
             if (isPlumbingMachinePlacement && Transform(ent).Anchored && HasComp<PlumbingConnectorAppearanceComponent>(ent))
             {

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -656,11 +656,9 @@ public sealed partial class RCDSystem : EntitySystem
         {
             if (isWindow && HasComp<SharedCanBuildWindowOnTopComponent>(ent))
                 continue;
-            // Starlight Start: Airlocks can be built on a tile that already holds a firelock (any variant)
+            // Starlight Start: Airlocks and Firelocks can be built on top of one another
             if (isAirlock && HasComp<FirelockComponent>(ent))
                 continue;
-            // Starlight End
-            // Starlight Start: Firelocks can be built on a tile that already holds an airlock (any variant)
             if (isFirelock && HasComp<AirlockComponent>(ent))
                 continue;
             // Starlight End

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -642,6 +642,7 @@ public sealed partial class RCDSystem : EntitySystem
         var isWindow = prototype.ConstructionRules.Contains(RcdConstructionRule.IsWindow);
         var isCatwalk = prototype.ConstructionRules.Contains(RcdConstructionRule.IsCatwalk);
         var isAirlock = prototype.ConstructionRules.Contains(RcdConstructionRule.IsAirlock); // Starlight: airlocks can be built over firelocks
+        var isFirelock = prototype.ConstructionRules.Contains(RcdConstructionRule.IsFirelock); // Starlight: firelocks can be built over airlocks
         // Starlight Start: RPLD
         var isPlumbingMachinePlacement = component.IsRPLD
             && prototype.Prototype != null
@@ -657,6 +658,10 @@ public sealed partial class RCDSystem : EntitySystem
                 continue;
             // Starlight Start: Airlocks can be built on a tile that already holds a firelock (any variant)
             if (isAirlock && HasComp<FirelockComponent>(ent))
+                continue;
+            // Starlight End
+            // Starlight Start: Firelocks can be built on a tile that already holds an airlock (any variant)
+            if (isFirelock && HasComp<AirlockComponent>(ent))
                 continue;
             // Starlight End
             // Starlight Start: RPLD

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -168,6 +168,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules: # Starlight
+    - IsAirlock # Starlight
   rotation: Camera
   fx: EffectRCDConstruct4
 
@@ -180,6 +182,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules: # Starlight
+    - IsAirlock # Starlight
   rotation: Camera
   fx: EffectRCDConstruct4
 

--- a/Resources/Prototypes/RCD/rcd.yml
+++ b/Resources/Prototypes/RCD/rcd.yml
@@ -196,6 +196,8 @@
   cost: 4
   delay: 3
   collisionMask: FullTileMask
+  rules: # Starlight
+    - IsFirelock # Starlight
   rotation: Camera
   fx: EffectRCDConstruct3
 

--- a/Resources/Prototypes/_Starlight/RCD/rcd.yml
+++ b/Resources/Prototypes/_Starlight/RCD/rcd.yml
@@ -9,6 +9,8 @@
   delay: 3
   collisionMask: Impassable
   collisionBounds: "-0.23,-0.49,0.23,-0.36"
+  rules:
+    - IsFirelock
   rotation: User
   fx: EffectRCDConstruct3
 

--- a/Resources/Prototypes/_Starlight/RCD/rcd_xeno.yml
+++ b/Resources/Prototypes/_Starlight/RCD/rcd_xeno.yml
@@ -33,6 +33,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules:
+    - IsAirlock
   rotation: Camera
   fx: EffectRCDConstruct4
 
@@ -45,6 +47,8 @@
   cost: 4
   delay: 4
   collisionMask: FullTileMask
+  rules:
+    - IsAirlock
   rotation: Camera
   fx: EffectRCDConstruct4
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

The RCD can now build airlocks and firelocks on top of each other. Covers all firelock variants.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Firelocks and airlocks block the other's placement.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/d9f559e3-e502-49d8-8ae6-52ed2a0db707

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- tweak: The RCD can now build airlocks and firelocks on top of each other.