### PR TITLE
Reach shipyard price decrease

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/default_shipyard_catalog.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/default_shipyard_catalog.yml
@@ -92,7 +92,7 @@
   id: Reach
   name: SS-Reach III
   description: A large station vessel made for skeleton crews that we decided to allow stations to buy.
-  price: 1500000
+  price: 700500
   category: Humongous
   group: Command
   shuttlePath: /Maps/_Starlight/Shuttles/ReachButShipyard.yml


### PR DESCRIPTION
## Short description
Decreasing the price of the reach in the shipyard from 1.5 million to 700500.

## Why we need to add this
It was just not worth 1.5 million, especially after the decrease in price of frezon its way out of the ballpark of obtainable.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Changed the price of reach in the shipyard.
