### PR TITLE
Fix sprite offset in combination with AtmosPipeAppearanceSystem

### DIFF
--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -30,8 +30,6 @@ public sealed partial class AtmosPipeAppearanceSystem : SharedAtmosPipeAppearanc
         var numberOfPipeLayers = GetNumberOfPipeLayers(uid, out _);
 
         // Starlight START
-        // Insert connection nubs right after the main pipe layer instead of appending them at the
-        // end, so they don't render on top of layers added after it (e.g. a machine/tank body).
         _sprite.LayerMapTryGet((uid, sprite), PipeVisualLayers.Pipe, out var pipeIndex, false);
         // Starlight END
 
@@ -42,6 +40,7 @@ public sealed partial class AtmosPipeAppearanceSystem : SharedAtmosPipeAppearanc
                 var layerName = layerKey.ToString() + i.ToString();
 
                 // Starlight START
+                // The generated layer should go directly after the main pipe layer, not at the end, hence the pipeIndex+1.
                 if (!_sprite.LayerMapTryGet((uid, sprite), layerName, out var layer, false))
                 {
                     layer = pipeIndex + 1;

--- a/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
+++ b/Content.Client/Atmos/EntitySystems/AtmosPipeAppearanceSystem.cs
@@ -29,15 +29,37 @@ public sealed partial class AtmosPipeAppearanceSystem : SharedAtmosPipeAppearanc
 
         var numberOfPipeLayers = GetNumberOfPipeLayers(uid, out _);
 
+        // Starlight START
+        // Insert connection nubs right after the main pipe layer instead of appending them at the
+        // end, so they don't render on top of layers added after it (e.g. a machine/tank body).
+        _sprite.LayerMapTryGet((uid, sprite), PipeVisualLayers.Pipe, out var pipeIndex, false);
+        // Starlight END
+
         foreach (var layerKey in Enum.GetValues<PipeConnectionLayer>())
         {
             for (byte i = 0; i < numberOfPipeLayers; i++)
             {
                 var layerName = layerKey.ToString() + i.ToString();
-                var layer = _sprite.LayerMapReserve((uid, sprite), layerName);
+
+                // Starlight START
+                if (!_sprite.LayerMapTryGet((uid, sprite), layerName, out var layer, false))
+                {
+                    layer = pipeIndex + 1;
+                    _sprite.AddBlankLayer((uid, sprite), layer);
+                    _sprite.LayerMapSet((uid, sprite), layerName, layer);
+                }
+                // Starlight END
+
                 _sprite.LayerSetRsi((uid, sprite), layer, component.Sprite[i].RsiPath);
                 _sprite.LayerSetRsiState((uid, sprite), layer, component.Sprite[i].RsiState);
                 _sprite.LayerSetDirOffset((uid, sprite), layer, ToOffset(layerKey));
+
+                // Starlight START
+                // The generated pipe inlet/outlets don't have the correct offset, but we can simply use the inverse
+                // of the whole sprite offset to fix that. This fixes things like large tanks where the body sprite
+                // and "the tile" are offset from one another.
+                _sprite.LayerSetOffset((uid, sprite), layer, -sprite.Offset);
+                // Starlight END
             }
         }
     }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Fixes the dynamically added pipe sprite layer ordering and offset. This affects only the little magic pipe overlay that makes two pipes look connected. See Media.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Somehow missed this in https://github.com/ss14Starlight/space-station-14/pull/5425

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Before

<img width="251" height="324" alt="image" src="https://github.com/user-attachments/assets/17799846-92dc-4ee0-a606-6097fa16df0f" />

### After

<img width="286" height="334" alt="image" src="https://github.com/user-attachments/assets/22a2be5c-ef6e-4f93-aec4-5145a390b2aa" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Fixed tall gas tank pipe connection visuals.
