### PR TITLE
Fix switchblade errors

### DIFF
--- a/Resources/Locale/en-US/_Starlight/toggleVerbs/toggle.ftl
+++ b/Resources/Locale/en-US/_Starlight/toggleVerbs/toggle.ftl
@@ -1,2 +1,4 @@
 verb-toggle-magnet-activate = Activate Magnet
 verb-toggle-magnet-deactivate = Deactivate Magnet
+
+verb-categories-switch = Switch

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/boxcutter.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/boxcutter.yml
@@ -15,7 +15,7 @@
     state: sheathed
     states:
       sheathed: !type:ItemSwitchState
-        verb: unsheath
+        verb: sheathe
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/boxcutter.rsi
           state: boxcutter
@@ -35,7 +35,7 @@
           embedOnThrow: false
 
       unsheathed: !type:ItemSwitchState
-        verb: sheathe
+        verb: unsheath
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/boxcutter.rsi
           state: icon

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/boxcutter.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/boxcutter.yml
@@ -35,7 +35,7 @@
           embedOnThrow: false
 
       unsheathed: !type:ItemSwitchState
-        verb: unsheath
+        verb: unsheathe
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/boxcutter.rsi
           state: icon

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/switchblade.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/switchblade.yml
@@ -36,7 +36,7 @@
           embedOnThrow: false
 
       unsheathed: !type:ItemSwitchState
-        verb: unsheath
+        verb: unsheathe
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/switchblade.rsi
           state: icon

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/switchblade.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/switchblade.yml
@@ -15,7 +15,7 @@
     state: sheathed
     states:
       sheathed: !type:ItemSwitchState
-        verb: unsheath
+        verb: sheathe
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/switchblade.rsi
           state: switchblade
@@ -36,7 +36,7 @@
           embedOnThrow: false
 
       unsheathed: !type:ItemSwitchState
-        verb: sheathe
+        verb: unsheath
         sprite:
           sprite: _Starlight/Objects/Weapons/Melee/switchblade.rsi
           state: icon


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Fixes https://github.com/ss14Starlight/space-station-14/issues/5446
Fixes https://github.com/ss14Starlight/space-station-14/issues/5464

Switchable items now have the relevant menu item named 'Switch'. Box cutters and switch blades now have their states correctly mapped to the correct name.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

All items using the ItemSwitch system showed 'fix-switchblade-switch-verbs' which was the raw key. 

Switchblade and box cutter also incorrectly had inverted logic, meaning when unsheathe was selected the item would be sheathed.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/d6e9f5fc-13f9-465d-9533-ecbd285e1c60

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- fix: Switchblades and box cutters now map to the right state. 
- fix: Items that use the switch system now display 'Switch', instead of 'fix-switchblade-switch-verbs'.