### PR TITLE
Remove sparks from lightning

### DIFF
--- a/Content.Server/Tesla/EntitySystem/LightningSparkingSystem.cs
+++ b/Content.Server/Tesla/EntitySystem/LightningSparkingSystem.cs
@@ -24,7 +24,7 @@ public sealed partial class LightningSparkingSystem : EntitySystem
     {
         _appearance.SetData(uid.Owner, TeslaCoilVisuals.Lightning, true);
         uid.Comp.LightningEndTime = _gameTiming.CurTime + TimeSpan.FromSeconds(uid.Comp.LightningTime);
-        uid.Comp.IsSparking = true;
+        uid.Comp.IsSparking = false;
     }
 
     public override void Update(float frameTime)


### PR DESCRIPTION
Removes sparking from lightning

## Short description
Removes sparking from lightning due to supermatter interaction

## Why we need to add this
Supermatter will ignite its tritium when striking entities. (can maybe be re-enabled if it can be moved to the entity being struck instead).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- remove: lightning ignition sparks.
