### PR TITLE
Add an ERT Chaplain spawn point to the ERT Chaplain shuttle

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/CC-NT/Chaplain_GRID.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CC-NT/Chaplain_GRID.yml
@@ -3736,7 +3736,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
       parent: 2
-- proto: SpawnPointERTChaplain
+- proto: SpawnPointGhostERTChaplain
   entities:
   - uid: 532
     components:

--- a/Resources/Maps/_Starlight/Shuttles/CC-NT/Chaplain_GRID.yml
+++ b/Resources/Maps/_Starlight/Shuttles/CC-NT/Chaplain_GRID.yml
@@ -5,7 +5,7 @@ meta:
   forkId: starlight
   forkVersion: fa8e239d0a543c6b28095c43a0c08e188d953310
   time: 10/07/2025 21:52:20
-  entityCount: 516
+  entityCount: 517
 maps: []
 grids:
 - 2
@@ -3735,5 +3735,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
+      parent: 2
+- proto: SpawnPointERTChaplain
+  entities:
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 0.5,2.5
       parent: 2
 ...

--- a/Resources/Maps/_Starlight/Shuttles/SecureTerminal/ERT-Chaplain.yml
+++ b/Resources/Maps/_Starlight/Shuttles/SecureTerminal/ERT-Chaplain.yml
@@ -5,7 +5,7 @@ meta:
   forkId: starlight
   forkVersion: fa8e239d0a543c6b28095c43a0c08e188d953310
   time: 10/07/2025 21:52:20
-  entityCount: 516
+  entityCount: 517
 maps: []
 grids:
 - 2
@@ -3735,5 +3735,12 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-11.5
+      parent: 2
+- proto: SpawnPointGhostERTChaplain
+  entities:
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 0.5,2.5
       parent: 2
 ...


### PR DESCRIPTION
## Short description
Adds a singular spawnpoint to the ERT Chaplain's shuttle.

## Why we need to add this
[Antag Selection (Rebirth)](https://github.com/ss14Starlight/space-station-14/pull/4958) gets rid of the ERT Chaplain Antag ghost role, in favor of a normal ERT Chaplain ghost role, so it needs a singular spawn point mapped. Including this here so the other PR doesn't get hit with a mapping tag.

## Media (Video/Screenshots)
<img width="374" height="391" alt="image" src="https://github.com/user-attachments/assets/9afd340f-e0d8-459e-a0be-9c098987181b" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Technically nothing player facing until Antag Selection (Rebirth) is merged.