### PR TITLE
Fix hardcoded messages for RCD-family devices

### DIFF
--- a/Content.Client/RCD/RCDMenuBoundUserInterface.cs
+++ b/Content.Client/RCD/RCDMenuBoundUserInterface.cs
@@ -133,7 +133,12 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
         if (_playerManager.LocalSession?.AttachedEntity == null)
             return;
 
-        var msg = Loc.GetString("rcd-component-change-mode", ("mode", Loc.GetString(proto.SetName)));
+        // Starlight-start
+        // Equivalent to EntitySystem.Name(uid), which is unavailable here as this is not a system.
+        var device = EntMan.GetComponent<MetaDataComponent>(Owner).EntityName;
+        // Starlight-end
+
+        var msg = Loc.GetString("rcd-component-change-mode", ("device", device), ("mode", Loc.GetString(proto.SetName))); // Starlight-edit: name the actual device
 
         if (proto.Mode is RcdMode.ConstructTile or RcdMode.ConstructObject)
         {
@@ -145,7 +150,7 @@ public sealed partial class RCDMenuBoundUserInterface : BoundUserInterface
                 name = entProto.Name;
             }
 
-            msg = Loc.GetString("rcd-component-change-build-mode", ("name", name));
+            msg = Loc.GetString("rcd-component-change-build-mode", ("device", device), ("name", name)); // Starlight-edit: name the actual device
         }
 
         // Popup message

--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -544,7 +544,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (charges == 0)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-no-ammo-message"), uid, user);
+                _popup.PopupClient(Loc.GetString("rcd-component-no-ammo-message", ("device", Name(uid))), uid, user); // Starlight-edit: name the actual device (RCD/RPD/RPLD)
 
             return false;
         }
@@ -552,7 +552,7 @@ public sealed partial class RCDSystem : EntitySystem
         if (prototype.Cost > charges)
         {
             if (popMsgs)
-                _popup.PopupClient(Loc.GetString("rcd-component-insufficient-ammo-message"), uid, user);
+                _popup.PopupClient(Loc.GetString("rcd-component-insufficient-ammo-message", ("device", Name(uid))), uid, user); // Starlight-edit: name the actual device (RCD/RPD/RPLD)
 
             return false;
         }

--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -8,12 +8,14 @@ rcd-component-examine-build-details = It's currently set to build {MAKEPLURAL($n
 ### Interaction Messages
 
 # Mode change
-rcd-component-change-mode = The RCD is now set to '{$mode}' mode.
-rcd-component-change-build-mode = The RCD is now set to build {MAKEPLURAL($name)}.
+# Starlight-start: name the actual device, since the RPD, RPLD and all experimental variants share these messages
+rcd-component-change-mode = The {$device} is now set to '{$mode}' mode.
+rcd-component-change-build-mode = The {$device} is now set to build {MAKEPLURAL($name)}.
 
 # Ammo count
-rcd-component-no-ammo-message = The RCD has run out of charges!
-rcd-component-insufficient-ammo-message = The RCD doesn't have enough charges left!
+rcd-component-no-ammo-message = The {$device} has run out of charges!
+rcd-component-insufficient-ammo-message = The {$device} doesn't have enough charges left!
+# Starlight-end
 
 # Deconstruction
 rcd-component-tile-indestructible-message = That tile can't be destructed!


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Changed popup messages for RCD, RPD, RPLD and all experimental variants to reference their own device name, instead of the current hardcoded RCD message.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

This mirrors the fix already applied to the ammo refill messages in https://github.com/ss14Starlight/space-station-14/pull/5375, which had the same problem and was solved the same way.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/a323251e-f0f1-42c9-8b46-beb48665770c

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
fix: RCD, RPD, RPLD and experimental variants of them now properly show their name in all messages.