### PR TITLE
Seperate antag status railroading cards into their own game rules

### DIFF
--- a/Resources/Prototypes/_Starlight/CosmicCult/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/game_presets.yml
@@ -14,6 +14,7 @@
     - BasicRoundstartVariation
     - BasicStationEventScheduler
     - RailroadingMinor
+    - RailroadingAntagLow
 
 - type: gamePreset #Runs Cosmic Cult but shows "Secret" in lobby.
   id: SecretCosmicCult
@@ -31,3 +32,4 @@
     - BasicRoundstartVariation
     - BasicStationEventScheduler
     - RailroadingMinor
+    - RailroadingAntagLow

--- a/Resources/Prototypes/_Starlight/GameRules/railroading.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/railroading.yml
@@ -68,6 +68,76 @@
 
 - type: entity
   parent: BaseGameRule
+  id: RailroadingAntagLow
+  components:
+    - type: StationEvent
+      earliestStart: 1
+      weight: 3
+      minimumPlayers: 10
+      duration: 1
+      MaxOccurrences: 1
+    - type: RailroadRule
+      preSpawnDelay: 10
+      delay: 10
+      cards:
+        # antagonists
+        - RRCardCriminal
+        - RRCardWar
+
+- type: entity
+  parent: BaseGameRule
+  id: RailroadingAntagMedium
+  components:
+    - type: StationEvent
+      earliestStart: 1
+      weight: 10
+      minimumPlayers: 40
+      duration: 1
+      MaxOccurrences: 2
+    - type: RailroadRule
+      preSpawnDelay: 10
+      delay: 10
+      cards:
+        # antagonists
+        - RRCardCriminal
+        - RRCardWar
+
+- type: entity
+  parent: BaseGameRule
+  id: RailroadingAntagHigh
+  components:
+    - type: StationEvent
+      earliestStart: 1
+      weight: 20
+      minimumPlayers: 60
+      duration: 1
+    - type: RailroadRule
+      preSpawnDelay: 10
+      delay: 10
+      cards:
+        # antagonists
+        - RRCardCriminal
+        - RRCardWar
+
+- type: entity
+  parent: BaseGameRule
+  id: RailroadingAntagExtreme
+  components:
+    - type: StationEvent
+      earliestStart: 1
+      weight: 40
+      minimumPlayers: 80
+      duration: 1
+    - type: RailroadRule
+      preSpawnDelay: 10
+      delay: 10
+      cards:
+        # antagonists
+        - RRCardCriminal
+        - RRCardWar
+
+- type: entity
+  parent: BaseGameRule
   id: RailroadingMinor
   components:
   - type: StationEvent
@@ -81,8 +151,8 @@
     cards:
     # antagonists
 
-    - RRCardCriminal
-    - RRCardWar
+    #- RRCardCriminal Move to new gamerule
+    #- RRCardWar
 
     # open mail
 

--- a/Resources/Prototypes/_Starlight/GameRules/railroading.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/railroading.yml
@@ -76,6 +76,8 @@
       minimumPlayers: 10
       duration: 1
       MaxOccurrences: 1
+    - type: DynamicRuleCost
+      cost: 75
     - type: RailroadRule
       preSpawnDelay: 10
       delay: 10
@@ -88,6 +90,8 @@
   parent: RailroadingAntagLow
   id: RailroadingAntagMedium
   components:
+    - type: DynamicRuleCost
+      cost: 125
     - type: StationEvent
       earliestStart: 1
       weight: 10
@@ -99,6 +103,8 @@
   parent: RailroadingAntagLow
   id: RailroadingAntagHigh
   components:
+    - type: DynamicRuleCost
+      cost: 175
     - type: StationEvent
       earliestStart: 1
       weight: 20
@@ -109,11 +115,14 @@
   parent: RailroadingAntagLow
   id: RailroadingAntagExtreme
   components:
+    - type: DynamicRuleCost
+      cost: 200
     - type: StationEvent
       earliestStart: 1
       weight: 40
       minimumPlayers: 80
       duration: 1
+
 - type: entity
   parent: BaseGameRule
   id: RailroadingMinor

--- a/Resources/Prototypes/_Starlight/GameRules/railroading.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/railroading.yml
@@ -85,7 +85,7 @@
         - RRCardWar
 
 - type: entity
