### PR TITLE
Scent System:  Feedback Pass

### DIFF
--- a/Content.Client/_Starlight/Scent/Overlays/ScentPerceptionOverlay.cs
+++ b/Content.Client/_Starlight/Scent/Overlays/ScentPerceptionOverlay.cs
@@ -80,6 +80,10 @@ public sealed class ScentPerceptionOverlay : Robust.Client.Graphics.Overlay
                 continue;
 
             var (position, rotation) = _transform.GetWorldPositionRotation(xform);
+
+            if (!args.WorldBounds.Contains(position))
+                continue;
+
             _sprite.RenderSprite((uid, sprite), worldHandle, eyeRotation, rotation, position);
         }
     }

--- a/Content.Client/_Starlight/Scent/Overlays/ScentPerceptionOverlay.cs
+++ b/Content.Client/_Starlight/Scent/Overlays/ScentPerceptionOverlay.cs
@@ -1,0 +1,86 @@
+using Content.Shared._Starlight.Eye;
+using Content.Shared._Starlight.Scent.Components;
+using Content.Shared.Eye.Blinding.Components;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+
+namespace Content.Client._Starlight.Scent.Overlays;
+
+// Redraws visible ScentMarker sprites after BlindOverlay, DarkenedVisionOverlay, and
+// BlurryVisionOverlay paint over the screen. Only draws markers the client already has and
+// ScentTrackingSystem still marks Visible.
+public sealed class ScentPerceptionOverlay : Robust.Client.Graphics.Overlay
+{
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+
+    private readonly SpriteSystem _sprite;
+    private readonly TransformSystem _transform;
+    private readonly ContainerSystem _container;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+
+    // BlindOverlay, DarkenedVisionOverlay, and BlurryVisionOverlay never set ZIndex, so they
+    // draw at the default 0. Anything higher draws after them.
+    public ScentPerceptionOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _sprite = _entityManager.System<SpriteSystem>();
+        _transform = _entityManager.System<TransformSystem>();
+        _container = _entityManager.System<ContainerSystem>();
+        ZIndex = 1;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        if (!_entityManager.TryGetComponent(_playerManager.LocalSession?.AttachedEntity, out EyeComponent? eyeComp))
+            return false;
+
+        if (args.Viewport.Eye != eyeComp.Eye)
+            return false;
+
+        if (_playerManager.LocalSession?.AttachedEntity is not { } player)
+            return false;
+
+        return IsVisionObscured(player);
+    }
+
+    private bool IsVisionObscured(EntityUid player)
+    {
+        if (_entityManager.TryGetComponent(player, out BlindableComponent? blindable) && blindable.IsBlind)
+            return true;
+
+        if (_entityManager.TryGetComponent(player, out DarkenedVisionComponent? darkened) &&
+            darkened.Strength > 0f && darkened.Strength < darkened.BlindTreshold)
+            return true;
+
+        if (_entityManager.TryGetComponent(player, out BlurryVisionComponent? blurry) && blurry.Magnitude > 0f)
+            return true;
+
+        return false;
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var worldHandle = args.WorldHandle;
+        var eyeRotation = args.Viewport.Eye?.Rotation ?? Angle.Zero;
+
+        var query = _entityManager.EntityQueryEnumerator<ScentMarkerComponent, SpriteComponent, TransformComponent, MetaDataComponent>();
+        while (query.MoveNext(out var uid, out _, out var sprite, out var xform, out var meta))
+        {
+            if (xform.MapID != args.MapId)
+                continue;
+
+            if (!sprite.Visible)
+                continue;
+
+            if (_container.IsEntityInContainer(uid, meta))
+                continue;
+
+            var (position, rotation) = _transform.GetWorldPositionRotation(xform);
+            _sprite.RenderSprite((uid, sprite), worldHandle, eyeRotation, rotation, position);
+        }
+    }
+}

--- a/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
@@ -1,9 +1,56 @@
-using Content.Shared._Starlight.Scent;
+using Content.Client._Starlight.Scent.Overlays;
+using Content.Shared._Starlight.Scent.Components;
 using Content.Shared._Starlight.Scent.Systems;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Player;
 
 namespace Content.Client._Starlight.Scent.Systems;
 
