### PR TITLE
Upstream/spawn rotation

### DIFF
--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -127,15 +127,16 @@ namespace Content.Server.Spawners.EntitySystems
                 return;
 
             var coords = Transform(ent).Coordinates;
+            var offset = ent.Comp.Offset;
 
             var spawns = _entityTable.GetSpawns(ent.Comp.Table);
             foreach (var proto in spawns)
             {
-                var xOffset = _robustRandom.NextFloat(-ent.Comp.Offset, ent.Comp.Offset);
-                var yOffset = _robustRandom.NextFloat(-ent.Comp.Offset, ent.Comp.Offset);
+                var xOffset = _robustRandom.NextFloat(-offset, offset);
+                var yOffset = _robustRandom.NextFloat(-offset, offset);
                 var trueCoords = coords.Offset(new Vector2(xOffset, yOffset));
 
-                SpawnAtPosition(proto, trueCoords);
+                SpawnAttachedTo(proto, trueCoords);
             }
         }
     }

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -1,12 +1,15 @@
-using System.Numerics;
 using Content.Server.GameTicking;
 using Content.Server.Spawners.Components;
 using Content.Shared.EntityTable;
 using Content.Shared.GameTicking.Components;
 using JetBrains.Annotations;
-using Robust.Shared.Map;
+using Robust.Server.GameObjects;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 
+// TODO: This whole system is a mess. A lot of this should be marked obsolete.
+// TODO: It should probably use interfaces with entity tables *if* more than one component is needed.
+// TODO: Remove the TransformSystem Dependency when engine SpawnAtPosition EntityCoordinates override is fixed.
 namespace Content.Server.Spawners.EntitySystems
 {
     [UsedImplicitly]
@@ -15,6 +18,7 @@ namespace Content.Server.Spawners.EntitySystems
         [Dependency] private IRobustRandom _robustRandom = default!;
         [Dependency] private GameTicker _ticker = default!;
         [Dependency] private EntityTableSystem _entityTable = default!;
+        [Dependency] private TransformSystem _xform = default!;
 
         public override void Initialize()
         {
@@ -88,37 +92,64 @@ namespace Content.Server.Spawners.EntitySystems
                 return;
             }
 
-            if (!Deleted(uid))
-                Spawn(_robustRandom.Pick(component.Prototypes), Transform(uid).Coordinates);
+            if (Deleted(uid))
+                return;
+
+            var xform = Transform(uid);
+            var coords = _xform.GetMapCoordinates(uid, xform);
+            var rotation = _xform.GetWorldRotation(xform);
+
+            Spawn(_robustRandom.Pick(component.Prototypes), coords, rotation: rotation);
         }
 
         private void Spawn(EntityUid uid, RandomSpawnerComponent component)
         {
-            if (component.RarePrototypes.Count > 0 && (component.RareChance == 1.0f || _robustRandom.Prob(component.RareChance)))
-            {
-                Spawn(_robustRandom.Pick(component.RarePrototypes), Transform(uid).Coordinates);
-                return;
-            }
-
-            if (component.Chance != 1.0f && !_robustRandom.Prob(component.Chance))
-                return;
-
-            if (component.Prototypes.Count == 0)
-            {
-                Log.Warning($"Prototype list in RandomSpawnerComponent is empty! Entity: {ToPrettyString(uid)}");
-                return;
-            }
-
             if (Deleted(uid))
                 return;
 
+            if (GetPrototype((uid, component)) is not { } proto)
+                return;
+
             var offset = component.Offset;
-            var xOffset = _robustRandom.NextFloat(-offset, offset);
-            var yOffset = _robustRandom.NextFloat(-offset, offset);
+            var vOffset = _robustRandom.NextVector2Box(-offset, offset);
 
-            var coordinates = Transform(uid).Coordinates.Offset(new Vector2(xOffset, yOffset));
+            var xform = Transform(uid);
+            var coords = _xform.GetMapCoordinates(uid, xform).Offset(vOffset);
+            var rotation = _xform.GetWorldRotation(xform);
 
-            Spawn(_robustRandom.Pick(component.Prototypes), coordinates);
+            Spawn(proto, coords, rotation: rotation);
+        }
+
+        private EntProtoId? GetPrototype(Entity<RandomSpawnerComponent> spawner)
+        {
+            if (GetPrototypes(spawner) is not { } list)
+                return null;
+
+            return _robustRandom.Pick(list);
+        }
+
+        private List<EntProtoId>? GetPrototypes(Entity<RandomSpawnerComponent> spawner)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (spawner.Comp.RarePrototypes.Count > 0 &&
+                (spawner.Comp.RareChance == 1.0f || _robustRandom.Prob(spawner.Comp.RareChance)))
+            {
+                return spawner.Comp.RarePrototypes;
+            }
+
+            if (spawner.Comp.Prototypes.Count == 0)
+            {
+                Log.Warning($"Prototype list in RandomSpawnerComponent is empty! Entity: {ToPrettyString(spawner)}");
+                return null;
+            }
+
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (spawner.Comp.Chance == 1.0f || !_robustRandom.Prob(spawner.Comp.Chance))
+            {
+                return spawner.Comp.Prototypes;
+            }
+
+            return null;
         }
 
         private void Spawn(Entity<EntityTableSpawnerComponent> ent)
