### PR TITLE
Hypopens and Microinjectors no longer have interaction particles

### DIFF
--- a/Content.Shared/Chemistry/Components/InjectorComponent.cs
+++ b/Content.Shared/Chemistry/Components/InjectorComponent.cs
@@ -72,6 +72,14 @@ public sealed partial class InjectorComponent : Component
     [DataField]
     public bool IgnoreClosed = true;
 
+    #region Starlight
+    /// <summary>
+    /// Whether using this injector displays interaction particles.
+    /// </summary>
+    [DataField]
+    public bool ShowInteractionParticles = true;
+    #endregion
+
     /// <summary>
     /// Reagents that are allowed to be within this injector.
     /// If a solution has both allowed and non-allowed reagents, only allowed reagents will be drawn into this injector.

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -56,6 +56,8 @@ public sealed partial class InjectorSystem : EntitySystem
     #region Events Handling
     private void OnInjectorUse(Entity<InjectorComponent> injector, ref UseInHandEvent args)
     {
+        args.ShowInteractionParticles &= injector.Comp.ShowInteractionParticles; // Starlight
+
         if (args.Handled
             || !_prototypeManager.Resolve(injector.Comp.ActiveModeProtoId, out var activeProto))
             return;
@@ -71,6 +73,8 @@ public sealed partial class InjectorSystem : EntitySystem
 
     private void OnInjectorAfterInteract(Entity<InjectorComponent> injector, ref AfterInteractEvent args)
     {
+        args.SpawnInteractionParticles &= injector.Comp.ShowInteractionParticles; // Starlight
+
         if (args.Handled || !args.CanReach || args.Target is not { Valid: true } target)
             return;
 

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -243,7 +243,7 @@ public sealed partial class DoorComponent : Component
     /// Whether activating this door displays an interaction particle.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public bool ShowInteractionParticle = true;
+    public bool ShowInteractionParticles = true;
     #endregion
 
     #endregion Graphics

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -203,7 +203,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
     #region Interactions
     protected void OnActivate(EntityUid uid, DoorComponent door, ActivateInWorldEvent args)
     {
-        args.InteractionParticle &= door.ShowInteractionParticle; // Starlight, don't show SECRET doors
+        args.InteractionParticle &= door.ShowInteractionParticles; // Starlight, don't show SECRET doors
 
         // Starlight edit start: Enable entities with prying capabilities on themselves to open doors
         var pryingCapable = args.Complex || HasComp<PryingComponent>(args.User);

--- a/Content.Shared/Interaction/Events/UseInHandEvent.cs
+++ b/Content.Shared/Interaction/Events/UseInHandEvent.cs
@@ -21,6 +21,12 @@ public sealed class UseInHandEvent : HandledEntityEventArgs
     /// </summary>
     public bool ApplyDelay = true;
 
+    #region Starlight
+    /// <summary>
+    /// Whether this use should display interaction particles.
+    /// </summary>
+    public bool ShowInteractionParticles = true;
+    #endregion
     public UseInHandEvent(EntityUid user)
     {
         User = user;

--- a/Content.Shared/Interaction/SharedInteractionSystem.cs
+++ b/Content.Shared/Interaction/SharedInteractionSystem.cs
@@ -1260,7 +1260,7 @@ namespace Content.Shared.Interaction
             RaiseLocalEvent(used, useMsg, true);
             if (useMsg.Handled)
             {
-                DoContactInteraction(user, used, null, true, useMsg); // ES - Interaction particles
+                DoContactInteraction(user, used, null, true, useMsg, interactionParticles: useMsg.ShowInteractionParticles); // ES - Interaction particles - Starlight, you can now disable them too
                 if (delayComponent != null && useMsg.ApplyDelay)
                     _useDelay.TryResetDelay((used, delayComponent));
                 return true;

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -632,6 +632,13 @@
     layers:
     - state: microstimpen
       map: ["enum.SolutionContainerLayers.Fill"]
+  - type: Injector # Starlight start
+    solutionName: pen # This section's really only here so we can make the microinjector not have interaction particles
+    currentTransferAmount: null
+    activeModeProtoId: HyposprayInjectMode
+    allowedModes:
+    - HyposprayInjectMode
+    showInteractionParticles: false # Starlight end
   - type: SolutionContainerManager
     solutions:
       pen:
@@ -708,6 +715,7 @@
     allowedModes:
     - HyposprayInjectMode
     - HypopenDynamicMode
+    showInteractionParticles : false
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -633,11 +633,6 @@
     - state: microstimpen
       map: ["enum.SolutionContainerLayers.Fill"]
   - type: Injector # Starlight start
-    solutionName: pen # This section's really only here so we can make the microinjector not have interaction particles
-    currentTransferAmount: null
-    activeModeProtoId: HyposprayInjectMode
-    allowedModes:
-    - HyposprayInjectMode
     showInteractionParticles: false # Starlight end
   - type: SolutionContainerManager
     solutions:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -715,7 +715,7 @@
     allowedModes:
     - HyposprayInjectMode
     - HypopenDynamicMode
-    showInteractionParticles : false
+    showInteractionParticles : false # Starlight
   - type: UseDelay
     delay: 0.5
   - type: StaticPrice # A new shitcurity meta

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -38,7 +38,7 @@
     openTimeTwo: 0.2
     openingAnimationTime: 1.2
     closingAnimationTime: 1.2
-    showInteractionParticle: false # Starlight
+    showInteractionParticles: false # Starlight
   - type: Appearance
   - type: Weldable
     time: 2


### PR DESCRIPTION
## Short description
Hypopens and microinjectors (ie, just the hyperzine one) no longer have interaction particles.

## Why we need to add this
Can't really use the hypopen secretly if everyone can see it. The hyposprays aren't small, everyone should be able to see them.

I guess a niche buff for the hyperzine microinjector too.

## Media (Video/Screenshots)
[Content.Client_dzAlQFqiK4.webm](https://github.com/user-attachments/assets/a8463b9c-160c-40af-99ec-94e131d2051c)


## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Hypopens and microinjectors (so just the hyperzine one) no longer have interaction particles.
