### PR TITLE
Add missing meat and soup tags to food item 'wing fang chu'

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -735,6 +735,12 @@
           Quantity: 10
         - ReagentId: Vitamin
           Quantity: 10
+  #Starlight start
+  - type: Tag
+    tags:
+    - Meat
+    - Soup
+  #Starlight end
 
 - type: entity
   name: clown's tears


### PR DESCRIPTION
## Short description
Adds missing tags to 'wing fang chu', so it is now classified as a meat soup.

## Why we need to add this
Makes this item edible by carnivores. It is made of `FoodMeatXenoCutlet` or `FoodMeatSpider`, so it is obviously a meat food.
 
## Media (Video/Screenshots)
<img width="247" alt="image" src="https://github.com/user-attachments/assets/e5b33352-5915-42ab-a087-ee34c13520cb" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: 'Wing fang chu' is now classified as meat food.