### PR TITLE
Add monkey emote sounds

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1520,6 +1520,13 @@
   - type: Tag
     tags:
       - Monkey
+  - type: Vocal
+    sounds:
+      Male: Monkey
+      Female: Monkey
+      Unsexed: Monkey
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
 
 - type: Tag
   id: Monkey

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1549,6 +1549,13 @@
     - Ancestor
     - GalacticCommon
   - type: VentCrawler # Starlight
+  - type: Vocal
+    sounds:
+      Male: Monkey
+      Female: Monkey
+      Unsexed: Monkey
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
   # Starlight-End
   - type: NameIdentifier
     group: Monkey

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
@@ -40,6 +40,8 @@
       Male: Monkey
       Female: Monkey
       Unsexed: Monkey
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-primate
   - type: AlwaysRevolutionaryConvertible
@@ -66,8 +68,6 @@
       - Monkey
   - type: Body
     prototype: AdvancedPrimate
-  - type: BodyEmotes
-    soundsId: GeneralBodyEmotes
   - type: Inventory
     templateId: advancedmonkey
     speciesId: monkey

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
@@ -35,6 +35,11 @@
   - type: Speech
     speechSounds: Monkey
     speechVerb: Monkey
+  - type: Vocal
+    sounds:
+      Male: Monkey
+      Female: Monkey
+      Unsexed: Monkey
   - type: SentienceTarget
     flavorKind: station-event-random-sentience-flavor-primate
   - type: AlwaysRevolutionaryConvertible
@@ -61,6 +66,8 @@
       - Monkey
   - type: Body
     prototype: AdvancedPrimate
+  - type: BodyEmotes
+    soundsId: GeneralBodyEmotes
   - type: Inventory
     templateId: advancedmonkey
     speciesId: monkey

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -74,6 +74,11 @@
     - AnomalyHost
   - type: Loadout
     prototypes: [ MobKoboldGear ]
+  - type: Vocal
+    sounds:
+      Male: MaleReptilian
+      Female: FemaleReptilian
+      Unsexed: FemaleReptilian
   - type: Grammar
     attributes:
       proper: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -74,11 +74,6 @@
     - AnomalyHost
   - type: Loadout
     prototypes: [ MobKoboldGear ]
-  - type: Vocal
-    sounds:
-      Male: MaleReptilian
-      Female: FemaleReptilian
-      Unsexed: FemaleReptilian
   - type: Grammar
     attributes:
       proper: true

--- a/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
@@ -765,13 +765,17 @@
         variation: 0.125
     Whistle:
       collection: Whistles
+      params:
+        variation: 0.125
     Snore:
       collection: Snores
       params:
         pitch: 1.3
         volume: -5
+        variation: 0.125
     Gasp:
       collection: MaleGasp
       params:
         pitch: 1.3
         volume: -5
+        variation: 0.125

--- a/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
@@ -755,3 +755,28 @@
         volume: -6
     Salute:
       collection: Salutes
+
+- type: emoteSounds
+  id: Monkey
+  sounds:
+    Scream:
+      path: /Audio/Animals/monkey_scream.ogg
+      params:
+        variation: 0.125
+    Whistle:
+      collection: Whistles
+    Snore:
+      collection: Snores
+      params:
+        pitch: 1.3
+        volume: -5
+    Gasp:
+      collection: MaleGasp
+      params:
+        pitch: 1.3
+        volume: -5
+    DefaultDeathgasp:
+      collection: MaleDeathGasp
+      params:
+        pitch: 1.3
+        volume: -5

--- a/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
@@ -775,8 +775,3 @@
       params:
         pitch: 1.3
         volume: -5
-    DefaultDeathgasp:
-      collection: MaleDeathGasp
-      params:
-        pitch: 1.3
-        volume: -5

--- a/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_Starlight/Voice/speech_emote_sounds.yml
@@ -778,4 +778,4 @@
       params:
         pitch: 1.3
         volume: -5
-        variation: 0.125
+        variation: 0.025


### PR DESCRIPTION
## Short description
Adds several basic emote sounds to monkeys. This includes Pun Pun, Stir Stir, and Syndicate variants.

## Why we need to add this
Adds a few basic emotes to monkeys, making them less mute. While not as extensive as Kiki, who has the whole reptilian emote suite, it will make Pun Pun and other monkeys more audible.

Since this just reuses existing sound effects, some were pitch-shifted to make them more distinctive from player characters. Volume for these was also reduced to make them less overwhelming en-masse and reduce the potential for obnoxious behaviour.

This also establishes the framework to add more audio to monkeys later.

#### List of emotes
- Clap
- Single Clap
- Salute
- Snap
- Gasp
- Whistle
- Snore

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/d213473a-bb89-455d-82b7-e263d1a535d1

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- add: Monkeys now have access to voice emotes in the emote wheel.
- add: Monkeys now get the quick action to scream.
- add: Monkeys now have sound for some emotes such as scream, clap, salute, and whistle.