-// Deliberately empty. Exists so SharedScentSystem's handlers actually run on the client too.
+// Also handles adding/removing ScentPerceptionOverlay for the local Smeller, so
+// SharedScentSystem's handlers actually run on the client too.
 public sealed class ClientScentSystem : SharedScentSystem
 {
+    [Dependency] private readonly IPlayerManager _player = default!;
+    [Dependency] private readonly IOverlayManager _overlayMan = default!;
+
+    private ScentPerceptionOverlay _overlay = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlay = new();
+
+        SubscribeLocalEvent<SmellerComponent, ComponentInit>(OnSmellerInit);
+        SubscribeLocalEvent<SmellerComponent, LocalPlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeLocalEvent<SmellerComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
+    }
+
+    private void OnSmellerInit(EntityUid uid, SmellerComponent component, ComponentInit args)
+    {
+        if (_player.LocalEntity == uid)
+            _overlayMan.AddOverlay(_overlay);
+    }
+
+    // Overrides the base handler instead of subscribing to ComponentShutdown again: the base
+    // class already owns that subscription, and SubscribeLocalEvent doesn't allow a second one
+    // for the same (component, event) pair.
+    protected override void OnSmellerShutdown(Entity<SmellerComponent> ent, ref ComponentShutdown args)
+    {
+        base.OnSmellerShutdown(ent, ref args);
+
+        if (_player.LocalEntity == ent.Owner)
+            _overlayMan.RemoveOverlay(_overlay);
+    }
+
+    private void OnPlayerAttached(EntityUid uid, SmellerComponent component, LocalPlayerAttachedEvent args)
+    {
+        _overlayMan.AddOverlay(_overlay);
+    }
+
+    private void OnPlayerDetached(EntityUid uid, SmellerComponent component, LocalPlayerDetachedEvent args)
+    {
+        _overlayMan.RemoveOverlay(_overlay);
+    }
 }

--- a/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
@@ -29,7 +29,7 @@ public sealed class ClientScentSystem : SharedScentSystem
 
     private void OnSmellerInit(EntityUid uid, SmellerComponent component, ComponentInit args)
     {
-        if (_player.LocalEntity == uid)
+        if (_player.LocalEntity == uid && !_overlayMan.HasOverlay<ScentPerceptionOverlay>())
             _overlayMan.AddOverlay(_overlay);
     }
 
@@ -46,7 +46,8 @@ public sealed class ClientScentSystem : SharedScentSystem
 
     private void OnPlayerAttached(EntityUid uid, SmellerComponent component, LocalPlayerAttachedEvent args)
     {
-        _overlayMan.AddOverlay(_overlay);
+        if (!_overlayMan.HasOverlay<ScentPerceptionOverlay>())
+            _overlayMan.AddOverlay(_overlay);
     }
 
     private void OnPlayerDetached(EntityUid uid, SmellerComponent component, LocalPlayerDetachedEvent args)

--- a/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
@@ -1,9 +1,11 @@
 using Content.Shared._Starlight.Medical.Body.Systems;
 using Content.Shared._Starlight.Scent.Components;
+using Content.Shared.Storage.Components;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
 using Robust.Client.Player;
 using Robust.Shared.Animations;
+using Robust.Shared.Containers;
 using Robust.Shared.Timing;
 using System.Globalization;
 using System.Numerics;
@@ -42,6 +44,14 @@ public sealed class ScentTrackingSystem : EntitySystem
         SubscribeLocalEvent<SmellerComponent, AfterAutoHandleStateEvent>(OnSmellerState);
         SubscribeLocalEvent<ScentMarkerComponent, ComponentStartup>(OnMarkerStartup);
         SubscribeLocalEvent<ScentMarkerComponent, AfterAutoHandleStateEvent>(OnMarkerState);
+        SubscribeLocalEvent<SmellerComponent, EntGotInsertedIntoContainerMessage>(OnOwnEnclosureChanged);
+        SubscribeLocalEvent<SmellerComponent, EntGotRemovedFromContainerMessage>(OnOwnEnclosureChanged);
+    }
+
+    private void OnOwnEnclosureChanged<T>(Entity<SmellerComponent> ent, ref T args)
+    {
+        if (_player.LocalSession?.AttachedEntity == ent.Owner)
+            RefreshAllMarkers(ent.Comp);
     }
 
     private void OnSmellerState(EntityUid uid, SmellerComponent component, ref AfterAutoHandleStateEvent args)
@@ -102,8 +112,37 @@ public sealed class ScentTrackingSystem : EntitySystem
 
         var visible = !IsPerceptionBlocked(smeller) &&
                       !(smeller.Perception == ScentPerception.Partial && ent.Comp.WasContained) &&
