### PR TITLE
Fix RCD spawning a debug variant of light post

### DIFF
--- a/Resources/Prototypes/_Starlight/RCD/rcd.yml
+++ b/Resources/Prototypes/_Starlight/RCD/rcd.yml
@@ -18,7 +18,7 @@
   category: Lighting
   sprite: /Textures/_Starlight/Interface/Radial/RCD/small_light_post.png
   mode: ConstructObject
-  prototype: LightPostSmall
+  prototype: PoweredLightPostSmall
   cost: 3
   delay: 2
   collisionMask: MachineMask


### PR DESCRIPTION
## Short description

Title

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

It's busted

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: RCD now spawns the correct post light variant.
