### PR TITLE
Replaces plastitanium walls on Harm's Space Truck

### DIFF
--- a/Resources/Maps/_Starlight/Shuttles/SpaceTruck.yml
+++ b/Resources/Maps/_Starlight/Shuttles/SpaceTruck.yml
@@ -3513,7 +3513,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-- proto: WallPlastitanium
+- proto: WallReinforced
   entities:
   - uid: 232
     components:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
The Harm's Space Truck (available in the Shipyard console) had plastitanium walls. I forgot that these walls are super tough and meant for Syndicate stuff.

This PR replaces them with budget-friendly reinforced walls.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I forgot how tuff plastitanium walls are.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="789" height="959" alt="image" src="https://github.com/user-attachments/assets/2badac79-e952-4ed4-ac1e-2b4da0796a3a" />

fig. 1 - Walls swapped.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: (Shipyard) Due to the rising cost of manufacturing, Harm's 'Space Truck' has had its plastitanium walls replaced with regular reinforced walls. No refunds will be issued.