@@ -126,17 +157,18 @@ namespace Content.Server.Spawners.EntitySystems
             if (TerminatingOrDeleted(ent) || !Exists(ent))
                 return;
 
-            var coords = Transform(ent).Coordinates;
+            var xform = Transform(ent);
+            var coords = _xform.GetMapCoordinates(ent, xform);
+            var rotation = _xform.GetWorldRotation(xform);
             var offset = ent.Comp.Offset;
 
             var spawns = _entityTable.GetSpawns(ent.Comp.Table);
             foreach (var proto in spawns)
             {
-                var xOffset = _robustRandom.NextFloat(-offset, offset);
-                var yOffset = _robustRandom.NextFloat(-offset, offset);
-                var trueCoords = coords.Offset(new Vector2(xOffset, yOffset));
+                var vOffset = _robustRandom.NextVector2(-offset, offset);
+                var trueCoords = coords.Offset(vOffset);
 
-                SpawnAttachedTo(proto, trueCoords);
+                Spawn(proto, trueCoords, rotation: rotation);
             }
         }
     }

--- a/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
+++ b/Content.Server/Spawners/EntitySystems/ConditionalSpawnerSystem.cs
@@ -144,7 +144,7 @@ namespace Content.Server.Spawners.EntitySystems
             }
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (spawner.Comp.Chance == 1.0f || !_robustRandom.Prob(spawner.Comp.Chance))
+            if (spawner.Comp.Chance == 1.0f || _robustRandom.Prob(spawner.Comp.Chance))
             {
                 return spawner.Comp.Prototypes;
             }


### PR DESCRIPTION
## Short description
Ports some Wizden PRs that deal with conditional spawners, namely:
- Wizden [#43234](https://github.com/space-wizards/space-station-14/pull/43234)
- Wizden [#43589](https://github.com/space-wizards/space-station-14/pull/43589)
- Wizden [#44912](https://github.com/space-wizards/space-station-14/pull/44912)

I went around/skipped Wizden [#39096](https://github.com/space-wizards/space-station-14/pull/39096), since it has a lot more entity-related stuff that I don't think we have + it would take another series of PRs, and for our purposes right now, we only need these 3 PRs.

## Why we need to add this
We have random spawners that mappers can't use because they don't hold rotation; now they do. + requested by Caws

## Media (Video/Screenshots)
<img width="988" height="771" alt="image" src="https://github.com/user-attachments/assets/5a63869c-39f4-4070-b262-8df07582f540" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: SnappingOpossum, Princess-Cheeseballs, MilenVolf
- fix: Certain randomized items and decorations no longer spawn with the wrong rotation.
- fix: Handheld artifacts will no longer create entities glued to players.
