### PR TITLE
Fix JobWeightTest causing failures

### DIFF
--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
-using Content.IntegrationTests.Pair;
+using Content.IntegrationTests.Fixtures.Attributes;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
@@ -49,6 +49,16 @@ public sealed class JobTest : GameTest
         Connected = true,
         InLobby = true
     };
+
+    // Starlight START: Separate settings for JobWeightTest to dirty the pair
+    public static PoolSettings Disconnected => new()
+    {
+        DummyTicker = false,
+        Connected = true,
+        InLobby = true,
+        Dirty = true,
+    };
+    // Starlight END
 
     /// <summary>
     /// Simple test that checks that starting the round spawns the player into the test map as a passenger.
@@ -121,6 +131,7 @@ public sealed class JobTest : GameTest
     /// get their preferred job.
     /// </summary>
     [Test]
+    [PairConfig(nameof(Disconnected))] // Starlight: Needs to dirty pair
     public async Task JobWeightTest()
     {
         var pair = Pair;

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -50,16 +50,6 @@ public sealed class JobTest : GameTest
         InLobby = true
     };
 
-    // Starlight START: Separate settings for JobWeightTest to dirty the pair
-    public static PoolSettings Disconnected => new()
-    {
-        DummyTicker = false,
-        Connected = true,
-        InLobby = true,
-        Dirty = true,
-    };
-    // Starlight END
-
     /// <summary>
     /// Simple test that checks that starting the round spawns the player into the test map as a passenger.
     /// </summary>
@@ -131,7 +121,6 @@ public sealed class JobTest : GameTest
     /// get their preferred job.
     /// </summary>
     [Test]
-    [PairConfig(nameof(Disconnected))] // Starlight: Needs to dirty pair
     public async Task JobWeightTest()
     {
         var pair = Pair;
@@ -161,8 +150,7 @@ public sealed class JobTest : GameTest
 
         pair.AssertJob(Captain);
 
-        await pair.Client.WaitPost(() => ((IClientNetManager) pair.Client.NetMan).ClientDisconnect("JobWeightTest cleanup"));
-        await pair.RunTicksSync(1);
+        // Starlight: Removed 2 lines that caused pair to require dirtying
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
     }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -150,7 +150,8 @@ public sealed class JobTest : GameTest
 
         pair.AssertJob(Captain);
 
-        // Starlight: Removed 2 lines that caused pair to require dirtying
+        // await pair.Client.WaitPost(() => ((IClientNetManager) pair.Client.NetMan).ClientDisconnect("JobWeightTest cleanup")); // Starlight: No, don't make the pair require dirtying.
+        // await pair.RunTicksSync(1); // Starlight
 
         await pair.Server.WaitPost(() => ticker.RestartRound());
     }

--- a/Content.IntegrationTests/Tests/Round/JobTest.cs
+++ b/Content.IntegrationTests/Tests/Round/JobTest.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Content.IntegrationTests.Fixtures;
-using Content.IntegrationTests.Fixtures.Attributes;
+using Content.IntegrationTests.Pair;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
 using Content.Shared.GameTicking;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

JobWeightTest disconnects the pair, but does not dirty the pair. The rest of the tests rely on them being connected

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Failing lots, e.g. on https://github.com/ss14Starlight/space-station-14/pull/5169

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Not user facing, no CL