### PR TITLE
Admin help QOL

### DIFF
--- a/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkControl.xaml
@@ -15,6 +15,10 @@
                 <Control HorizontalExpand="True" MinWidth="5" />
                 <CheckBox Name="PlaySound" Access="Public" Text="{Loc 'admin-bwoink-play-sound'}" Pressed="True" />
                 <Control HorizontalExpand="True" MinWidth="5" />
+                <!-- Starlight begin -->
+                <CheckBox Name="RememberSelected" Access="Public" Text="{Loc 'admin-ahelp-remember-selected'}" ToolTip="{Loc 'admin-ahelp-remember-selected-tooltip'}" Pressed="True"/>
+                <Control HorizontalExpand="True" MinWidth="5" />
+                <!-- Starlight end -->
                 <Button Visible="True" Name="PopOut" Access="Public" Text="{Loc 'admin-logs-pop-out'}" StyleClasses="OpenBoth" HorizontalAlignment="Left" />
                 <Control HorizontalExpand="True" />
                 <Button Visible="False" Name="Bans" Text="{Loc 'admin-player-actions-bans'}" StyleClasses="OpenRight" />

--- a/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
+++ b/Content.Client/Administration/UI/Bwoink/BwoinkWindow.xaml
@@ -1,6 +1,6 @@
 ﻿<DefaultWindow xmlns="https://spacestation14.io"
             xmlns:cc="clr-namespace:Content.Client.Administration.UI.Bwoink"
-            SetSize="900 500"
+            SetSize="920 500"
             HeaderClass="windowHeaderAlert"
             TitleClass="windowTitleAlert"
             Title="{Loc 'bwoink-user-title'}" >

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -262,6 +262,11 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
         helper.WindowRoot = _uiManager.CreateWindowRoot(helper.ClydeWindow);
         helper.WindowRoot.AddChild(helper.Control);
 
+        // Starlight begin
+        helper.Control.RememberSelected.Disabled = true;
+        helper.Control.RememberSelected.Visible = false;
+        // Starlight end
+
         helper.Control.PopOut.Disabled = true;
         helper.Control.PopOut.Visible = false;
     }
@@ -388,11 +393,6 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
 
     public void Close()
     {
-        // Starlight begin
-        EnsurePanel(_ownerId);
-        Control?.SelectChannel(_ownerId);
-        // Starlight end
-
         Window?.Close();
 
         // popped-out window is being closed
@@ -400,6 +400,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
         {
             ClydeWindow.RequestClosed -= OnRequestClosed;
             ClydeWindow.Dispose();
+            ClydeWindow = null; // Starlight
             // need to dispose control cause we cant reattach it directly back to the window
             // but orphan panels first so -they- can get readded when the window is opened again
             if (Control != null)
@@ -413,6 +414,14 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
             // window wont be closed here so we will invoke ourselves
             OnClose?.Invoke();
         }
+
+        // Starlight begin
+        if (Control is not {Disposed: true})
+        {
+            EnsurePanel(_ownerId);
+            Control?.SelectChannel(_ownerId);
+        }
+        // Starlight end
     }
 
     public void ToggleWindow()

--- a/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
+++ b/Content.Client/UserInterface/Systems/Bwoink/AHelpUIController.cs
@@ -184,7 +184,13 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
 
         UIHelper.SendMessageAction = (userId, textMessage, playSound, adminOnly) => _bwoinkSystem?.Send(userId, textMessage, playSound, adminOnly);
         UIHelper.InputTextChanged += (channel, text) => _bwoinkSystem?.SendInputTextUpdated(channel, text.Length > 0);
-        UIHelper.OnClose += () => { SetAHelpPressed(false); };
+        // Starlight begin
+        UIHelper.OnClose += () =>
+        {
+            SetAHelpPressed(false);
+            UIHelper.Close();
+        };
+        // Starlight end
         UIHelper.OnOpen +=  () => { SetAHelpPressed(true); };
         SetAHelpPressed(UIHelper.IsOpen);
     }
@@ -197,6 +203,13 @@ public sealed partial class AHelpUIController: UIController, IOnSystemChanged<Bw
             return;
         }
         EnsureUIHelper();
+
+        // Starlight begin
+        localUser = UIHelper!.IsAdmin && UIHelper is AdminAHelpUIHandler { RememberSelected: true } aHelper
+            ? aHelper.SelectedPlayer ?? localUser
+            : localUser;
+        //Starlight end
+
         if (UIHelper!.IsOpen)
             return;
         UIHelper!.Open(localUser.Value, _discordRelayActive);
@@ -347,6 +360,8 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     public bool IsAdmin => true;
     public bool IsOpen => Window is { Disposed: false, IsOpen: true } || ClydeWindow is { IsDisposed: false };
     public bool EverOpened;
+    public bool RememberSelected => Window?.Bwoink.RememberSelected.Pressed ?? false; // Starlight
+    public NetUserId? SelectedPlayer; // Starlight
 
     public BwoinkWindow? Window;
     public WindowRoot? WindowRoot;
@@ -373,6 +388,11 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
 
     public void Close()
     {
+        // Starlight begin
+        EnsurePanel(_ownerId);
+        Control?.SelectChannel(_ownerId);
+        // Starlight end
+
         Window?.Close();
 
         // popped-out window is being closed
@@ -454,6 +474,14 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
             }
             panel.Visible = false;
         }
+
+        // Starlight begin
+        Control.ChannelSelector.OnSelectionChanged += inf =>
+        {
+            if (!IsOpen) return;
+            SelectedPlayer = inf?.SessionId ?? _ownerId;
+        };
+        // Starlight end
     }
 
     public void HideAllPanels()
@@ -485,6 +513,7 @@ public sealed class AdminAHelpUIHandler : IAHelpUIHandler
     {
         EnsurePanel(uid);
         Control!.SelectChannel(uid);
+        SelectedPlayer = uid; // Starlight
     }
 
     public void Dispose()

--- a/Resources/Locale/en-US/_Starlight/administration/bwoink.ftl
+++ b/Resources/Locale/en-US/_Starlight/administration/bwoink.ftl
@@ -1,0 +1,2 @@
+admin-ahelp-remember-selected = Remember Selected
+admin-ahelp-remember-selected-tooltip = Remembers the selected player when reopening the ahelp window.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fix a bug where the ahelp window's `Close()` method was not actually being called when closing the window. This had the side effect of making so if you were selected on a player's channel and closed the window, then that player sent a message, when you reopened the window you would've technically been on their tab still, so you didn't see the ping notifier next to their name.
Also adds a new checkbox to the window that is on by default to remember the last selected channel. When toggled on, will make so the ahelp window will not switch to your channel when opening it, instead remaining on the last selected channel. When off, opening ahelp will switch to your channel like it currently does.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.