### PR TITLE
A new Job Override Component

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -428,6 +428,12 @@ public sealed partial class RadioSystem : EntitySystem
             jobName = Loc.GetString(chassis?.LocalizedJobTitle ?? "job-name-borg"); // Starlight edit
         }
 
+        if (TryComp<JobIconOverrideComponent>(messageSource, out var overrideComp)) // Starlight Edit
+        {
+            iconId = overrideComp?.JobIconOverride ?? "JobIconBorg"; // Starlight edit
+            jobName = Loc.GetString(overrideComp?.LocalizedJobTitle ?? "job-name-borg"); // Starlight edit
+        }
+
         if (HasComp<StationAiHeldComponent>(messageSource) || (TryComp<StationAIShuntComponent>(messageSource, out var aiShunt) && aiShunt.Return.HasValue))
         {
             iconId = "JobIconStationAi";

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -428,10 +428,10 @@ public sealed partial class RadioSystem : EntitySystem
             jobName = Loc.GetString(chassis?.LocalizedJobTitle ?? "job-name-borg"); // Starlight edit
         }
 
-        if (TryComp<JobIconOverrideComponent>(messageSource, out var overrideComp)) // Starlight Edit
+        if (TryComp<JobIconOverrideComponent>(messageSource, out var overrideComp) && overrideComp.LocalizedJobTitle.Length>0)
         {
-            iconId = overrideComp?.JobIconOverride ?? "JobIconBorg"; // Starlight edit
-            jobName = Loc.GetString(overrideComp?.LocalizedJobTitle ?? "job-name-borg"); // Starlight edit
+            iconId = overrideComp.JobIconOverride;
+            jobName = overrideComp.LocalizedJobTitle;
         }
 
         if (HasComp<StationAiHeldComponent>(messageSource) || (TryComp<StationAIShuntComponent>(messageSource, out var aiShunt) && aiShunt.Return.HasValue))

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -428,11 +428,13 @@ public sealed partial class RadioSystem : EntitySystem
             jobName = Loc.GetString(chassis?.LocalizedJobTitle ?? "job-name-borg"); // Starlight edit
         }
 
-        if (TryComp<JobIconOverrideComponent>(messageSource, out var overrideComp) && overrideComp.LocalizedJobTitle.Length>0)
+        // Starlight START
+        if (TryComp<JobIconOverrideComponent>(messageSource, out var overrideComp))
         {
             iconId = overrideComp.JobIconOverride;
             jobName = overrideComp.LocalizedJobTitle;
         }
+        // Starlight END
 
         if (HasComp<StationAiHeldComponent>(messageSource) || (TryComp<StationAIShuntComponent>(messageSource, out var aiShunt) && aiShunt.Return.HasValue))
         {

--- a/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
+++ b/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
@@ -1,0 +1,16 @@
+using Content.Shared.StatusIcon;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Starlight.Radio.Systems;
+
+/// <summary>
+/// Easy workaround if you intend to override a job icon in the radio
+/// </summary>
+
+[RegisterComponent]
+public sealed partial class JobIconOverrideComponent : Component
+{
+[DataField] public ProtoId<JobIconPrototype> JobIconOverride = "JobIconBorg";
+    [DataField] public LocId? JobTitleOverride = "job-name-borg";
+    [field: DataField]     public string? LocalizedJobTitle { set; get => field ?? Loc.GetString(JobTitleOverride ?? string.Empty); }
+}

--- a/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
+++ b/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
@@ -13,6 +13,7 @@ public sealed partial class JobIconOverrideComponent : Component
     [DataField] public ProtoId<JobIconPrototype> JobIconOverride = "JobIconAssistant";
 
     [DataField] public LocId JobTitleOverride = "job-name-assistant";
+
     public string LocalizedJobTitle =>
         field ??= Loc.GetString(JobTitleOverride);
 }

--- a/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
+++ b/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class JobIconOverrideComponent : Component
 {
     [DataField] public ProtoId<JobIconPrototype> JobIconOverride = "JobIconAssistant";
 
-    [DataField] public LocId? JobTitleOverride = "job-name-assistant";
+    [DataField] public LocId JobTitleOverride = "job-name-assistant";
     public string LocalizedJobTitle =>
-        field ??= Loc.GetString(JobTitleOverride ?? string.Empty);
+        field ??= Loc.GetString(JobTitleOverride);
 }

--- a/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
+++ b/Content.Server/_Starlight/Radio/Systems/JobIconOverrideComponent.cs
@@ -10,7 +10,9 @@ namespace Content.Server._Starlight.Radio.Systems;
 [RegisterComponent]
 public sealed partial class JobIconOverrideComponent : Component
 {
-[DataField] public ProtoId<JobIconPrototype> JobIconOverride = "JobIconBorg";
-    [DataField] public LocId? JobTitleOverride = "job-name-borg";
-    [field: DataField]     public string? LocalizedJobTitle { set; get => field ?? Loc.GetString(JobTitleOverride ?? string.Empty); }
+    [DataField] public ProtoId<JobIconPrototype> JobIconOverride = "JobIconAssistant";
+
+    [DataField] public LocId? JobTitleOverride = "job-name-assistant";
+    public string LocalizedJobTitle =>
+        field ??= Loc.GetString(JobTitleOverride ?? string.Empty);
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds a new component for admins to use that will override a job icon in the radio to whatever they choose, Same with the job title 
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
At the moment JobIconOveride is only coded into borg chassis which makes it annoying when you want to override a job icon without using the Borg Chassis Component (Also it will be used for the Syndicate core for Cy's SHC event)
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="940" height="532" alt="image" src="https://github.com/user-attachments/assets/d22376ce-84e6-4795-b25f-a0381fa60450" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: Forrestgod
- add: Created a new Component: JobIconOverride, It lets admins override a job icon in the radio to whatever as well as the job title.