+                      !(smeller.Perception == ScentPerception.Partial && IsOutsideOwnEnclosure(ent)) &&
                       (smeller.TrackedScentId == null || ent.Comp.ScentId == smeller.TrackedScentId);
         _sprite.SetVisible((ent.Owner, sprite), visible);
+    }
+
+    // A Partial perceiver inside an airtight container can't perceive markers outside it. A Full
+    // perceiver is unaffected.
+    private bool IsOutsideOwnEnclosure(Entity<ScentMarkerComponent> ent)
+    {
+        if (!TryGetOwnEnclosure(out var enclosure))
+            return false;
+
+        return !TryComp<TransformComponent>(ent.Owner, out var markerXform) ||
+               markerXform.ParentUid != enclosure;
+    }
+
+    // Resolves the airtight container the local player is currently inside, if any.
+    private bool TryGetOwnEnclosure(out EntityUid enclosure)
+    {
+        enclosure = default;
+
+        if (_player.LocalSession?.AttachedEntity is not { } local ||
+            !TryComp<TransformComponent>(local, out var localXform) ||
+            !TryComp<EntityStorageComponent>(localXform.ParentUid, out var storage) ||
+            !storage.Airtight)
+        {
+            return false;
+        }
+
+        enclosure = localXform.ParentUid;
+        return true;
     }
 
     // A Partial perceiver loses all scent perception while breathing internals.

--- a/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
@@ -79,8 +79,11 @@ public sealed class ScentTrackingSystem : EntitySystem
     // silently undo our filter without re-firing ScentMarkerComponent's own ComponentStartup.
     private void ApplyFilterForLocalPlayer(Entity<ScentMarkerComponent> ent)
     {
-        if (TryGetLocalSmeller(out var smeller))
-            ApplyFilter(ent, smeller);
+        if (!TryGetLocalSmeller(out var smeller))
+            return;
+
+        var enclosure = TryGetOwnEnclosure(out var own) ? own : (EntityUid?)null;
+        ApplyFilter(ent, smeller, enclosure);
     }
 
     // Resolves the local player's own SmellerComponent, if they have one attached.
@@ -98,34 +101,36 @@ public sealed class ScentTrackingSystem : EntitySystem
 
     private void RefreshAllMarkers(SmellerComponent smeller)
     {
+        var enclosure = TryGetOwnEnclosure(out var own) ? own : (EntityUid?)null;
+
         var query = EntityQueryEnumerator<ScentMarkerComponent>();
         while (query.MoveNext(out var uid, out var marker))
         {
-            ApplyFilter((uid, marker), smeller);
+            ApplyFilter((uid, marker), smeller, enclosure);
         }
     }
 
-    private void ApplyFilter(Entity<ScentMarkerComponent> ent, SmellerComponent smeller)
+    private void ApplyFilter(Entity<ScentMarkerComponent> ent, SmellerComponent smeller, EntityUid? enclosure)
     {
         if (!TryComp<SpriteComponent>(ent.Owner, out var sprite))
             return;
 
         var visible = !IsPerceptionBlocked(smeller) &&
                       !(smeller.Perception == ScentPerception.Partial && ent.Comp.WasContained) &&
-                      !(smeller.Perception == ScentPerception.Partial && IsOutsideOwnEnclosure(ent)) &&
+                      !(smeller.Perception == ScentPerception.Partial && IsOutsideOwnEnclosure(ent, enclosure)) &&
                       (smeller.TrackedScentId == null || ent.Comp.ScentId == smeller.TrackedScentId);
         _sprite.SetVisible((ent.Owner, sprite), visible);
     }
 
     // A Partial perceiver inside an airtight container can't perceive markers outside it. A Full
     // perceiver is unaffected.
-    private bool IsOutsideOwnEnclosure(Entity<ScentMarkerComponent> ent)
+    private bool IsOutsideOwnEnclosure(Entity<ScentMarkerComponent> ent, EntityUid? enclosure)
     {
-        if (!TryGetOwnEnclosure(out var enclosure))
+        if (enclosure is not { } own)
             return false;
 
         return !TryComp<TransformComponent>(ent.Owner, out var markerXform) ||
-               markerXform.ParentUid != enclosure;
+               markerXform.ParentUid != own;
     }
 
     // Resolves the airtight container the local player is currently inside, if any.

--- a/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
+++ b/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
@@ -75,9 +75,7 @@ public sealed class ScentSystem : SharedScentSystem
         SubscribeLocalEvent<DoorComponent, DoorStateChangedEvent>(OnDoorStateChanged);
     }
 
