### PR TITLE
Change Kiki to use female reptilian emotes

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -74,6 +74,11 @@
     - AnomalyHost
   - type: Loadout
     prototypes: [ MobKoboldGear ]
+  - type: Vocal
+    sounds:
+      Male: MaleReptilian
+      Female: FemaleReptilian
+      Unsexed: FemaleReptilian
   - type: Grammar
     attributes:
       proper: true


### PR DESCRIPTION
## Short description
Changes Kiki from using Male to Female emote sounds.

## Why we need to add this
Corrects a probable oversight due to the audio system using unsexed voice emotes for kobolds, which happens to be the male set.

## Media (Video/Screenshots)

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: Kiki now uses female reptilian voice emotes, instead of male.
