### PR TITLE
Add advanced paperwork cyborg module

### DIFF
--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -661,13 +661,13 @@ public sealed partial class FaxSystem : EntitySystem
         var printout = component.PrintingQueue.Dequeue();
 
         var entityToSpawn = printout.PrototypeId.Length == 0 ? component.PrintPaperId.ToString() : printout.PrototypeId;
-        #region Starlight
+        // Starlight start
         var xform = Transform(uid);
         var coords = _container.TryGetOuterContainer(uid, xform, out var outerContainer)
             ? Transform(outerContainer.Owner).Coordinates
             : xform.Coordinates;
         var printed = Spawn(entityToSpawn, coords);
-        #endregion
+        // Starlight end
 
         if (TryComp<PaperComponent>(printed, out var paper))
         {

--- a/Content.Server/Fax/FaxSystem.cs
+++ b/Content.Server/Fax/FaxSystem.cs
@@ -68,6 +68,7 @@ public sealed partial class FaxSystem : EntitySystem
     [Dependency] private IPrototypeManager _proto = default!;
     [Dependency] private InventorySystem _inventory = default!;
     [Dependency] private SharedTimeSystem _time = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
     #endregion
 
     private static readonly ProtoId<ToolQualityPrototype> ScrewingQuality = "Screwing";
@@ -660,7 +661,13 @@ public sealed partial class FaxSystem : EntitySystem
         var printout = component.PrintingQueue.Dequeue();
 
         var entityToSpawn = printout.PrototypeId.Length == 0 ? component.PrintPaperId.ToString() : printout.PrototypeId;
-        var printed = Spawn(entityToSpawn, Transform(uid).Coordinates);
+        #region Starlight
+        var xform = Transform(uid);
+        var coords = _container.TryGetOuterContainer(uid, xform, out var outerContainer)
+            ? Transform(outerContainer.Owner).Coordinates
+            : xform.Coordinates;
+        var printed = Spawn(entityToSpawn, coords);
+        #endregion
 
         if (TryComp<PaperComponent>(printed, out var paper))
         {

--- a/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertComponent.cs
+++ b/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Containers.ItemSlots;
+
+/// <summary>
+/// Lets a held entity fill one of its own item slots by clicking the item to be inserted,
+/// rather than requiring the holder to click the slot owner with that item.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ItemSlotQuickInsertComponent : Component
+{
+    [DataField(required: true)]
+    public string Slot = string.Empty;
+}

--- a/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertSystem.cs
+++ b/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Interaction;
+
+namespace Content.Shared._Starlight.Containers.ItemSlots;
+
+public sealed class ItemSlotQuickInsertSystem : EntitySystem
+{
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ItemSlotQuickInsertComponent, AfterInteractEvent>(OnAfterInteract);
+    }
+
+    private void OnAfterInteract(Entity<ItemSlotQuickInsertComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach || args.Target is not { } target)
+            return;
+
+        if (!_itemSlots.TryGetSlot(ent, ent.Comp.Slot, out var slot))
+            return;
+
+        if (!_itemSlots.CanInsert(ent, target, args.User, slot))
+            return;
+
+        args.Handled = _itemSlots.TryInsert(ent, slot, target, args.User);
+    }
+}

--- a/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertSystem.cs
+++ b/Content.Shared/_Starlight/Containers/ItemSlots/ItemSlotQuickInsertSystem.cs
@@ -3,6 +3,9 @@ using Content.Shared.Interaction;
 
 namespace Content.Shared._Starlight.Containers.ItemSlots;
 
