### PR TITLE
Hydrogen + Helium Price Nerf

### DIFF
--- a/Resources/Prototypes/_Funkystation/Atmospherics/gases.yml
+++ b/Resources/Prototypes/_Funkystation/Atmospherics/gases.yml
@@ -52,7 +52,7 @@
   molarMass: 1
   color: fffaf0
   reagent: Hydrogen
-  pricePerMole: 1.2
+  pricePerMole: 0
 
 - type: gas
   id: HyperNoblium
@@ -113,7 +113,7 @@
   molarMass: 4
   color: 005959
   reagent: Helium
-  pricePerMole: 0.8
+  pricePerMole: 0.05
 
 - type: gas
   id: AntiNoblium


### PR DESCRIPTION
## Short description
Remove selling value of hydrogen. Reduce the selling price of helium.

## Why we need to add this
Hydrogen and helium are the most common elements in the universe, they shouldn't have much, if any, value. As well, https://github.com/ss14Starlight/space-station-14/pull/5209 will likely increase the amount of helium produced on average, requiring curbing.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl:
- tweak: Changed Hydrogen price per mol from 1.2 to 0.
- tweak: Changed Helium price per mol from 0.8 to 0.05.
