### PR TITLE
CosCult rift fixes

### DIFF
--- a/Content.Shared/Anomaly/Components/AnomalyComponent.cs
+++ b/Content.Shared/Anomaly/Components/AnomalyComponent.cs
@@ -227,6 +227,9 @@ public sealed partial class AnomalyComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool CanPulse = true;
+
+    [DataField, AutoNetworkedField]
+    public bool CanBePunched = true;
     #endregion
 
     #region Points and Vessels

--- a/Content.Shared/Anomaly/SharedAnomalySystem.cs
+++ b/Content.Shared/Anomaly/SharedAnomalySystem.cs
@@ -48,7 +48,11 @@ public abstract partial class SharedAnomalySystem : EntitySystem
 
     private void OnAnomalyThrowStart(Entity<AnomalyComponent> ent, ref MeleeThrowOnHitStartEvent args)
     {
-        if (!TryComp<CorePoweredThrowerComponent>(args.Weapon, out var corePowered) || !TryComp<PhysicsComponent>(ent, out var body))
+        // Starlight edit Start: Added CanBePunched
+        if (!ent.Comp.CanBePunched ||
+            !TryComp<CorePoweredThrowerComponent>(args.Weapon, out var corePowered) ||
+            !TryComp<PhysicsComponent>(ent, out var body))
+        // Starlight edit End
             return;
 
         // anomalies are static by default, so we have set them to dynamic to be throwable

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -463,8 +463,8 @@
     corePrototype: null
     coreInertPrototype: null
     deleteEntity: true
-    minPointsPerSecond: 10
-    maxPointsPerSecond: 70
+    minPointsPerSecond: 0
+    maxPointsPerSecond: 0
     decayhreshold: -1
     severityGrowthCoefficient: 0
     healthChangePerSecond: 0
@@ -476,6 +476,7 @@
     useNormalContainmentParticle: false
     useNormalTransformationParticle: false
     canPulse: false
+    canBePunched: false
     particleInteractions:
     - interactionKey: NullspaceStabilizer
       effect: EndAnomaly


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes two issues with cosmic rifts, 1. They were never meant to generate points (It shows up as an error on scanners) and 2. they should not be moveable as the area they expand from goes from where they spawned not from the rift.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bigfixes
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: You can no longer G.O.R.I.L.L.A. Punch CosCult rifts.
- fix: CosCult rifts no longer generate points.