-    // DoorStateChangedEvent only fires once StartOpening genuinely succeeds (bolts, power, and
-    // access checks have all already passed), and now carries the user via a Starlight-side
-    // addition to SharedDoorSystem, so no separate pre-open hook or bridging state is needed.
+    // Only fires once StartOpening succeeds, so bolted or access-denied bumps don't leave a trace.
     private void OnDoorStateChanged(EntityUid uid, DoorComponent component, DoorStateChangedEvent args)
     {
         if (args.State != DoorState.Opening)

--- a/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
+++ b/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
@@ -9,6 +9,9 @@ using Content.Shared._Starlight.Scent.Components;
 using Content.Shared._Starlight.Scent.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.DoAfter;
+using Content.Shared.Doors;
+using Content.Shared.Doors.Components;
+using Content.Shared.Doors.Systems;
 using Content.Shared.Eye;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Prototypes;
@@ -19,6 +22,7 @@ using Content.Shared.Inventory;
 using Content.Shared.Nutrition.EntitySystems;
 using Content.Shared.Popups;
 using Content.Shared.Storage.Components;
+using Content.Shared.Tag;
 using Content.Shared.Verbs;
 using Content.Shared.Zombies;
 using Robust.Shared.Audio.Systems;
@@ -43,6 +47,7 @@ public sealed class ScentSystem : SharedScentSystem
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly AtmosphereSystem _atmosphere = default!;
     [Dependency] private readonly InventorySystem _inventory = default!;
+    [Dependency] private readonly TagSystem _tags = default!;
 
     private const string ScentMarkerPrototype = "ScentMarker";
     private const int ScentIdByteLength = 8;
@@ -66,6 +71,21 @@ public sealed class ScentSystem : SharedScentSystem
             before: [typeof(ForensicsSystem), typeof(IngestionSystem)]);
         SubscribeLocalEvent<CleansScentComponent, CleanScentDoAfterEvent>(OnCleanScentDoAfter);
         SubscribeLocalEvent<CleansScentComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
+
+        SubscribeLocalEvent<DoorComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
+    }
+
+    // Normal interaction already deposits a scent trace on a door via ContactInteractionEvent.
+    // Bumping doesn't go through that pipeline at all, so it never did.
+    private void OnBeforeDoorOpened(EntityUid uid, DoorComponent component, BeforeDoorOpenedEvent args)
+    {
+        if (args.User is not { } user || !_tags.HasTag(user, SharedDoorSystem.DoorBumpTag))
+            return;
+
+        if (!TryComp<ScentComponent>(user, out var scent) || scent.ScentId is not { } scentId)
+            return;
+
+        ApplyScentTrace(user, scentId, uid);
     }
 
     private void OnSniffObjectAction(Entity<SmellerComponent> ent, ref SniffObjectActionEvent args)

--- a/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
+++ b/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
@@ -72,13 +72,17 @@ public sealed class ScentSystem : SharedScentSystem
         SubscribeLocalEvent<CleansScentComponent, CleanScentDoAfterEvent>(OnCleanScentDoAfter);
         SubscribeLocalEvent<CleansScentComponent, GetVerbsEvent<UtilityVerb>>(OnUtilityVerb);
 
-        SubscribeLocalEvent<DoorComponent, BeforeDoorOpenedEvent>(OnBeforeDoorOpened);
+        SubscribeLocalEvent<DoorComponent, DoorStateChangedEvent>(OnDoorStateChanged);
     }
 
