### PR TITLE
Changes to the recent S.E.L.F kits

### DIFF
--- a/Resources/Locale/en-US/_Starlight/catalog/self.ftl
+++ b/Resources/Locale/en-US/_Starlight/catalog/self.ftl
@@ -1,8 +1,8 @@
 self-backpack-category-saboteur-description =
     A man of passion, honour, and glory! Minus the glory and honour.
     These tools here should help with what you're doing.
-    Includes: Set of tools, some insulated gloves,
-    a Radio Jammer, a welding mask, a freedom implanter.
+    Includes: Jaws of death, tools, some insulated chameleon gloves,
+    a Radio Jammer, meson goggles, and a freedom implanter.
 
 self-backpack-category-press-description =
     Someone who doesn't publicly express their intentions isn't
@@ -10,15 +10,10 @@ self-backpack-category-press-description =
     Includes: Binary key, a microphone, handheld camera,
     a voice changer implanter, and a scram implant.
 
-self-backpack-category-liberator-description =
-    A new hire, or someone going back to the basics? Well,
-    either way this should suffice for you're gear.
-    Includes: Access breaker, insulated gloves, a screwdriver.
-
 self-backpack-category-spy-description =
     Don't like showing yourself out in the open? Well, aslong
     as you achieve you're goal of liberation, these tools will work.
-    Includes: A bag full of chameleon gear, a camera bug,
-    chameleon controller implant, a dna scrambler implant.
+    Includes: A silenced pistol, a camera bug,
+    storage implant, and a chameleon projector.
 
 self-toolbox-name = SELF Supplies

--- a/Resources/Prototypes/_Starlight/Catalog/self_toolbox_sets.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/self_toolbox_sets.yml
@@ -4,16 +4,16 @@
   description: self-backpack-category-saboteur-description
   sprite:
     sprite: Objects/Tools/jaws_of_life.rsi
-    state: proto_jaws_pry
+    state: syn_jaws_pry
   content:
-  - PrototypeJawsOfLife
+  - SyndicateJawsOfLife
   - WelderIndustrialAdvanced
   - PowerDrill
   - Multitool
-  - ClothingHandsGlovesColorYellow
+  - ClothingHandsGlovesInsulatedChameleon
   - RadioJammer
   - FreedomImplanter
-  - ClothingHeadHatWelding
+  - ClothingEyesGlassesMeson
 
 - type: thiefBackpackSet
   id: PressSELF
@@ -30,18 +30,6 @@
   - ScramImplanter
 
 - type: thiefBackpackSet
-  id: LiberatorSELF
-  name: The Liberator
-  description: self-backpack-category-liberator-description
-  sprite:
-    sprite: Objects/Tools/access_breaker.rsi
-    state: icon
-  content:
-  - AccessBreaker
-  - ClothingHandsGlovesColorYellow
-  - Screwdriver
-
-- type: thiefBackpackSet
   id: SpySELF
   name: The Spy
   description: self-backpack-category-spy-description
@@ -49,7 +37,7 @@
     sprite: Objects/Devices/camera_bug.rsi
     state: camera_bug
   content:
-  - ClothingBackpackChameleonFillAgent
-  - ChameleonControllerImplanter
-  - DnaScramblerImplanter
+  - StorageImplanter
+  - ChameleonProjector
+  - WeaponPistolStechkin
   - CameraBug

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/tools.yml
@@ -1138,5 +1138,4 @@
     possibleSets:
     - SaboteurSELF
     - PressSELF
-    - LiberatorSELF
     - SpySELF

--- a/Resources/Prototypes/_Starlight/Roles/Antags/self.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Antags/self.yml
@@ -39,5 +39,6 @@
   id: SELFAgentGear
   storage:
     back:
+    - AccessBreaker
     - EmagFREE
     - ToolboxSELF


### PR DESCRIPTION
## Short description
Changes the SELF kits to align with public opinion.

## Why we need to add this
After some talking in https://discord.com/channels/1272545509562777621/1532875236037496894 I decided to change a few of the kits a bit.

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Changed the SELF spy kit to not be chameleon based, instead having a storage implanter, stechkin, camera bug, and chameleon projector.
- tweak: Changed the SELF saboteur kit to use meson goggles and jaws of death.
- remove: The "Base" kit of the SELF was removed.
- add: The access breaker from the "base" kit of SELF was added as a normal equipment.
