### PR TITLE
Interaction particles are now optional

### DIFF
--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml
@@ -13,6 +13,7 @@
                 <Label Text="{Loc 'ui-options-quality-label'}" StyleClasses="LabelKeyText"/>
                 <ui:OptionDropDown Name="DropDownLightingQuality" Title="{Loc 'ui-options-lighting-label'}" />
                 <ui:OptionDropDown Name="DropDownParticleQuality" Title="{Loc 'ui-options-particles-label'}" /> <!-- _Starfall: Particles -->
+                <CheckBox Name="InteractionParticlesCheckBox" Text="{Loc 'ui-options-interaction-particles'}" ToolTip="{Loc 'ui-options-interaction-particles-tooltip'}" /> <!-- Starlight, interaction particles -->
                 <CheckBox Name="ViewportLowResCheckBox" Text="{Loc 'ui-options-vp-low-res'}" />
                 <CheckBox Name="ParallaxLowQualityCheckBox" Text="{Loc 'ui-options-parallax-low-quality'}" />
                 <CheckBox Name="AmbientOcclusionCheckBox" Text="{Loc 'ui-options-ambient-occlusion'}" />

--- a/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/GraphicsTab.xaml.cs
@@ -26,6 +26,7 @@ public sealed partial class GraphicsTab : Control
         Control.AddOption(new OptionFullscreen(Control, _cfg, FullscreenCheckBox));
         Control.AddOption(new OptionLightingQuality(Control, _cfg, DropDownLightingQuality));
         Control.AddOption(new OptionParticleQuality(Control, _cfg, DropDownParticleQuality)); // _Starfall: Particle quality.
+        Control.AddOptionCheckBox(StarlightCCVars.InteractionParticlesEnabled, InteractionParticlesCheckBox); // Starlight, interaction particles
 
         Control.AddOptionDropDown(
             CVars.DisplayUIScale,

--- a/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
+++ b/Content.Client/_ST/Interaction/StellarInteractionParticleSystem.cs
@@ -5,8 +5,10 @@
 using System.Numerics;
 using Content.Client._Moffstation.Interaction;
 using Content.Shared._ST.Interaction;
+using Content.Shared._Starlight.CCVar;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
+using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -20,6 +22,9 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
     [Dependency] private SpriteSystem _sprite = default!;
     [Dependency] private AnimationPlayerSystem _animation = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IConfigurationManager _cfg = default!; // Starlight
+
+    private bool _interactionParticlesEnabled; // Starlight
 
     private const string AnimateKey = "particle-animation";
 
@@ -33,11 +38,16 @@ public sealed partial class StellarInteractionParticleSystem : EntitySystem
     {
         base.Initialize();
 
+    Subs.CVar(_cfg, StarlightCCVars.InteractionParticlesEnabled, value => _interactionParticlesEnabled = value, true); // Starlight, interaction particle config
+
         SubscribeAllEvent<StellarInteractionParticleEvent>(OnInteractionParticle);
     }
 
     private void OnInteractionParticle(StellarInteractionParticleEvent ev)
     {
+        if (!_interactionParticlesEnabled) // Starlight, check if interaction particles are enabled
+            return; // Starlight, if not, don't display them!
+
         var performer = GetEntity(ev.Performer);
         var used = GetEntity(ev.Used);
         var target = GetEntity(ev.Target);

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
@@ -5,4 +5,11 @@ public sealed partial class StarlightCCVars
 {
     public static readonly CVarDef<bool> TracesEnabled =
         CVarDef.Create("opt.traces_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Whether hand, item, and pulling interaction particles are displayed.
+    /// Does not affect spark effects.
+    /// </summary>
+    public static readonly CVarDef<bool> InteractionParticlesEnabled =
+        CVarDef.Create("opt.interaction_particles_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
@@ -8,7 +8,6 @@ public sealed partial class StarlightCCVars
 
     /// <summary>
     /// Whether hand, item, and pulling interaction particles are displayed.
-    /// Does not affect spark effects.
     /// </summary>
     public static readonly CVarDef<bool> InteractionParticlesEnabled =
         CVarDef.Create("opt.interaction_particles_enabled", true, CVar.CLIENTONLY | CVar.ARCHIVE);

--- a/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_Starlight/escape-menu/ui/options-menu.ftl
@@ -66,3 +66,7 @@ ui-options-admin-ghost-script-label = aghost Script
 ui-options-admin-ghost-script-tooltip =
     The name of the script you want to automatically run when becoming admin ghost, either by command or by observing from lobby.
     Path is relative to your launcher's data directory, typically inside AppData on Windows or .local/share on Linux.
+
+# Graphics
+ui-options-interaction-particles = Show interaction particles
+ui-options-interaction-particles-tooltip = Shows hand, item, and pulling effects when characters interact.


### PR DESCRIPTION
## Short description
Config menu option.

This one was quite simple, though as always, I admit when I used AI for help, so I'll admit here too. Although, it was actually simple enough that I could've done it myself. As I'm learning a lot of these things are...

## Why we need to add this
Some people don't like them, fair enough. Still on by default though, so new players can benefit from them.

## Media (Video/Screenshots)
[Content.Client_yL9Q0qzKxZ.webm](https://github.com/user-attachments/assets/db5d334c-d6af-4a42-b413-abb9fe48f458)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Interaction particles are now optional via options menu.

