### PR TITLE
Various Energy Gun Changes [Pacifism Fixes]

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -86,6 +86,7 @@
       visualState: disable
       magState: disable
       heldPrefix: disable4
+      pacifismAllowedMode: true
     - proto: RedLaserBeam
       fireCost: 66.6
       visualState: kill
@@ -114,10 +115,12 @@
   - type: BatteryAmmoProvider
     proto: DisablerBolt
     fireCost: 100
+    pacifismAllowedMode: true
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
       fireCost: 100
+      pacifismAllowedMode: true
     - proto: RedLaserBeam
       fireCost: 200
       conditions:
@@ -191,15 +194,18 @@
     access: [["Security"], ["Cadet"]]
   - type: BatteryAmmoProvider
     proto: DisablerBolt
+    pacifismAllowedMode: true
     fireCost: 50
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
       fireCost: 50
       magState: disable
+      pacifismAllowedMode: true
     - proto: TaserBolt
       fireCost: 166
       magState: stun
+      pacifismAllowedMode: true
       conditions:
       - !type:AlertLevelCondition
         alertLevels:
@@ -260,16 +266,19 @@
   - type: BatteryAmmoProvider
     proto: DisablerBolt
     fireCost: 40
+    pacifismAllowedMode: true
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
       fireCost: 40
       magState: disable
       visualState: disable-unshaded
+      pacifismAllowedMode: true
     - proto: TaserBolt
       fireCost: 100
       magState: stun
       visualState: stun-unshaded
+      pacifismAllowedMode: true
     - proto: RedLaserBeam
       fireCost: 75
       magState: kill
@@ -915,6 +924,7 @@
       fireCost: 25
       magState: disable
       visualState: disable
+      pacifismAllowedMode: true
   - type: Item
     size: Large
     shape:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -115,7 +115,6 @@
   - type: BatteryAmmoProvider
     proto: DisablerBolt
     fireCost: 100
-    pacifismAllowedMode: true
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt
@@ -194,7 +193,6 @@
     access: [["Security"], ["Cadet"]]
   - type: BatteryAmmoProvider
     proto: DisablerBolt
-    pacifismAllowedMode: true
     fireCost: 50
   - type: BatteryWeaponFireModes
     fireModes:
@@ -266,7 +264,6 @@
   - type: BatteryAmmoProvider
     proto: DisablerBolt
     fireCost: 40
-    pacifismAllowedMode: true
   - type: BatteryWeaponFireModes
     fireModes:
     - proto: DisablerBolt


### PR DESCRIPTION

## Short description
Allows the Dominator, Miniature Energy Gun, Proto-5x, and X-01's disabler and taser functions to be fireable with pacifism enabled.

## Why we need to add this
It's been very inconsistent with guns disable/tazer settings working with pacifism (See ward's energy shotgun, it works. But the proto-5x does not), and fixing a handful of these weapons. This is not a comprehensive update, but these are the main guns that are really... obtainable? afaik? 

## Media (Video/Screenshots)
Media not required. 

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SeaTheProto
-tweak: allow Dominator, Miniature Energy Gun, Proto-5x, and the X-01's disabling settings to work with pacifism. Pacifists rejoice!