-    // Normal interaction already deposits a scent trace on a door via ContactInteractionEvent.
-    // Bumping doesn't go through that pipeline at all, so it never did.
-    private void OnBeforeDoorOpened(EntityUid uid, DoorComponent component, BeforeDoorOpenedEvent args)
+    // DoorStateChangedEvent only fires once StartOpening genuinely succeeds (bolts, power, and
+    // access checks have all already passed), and now carries the user via a Starlight-side
+    // addition to SharedDoorSystem, so no separate pre-open hook or bridging state is needed.
+    private void OnDoorStateChanged(EntityUid uid, DoorComponent component, DoorStateChangedEvent args)
     {
+        if (args.State != DoorState.Opening)
+            return;
+
         if (args.User is not { } user || !_tags.HasTag(user, SharedDoorSystem.DoorBumpTag))
             return;
 

--- a/Content.Shared/Doors/Components/DoorComponent.cs
+++ b/Content.Shared/Doors/Components/DoorComponent.cs
@@ -15,11 +15,12 @@ namespace Content.Shared.Doors.Components;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class DoorComponent : Component
 {
+    // Starlight: cref below updated for SetState's added optional user parameter
     /// <summary>
     /// The current state of the door -- whether it is open, closed, opening, or closing.
     /// </summary>
     /// <remarks>
-    /// This should never be set directly, use <see cref="SharedDoorSystem.SetState(EntityUid, DoorState, DoorComponent?)"/> instead.
+    /// This should never be set directly, use <see cref="SharedDoorSystem.SetState(EntityUid, DoorState, DoorComponent?, EntityUid?)"/> instead.
     /// </remarks>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField, AutoNetworkedField]

--- a/Content.Shared/Doors/DoorEvents.cs
+++ b/Content.Shared/Doors/DoorEvents.cs
@@ -8,10 +8,12 @@ namespace Content.Shared.Doors
     public sealed class DoorStateChangedEvent : EntityEventArgs
     {
         public readonly DoorState State;
+        public readonly EntityUid? User; // Starlight
 
-        public DoorStateChangedEvent(DoorState state)
+        public DoorStateChangedEvent(DoorState state, EntityUid? user = null) // Starlight: add user param
         {
             State = state;
+            User = user; // Starlight: add user
         }
     }
 

--- a/Content.Shared/Doors/Systems/SharedDoorSystem.cs
+++ b/Content.Shared/Doors/Systems/SharedDoorSystem.cs
@@ -148,7 +148,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
         RaiseLocalEvent(ent, new DoorStateChangedEvent(door.State));
     }
 
-    public bool SetState(EntityUid uid, DoorState state, DoorComponent? door = null)
+    public bool SetState(EntityUid uid, DoorState state, DoorComponent? door = null, EntityUid? user = null) // Starlight: added user param
     {
         if (!Resolve(uid, ref door))
             return false;
@@ -192,7 +192,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         door.State = state;
         Dirty(uid, door);
-        RaiseLocalEvent(uid, new DoorStateChangedEvent(state));
+        RaiseLocalEvent(uid, new DoorStateChangedEvent(state, user)); // Starlight: pass user through
 
         AppearanceSystem.SetData(uid, DoorVisuals.State, door.State);
         return true;
@@ -372,7 +372,7 @@ public abstract partial class SharedDoorSystem : EntitySystem
 
         var lastState = door.State;
 
-        if (!SetState(uid, DoorState.Opening, door))
+        if (!SetState(uid, DoorState.Opening, door, user)) // Starlight: pass user through
             return;
 
         if (predicted)

--- a/Content.Shared/_Starlight/Scent/Systems/SharedScentSystem.cs
+++ b/Content.Shared/_Starlight/Scent/Systems/SharedScentSystem.cs
@@ -30,7 +30,8 @@ public abstract class SharedScentSystem : EntitySystem
         Actions.AddAction(ent.Owner, ref ent.Comp.ToggleActionEntity, ent.Comp.ToggleAction);
     }
 
-    private void OnSmellerShutdown(Entity<SmellerComponent> ent, ref ComponentShutdown args)
+    // virtual so ClientScentSystem can override instead of subscribing to ComponentShutdown again.
+    protected virtual void OnSmellerShutdown(Entity<SmellerComponent> ent, ref ComponentShutdown args)
     {
         Actions.RemoveAction(ent.Owner, ent.Comp.ToggleActionEntity);
         Actions.RemoveAction(ent.Owner, ent.Comp.SneezeActionEntity);


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
In the Delta and Epsilon servers, people have been playing with scents.
Two main observations were found:
1. Bumping into doors doesn't leave scent traces, but interacting with them does.
2. Blindness means you can't see scents.  Given eyesight and smell are two separate sensory systems, scent should operate independently of eyesight.

I've implemented changes according to this feedback.  Blindness still allows you to smell things.  Being in an enclosed airtight container (lockers do in fact hermetically seal and you can journey in space inside one) means you can't smell outside of it, unless you're a full smeller.
Bumping into doors now leaves a scent trace.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Making sure scents are behaving according to expectations; blindness system interaction makes sense and so does the door bumping.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1212" height="982" alt="image" src="https://github.com/user-attachments/assets/ff49716f-985f-42ee-adac-4bea9715f9b8" />

https://github.com/user-attachments/assets/3bdfdced-cede-4bcc-838e-2935a006b7b0

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- tweak: Bumping into doors now leaves scent traces, like interacting with them already does.
- fix: Individuals that can smell things can still smell while blinded.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
-->