+/// <summary>
+/// Inserts a clicked entity into an item slot on the entity the user is holding.
+/// </summary>
 public sealed class ItemSlotQuickInsertSystem : EntitySystem
 {
     [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -416,6 +416,8 @@
         components:
         - FaxableObject
   - type: ItemSlots
+  - type: ItemSlotQuickInsert
+    slot: Paper
   - type: ContainerContainer
     containers:
       Paper: !type:ContainerSlot

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -427,7 +427,7 @@
     transmitFrequencyId: Fax
 
 - type: entity
-  id: BorgModuleAdvancedPaperwork
+  id: BorgModulePaperworkPrinting
   parent: [ BaseBorgModulePurrfus, BaseProviderBorgModule ]
   name: paperwork printing module
   description: A complete bureaucracy suite. Prints standard station forms, files them away, and faxes them out.

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -358,7 +358,7 @@
   - type: ItemBorgModule
     hands:
     - item: LuxuryPen
-    - item: BoxFolderCyborgClipboard
+    - item: HandLabeler
     - item: RubberStampApproved
     - item: RubberStampDenied
     - hand:
@@ -377,7 +377,75 @@
           - Pda
           - IdCard
           - Stamp
-    - item: HandLabeler # last entry so it shows at the top of the module slots
+  - type: BorgModuleIcon
+    icon: { sprite: _Starlight/Interface/Actions/actions_borg.rsi, state: paperwork-module }
+
+- type: entity
+  id: FaxMachineBorg
+  parent: BaseItem
+  name: integrated fax transmitter
+  description: A miniaturised bluespace fax array. It can send documents anywhere on the network, but keeps no listing of its own for others to reply to.
+  components:
+  - type: Sprite
+    sprite: Structures/Machines/fax_machine.rsi
+    layers:
+    - state: idle
+      map: [ "enum.FaxMachineVisuals.VisualState" ]
+  - type: Appearance
+  - type: GenericVisualizer
+    visuals:
+      enum.FaxMachineVisuals.VisualState:
+        enum.FaxMachineVisuals.VisualState:
+          Printing: { state: printing }
+          Normal: { state: idle }
+  - type: ActivatableUI
+    key: enum.FaxUiKey.Key
+  - type: UserInterface
+    interfaces:
+      enum.FaxUiKey.Key:
+        type: FaxBoundUi
+  - type: ApcPowerReceiver
+    needsPower: false
+  - type: FaxMachine
+    name: "Cyborg"
+    responsePings: false
+    paperSlot:
+      insertSound: /Audio/Machines/scanning.ogg
+      ejectSound: /Audio/Machines/tray_eject.ogg
+      whitelist:
+        components:
+        - FaxableObject
+  - type: ItemSlots
+  - type: ContainerContainer
+    containers:
+      Paper: !type:ContainerSlot
+  - type: DeviceNetwork
+    deviceNetId: Wireless
+    receiveFrequencyId: Fax
+    transmitFrequencyId: Fax
+
+- type: entity
+  id: BorgModuleAdvancedPaperwork
+  parent: [ BaseBorgModulePurrfus, BaseProviderBorgModule ]
+  name: advanced paperwork cyborg module
+  description: A complete bureaucracy suite. Prints standard station forms, files them away, and faxes them out.
+  components:
+  - type: Sprite
+    sprite: _Starlight/Objects/Specific/Robotics/borgmodule.rsi
+    layers:
+    - state: command
+    - state: icon-paperwork
+  - type: ItemBorgModule
+    hands:
+    - item: PrinterCyber
+    - item: FaxMachineBorg
+    - item: BoxFolderCyborgClipboard
+    - hand:
+        emptyLabel: borg-slot-papers-empty
+        emptyRepresentative: BorgModulePaperStampPlaceholder
+        whitelist:
+          tags:
+          - Document
   - type: BorgModuleIcon
     icon: { sprite: _Starlight/Interface/Actions/actions_borg.rsi, state: paperwork-module }
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -429,7 +429,7 @@
 - type: entity
   id: BorgModuleAdvancedPaperwork
   parent: [ BaseBorgModulePurrfus, BaseProviderBorgModule ]
-  name: advanced paperwork cyborg module
+  name: paperwork printing module
   description: A complete bureaucracy suite. Prints standard station forms, files them away, and faxes them out.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -162,7 +162,7 @@
   - BorgModulePrying
   - BorgModuleTool
   - BorgModulePaperwork
-  - BorgModuleAdvancedPaperwork
+  - BorgModulePaperworkPrinting
 
   radioChannels:
   - Common

--- a/Resources/Prototypes/_Starlight/borg_types.yml
+++ b/Resources/Prototypes/_Starlight/borg_types.yml
@@ -162,6 +162,7 @@
   - BorgModulePrying
   - BorgModuleTool
   - BorgModulePaperwork
+  - BorgModuleAdvancedPaperwork
 
   radioChannels:
   - Common


### PR DESCRIPTION
## Short description
Adds `BorgModuleAdvancedPaperwork`, an advanced paperwork module preinstalled on
the purrfus cyborg chassis. 

The module provides:
- The existing cybernetic document printer, which prints the standard NanoTrasen
  form set (permits, reports, orders) and is refilled by feeding it paper.
- A new integrated fax transmitter, letting the unit fax documents from anywhere.
- A cyborg clipboard and a document hand slot to carry the results.

The fax is send-only. It sets `responsePings: false`, so it never advertises itself
on the device network and cannot be selected as a destination by other fax machines.

This also fixes a pre-existing bug in `FaxSystem`: printed paper was spawned at the
fax's own coordinates, so a fax inside any container parented the paper to its holder
instead of dropping it on the floor, leaking the entity. It now resolves to the
outermost container's coordinates, mirroring the fix already present in
`LatheSystem.FinishProducing`. Behaviour for ordinary wall-mounted faxes is unchanged,
since they are not in a container and take the original code path.

Also, paper clipboard is also transferred to the new module from the old one.

## Why we need to add this
Suggested [here](https://discord.com/channels/1272545509562777621/1531355994381221988).


## Media
https://github.com/user-attachments/assets/9bfe68e1-cf1a-4030-a511-1f4f2adc2740



## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the MIT License and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Glaud
- add: Purrfus cyborgs now come with an paperwork printing module, holding a document printer, an integrated fax transmitter, a clipboard and a document slot.
- tweak: The clipboard have placed to the new module in purrfus.
- fix: Fax machines inside a container no longer lose the paper they print.