### PR TITLE
You can no longer see when people are stripping you

### DIFF
--- a/Content.Shared/Strip/SharedStrippableSystem.cs
+++ b/Content.Shared/Strip/SharedStrippableSystem.cs
@@ -868,8 +868,13 @@ public abstract partial class SharedStrippableSystem : EntitySystem
         if (args.Handled || !args.Complex || args.Target == args.User)
             return;
 
+        // Begin Stellar Changes - don't play an interact particle for examining the strip UI
         if (TryOpenStrippingUi(args.User, (uid, component)))
+        {
             args.Handled = true;
+            args.InteractionParticle = false;
+        }
+        // End Stellar Changes - don't play an interact particle for examining the strip UI
     }
 
     /// <summary>
@@ -920,19 +925,6 @@ public abstract partial class SharedStrippableSystem : EntitySystem
 
         if (!HasComp<StrippingComponent>(user))
             return false;
-
-        // Moffstation - Start - Interaction particles and strip menu notification
-        // Do this check to make it harder to spam the chat
-        var (_, stealth) = GetStripTimeModifiers(user, target, null, target.Comp.HandStripDelay);
-        if (!stealth && !_ui.IsUiOpen(target.Owner, StrippingUiKey.Key))
-        {
-            _popupSystem.PopupCoordinates(
-                Loc.GetString("strip-menu-viewing-message", ("user", Identity.Entity(user, EntityManager))),
-                Transform(user).Coordinates,
-                target.Owner
-                );
-        }
-        // Moffstation - end
 
         _ui.OpenUi(target.Owner, StrippingUiKey.Key, user);
         return true;


### PR DESCRIPTION
## Short description
Hides the strip effect, originally hidden in [this pr](https://github.com/DeltaV-Station/Delta-v/pull/5933), but then it got re-enabled in [this pr](https://github.com/moff-station/moff-station-14/pull/1489).

## Why we need to add this
Kinda makes it impossible to steal.

## Media (Video/Screenshots)
[Content.Client_QNbfUWMyn8.webm](https://github.com/user-attachments/assets/a460ee0f-28d2-4588-8ba5-85d4f6654c62)
Going to confirm real quick with a video, after this completes tests it should be merged to live asap.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, sowelipililimute
- fix: You can no longer see when people are stripping you.

