### PR TITLE
Fix casino chip case lock and missing casino job icons

### DIFF
--- a/Resources/Prototypes/_Starlight/Admeme/Casino/CasinoAssets/casino_briefcase.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/Casino/CasinoAssets/casino_briefcase.yml
@@ -13,9 +13,19 @@
     - state: locked
       map: [ "enum.LockVisualLayers.Lock" ]
       shader: unshaded
+    - state: unlocked
+      map: [ light ]
+      shader: unshaded
   - type: Item
     sprite: _Starlight/Admeme/Casino/Objects/casino_briefcase.rsi
   - type: Lock
   - type: LockVisuals
+  - type: LockedStorage
+  - type: GenericVisualizer
+    visuals:
+      enum.StorageVisuals.Open:
+        light:
+          True: { visible: true }
+          False: { visible: false }
   - type: AccessReader
     access: [["Casino"]]

--- a/Resources/Prototypes/_Starlight/Admeme/Casino/CasinoAssets/job.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/Casino/CasinoAssets/job.yml
@@ -2,7 +2,7 @@
   parent: JobIcon
   id: JobIconCasinoOwner
   icon:
-    sprite: &jobIcons _Starlight/Admeme/Casino/Interface/job_icons.rsi
+    sprite: &jobIcons /Textures/_Starlight/Admeme/Casino/Interface/job_icons.rsi
     state: owner
   jobName: job-name-casino-owner
   allowSelection: false

--- a/Resources/Prototypes/_Starlight/Stacks/coins.yml
+++ b/Resources/Prototypes/_Starlight/Stacks/coins.yml
@@ -7,5 +7,5 @@
 - type: stack
   id: CasinoChip
   name: stack-casino-chip
-  icon: { sprite: _Starlight/Admeme/Casino/Objects/casino_chips.rsi, state: chips-0 }
+  icon: { sprite: /Textures/_Starlight/Admeme/Casino/Objects/casino_chips.rsi, state: chips-0 }
   spawn: CasinoChip


### PR DESCRIPTION
## Short description
Small fix to casino content: The chip case could be opened while locked, because Lock on its own only adds the lock verbs and visuals. The lock light also vanished when the case was opened. Casino job icons stopped showing on the security HUD because the sprite path lost its /Textures/ prefix. 


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Glaud
- fix: Fixed minor bugs in casino content.
