### PR TITLE
Secret doors are secret again

### DIFF
--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -238,6 +238,14 @@ public sealed partial class DoorComponent : Component
     /// </summary>
     public object EmaggingAnimation = default!;
 
+    #region Starlight
+    /// <summary>
+    /// Whether activating this door displays an interaction particle.
+    /// </summary>
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool ShowInteractionParticle = true;
+    #endregion
+
     #endregion Graphics
 
     #region Serialization

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -203,6 +203,8 @@ public abstract partial class SharedDoorSystem : EntitySystem
     #region Interactions
     protected void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
     {
+        args.InteractionParticle &= door.ShowInteractionParticle; // Starlight, don't show SECRET doors
+
         // Starlight edit start: Enable entities with prying capabilities on themselves to open doors
         var pryingCapable = args.Complex || HasComp<PryingComponent>(args.User);
         if (args.Handled || !pryingCapable || !door.ClickOpen)

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -38,6 +38,7 @@
     openTimeTwo: 0.2
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
+    showInteractionParticle: false # Starlight
   - type: Appearance
   - type: Weldable
     time: 2


### PR DESCRIPTION
## Short description
Secret doors no longer display an interaction particle.

## Why we need to add this
Not really secret if you can see them now, are they?

## Media (Video/Screenshots)
[Content.Client_huzuCnQTKN.webm](https://github.com/user-attachments/assets/62fb8f44-3e61-4bf0-bc27-1e9aa74e3975)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Secret doors no longer display an interaction particle.