-  parent: BaseGameRule
+  parent: RailroadingAntagLow
   id: RailroadingAntagMedium
   components:
     - type: StationEvent
@@ -94,16 +94,9 @@
       minimumPlayers: 40
       duration: 1
       MaxOccurrences: 2
-    - type: RailroadRule
-      preSpawnDelay: 10
-      delay: 10
-      cards:
-        # antagonists
-        - RRCardCriminal
-        - RRCardWar
 
 - type: entity
-  parent: BaseGameRule
+  parent: RailroadingAntagLow
   id: RailroadingAntagHigh
   components:
     - type: StationEvent
@@ -111,16 +104,9 @@
       weight: 20
       minimumPlayers: 60
       duration: 1
-    - type: RailroadRule
-      preSpawnDelay: 10
-      delay: 10
-      cards:
-        # antagonists
-        - RRCardCriminal
-        - RRCardWar
 
 - type: entity
-  parent: BaseGameRule
+  parent: RailroadingAntagLow
   id: RailroadingAntagExtreme
   components:
     - type: StationEvent
@@ -128,14 +114,6 @@
       weight: 40
       minimumPlayers: 80
       duration: 1
-    - type: RailroadRule
-      preSpawnDelay: 10
-      delay: 10
-      cards:
-        # antagonists
-        - RRCardCriminal
-        - RRCardWar
-
 - type: entity
   parent: BaseGameRule
   id: RailroadingMinor

--- a/Resources/Prototypes/_Starlight/GameRules/railroading.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/railroading.yml
@@ -75,7 +75,7 @@
       weight: 3
       minimumPlayers: 10
       duration: 1
-      MaxOccurrences: 1
+      maxOccurrences: 1
     - type: DynamicRuleCost
       cost: 75
     - type: RailroadRule
@@ -97,7 +97,7 @@
       weight: 10
       minimumPlayers: 40
       duration: 1
-      MaxOccurrences: 2
+      maxOccurrences: 2
 
 - type: entity
   parent: RailroadingAntagLow

--- a/Resources/Prototypes/_Starlight/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/game_presets.yml
@@ -192,6 +192,7 @@
     - LoneOpsSpawn
     - RailroadingTerminator
     - RailroadingMinor
+    - RailroadingAntagHigh
     - Devil
     - CosmicCult
 
@@ -214,6 +215,7 @@
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
   - RailroadingMinor # 🌟Starlight🌟
+  - RailroadingAntagMedium
 
 - type: gamePreset
   id: DynamicLP
@@ -231,3 +233,4 @@
   - SpaceTrafficControlEventScheduler # No event/meteor schedulers, since we handle that in dynamic too.
   - BasicRoundstartVariation
   - RailroadingMinor
+  - RailroadingAntagLow

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -100,6 +100,7 @@
     - LoneOpsSpawn # Starlight
     - RailroadingTerminator # Starlight
     - RailroadingMinor # Starlight
+    - RailroadingAntagExtreme # Starlight
     - CosmicCult # Starlight
     #- TerrorSpidersSpawn # Starlight
     - Devil # Starlight
@@ -150,6 +151,7 @@
   - SpaceTrafficControlEventScheduler # Starlight
   - BasicRoundstartVariation
   - RailroadingMinor # Starlight, railroading
+  - RailroadingAntagMedium #Starlight, antag railroad cards
 
 - type: gamePreset
   id: Secret
@@ -193,6 +195,7 @@
   - SpaceTrafficControlEventScheduler # Starlight
   - BasicRoundstartVariation
   - RailroadingMinor # 🌟Starlight🌟
+  - RailroadingAntagMedium # 🌟Starlight🌟
 
 
 - type: gamePreset


### PR DESCRIPTION


## Short description
Limit the number of possible NT-ISD wanteds based on population. No more 3 criminals on a 15 pop server. (See issue #5420)

## Why we need to add this
Epsilon frequently sees 2-3 criminals in a 15 player shift. This runs counter to what is supposed to be a very rare situation. In the same set of changes though, we can up the frequency and likelihood of NT-ISD on higher populations.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Born Stellar
- tweak: Reduced the NT-ISD spam on lower server populations, while slightly boosting it at higher populations.
