### PR TITLE
AI upload console can now be bought from Cargo

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/Cargo/cargo_science.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Cargo/cargo_science.yml
@@ -8,3 +8,13 @@
 #   cost: 5000
 #   category: cargoproduct-category-name-science
 #   group: market
+
+- type: cargoProduct
+  id: StationAiUpload
+  icon:
+    sprite: Objects/Misc/module.rsi
+    state: std_mod
+  product: CrateStationAiUpload
+  cost: 4000
+  category: cargoproduct-category-name-science
+  group: market

--- a/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/science.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Fills/Crates/science.yml
@@ -39,3 +39,21 @@
             - id: GraySlimeExtract
             - id: MonkeyCubeBox
             - id: XenobiologyConsoleCameraTagger
+
+- type: entity
+  parent: CrateScienceSecure
+  id: CrateStationAiUpload
+  name: station AI upload console crate
+  description: Contains the components for constructing a station AI upload console. Still requires manual linking to the core. Requires Science access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: StationAiUploadCircuitboard
+        - id: SheetSteel1
+          amount: 5
+        - id: SheetGlass1
+          amount: 2
+        - id: CableApcStack1
+          amount: 5


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Adds a way for cargo to purchase a new AI upload console. Still requires linking to the AI via a multitool.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Antagonists would often steal the AI upload console to prevent relawing the AI, forcing the RD, or whoever else has a telecard, to just card the AI and carry the malf AI around until evac.

This makes fixing the AI after a stolen console more difficult rather than impossible.  

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="571" height="48" alt="image" src="https://github.com/user-attachments/assets/19fa0ae1-8812-459a-909c-7b089bffee46" />
<img width="436" height="154" alt="image" src="https://github.com/user-attachments/assets/591bdaa2-65e7-482c-8872-179367ac67c0" />
<img width="448" height="258" alt="image" src="https://github.com/user-attachments/assets/c4c28e3d-6e83-4c12-8189-7554a6425b3c" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Musiklie
- add: Added a purchasable AI upload crate to the Cargo console, giving command a way to fix a malf AI even if the antag broke the console.
