### PR TITLE
Remove revolutionary comms key from dungeon

### DIFF
--- a/Resources/Maps/_Starlight/Dungeon/sovietWEH.yml
+++ b/Resources/Maps/_Starlight/Dungeon/sovietWEH.yml
@@ -14713,14 +14713,6 @@ entities:
     - type: Transform
       pos: 8.165495,9.925802
       parent: 1
-- proto: EncryptionKeySoviet
-  entities:
-  - uid: 2369
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 28.448889,24.579391
-      parent: 1
 - proto: ExosuitFabricatorMachineCircuitboard
   entities:
   - uid: 2371


### PR DESCRIPTION
## Short description
Remove the revolutionaries comms key from the SovietWEH dungeon

## Why we need to add this
This may lead to the outing of head revs basically ruining the antag round

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- fix: Fixed Revolutionary comms key being available in a dungeon.

