### PR TITLE
Minor Dynamic Tweak

### DIFF
--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -57,12 +57,15 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 5
-        - id: VampireLess
+        - id: Vampire
           weight: 15
           prob: 0.90 # Vampire can have a small chance to fail too, it's the other "most likely" gamemode
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - VampireLess
           - !type:PlayerCountCondition
             min: 25
         - id: Nukeops
@@ -175,11 +178,14 @@
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - Vampire
           - !type:PlayerCountCondition
             min: 25
         - id: NukeopsLate
           weight: 9
-          prob: 0.40 # Have a 50% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
+          prob: 0.40 # Have a 40% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -57,18 +57,17 @@
           - !type:MaxRuleOccurenceCondition
           - !type:PlayerCountCondition
             min: 5
-        - id: Vampire
+        - id: VampireLess
           weight: 15
+          prob: 0.90 # Vampire can have a small chance to fail too, it's the other "most likely" gamemode
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
-          - !type:MutuallyExclusiveRuleCondition
-            rules:
-            - VampireLess
           - !type:PlayerCountCondition
             min: 25
         - id: Nukeops
           weight: 10
+          prob: 0.95 # Every main gamemode will have a very small chance to fail
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -76,6 +75,7 @@
             min: 20
         - id: Revolutionary
           weight: 10
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -83,6 +83,7 @@
             min: 15
         - id: CosmicCult
           weight: 10
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -90,6 +91,7 @@
             min: 20
         - id: Zombie
           weight: 10
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -97,6 +99,7 @@
             min: 20
         - id: WizardDuel
           weight: 10
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -172,9 +175,6 @@
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
-          - !type:MutuallyExclusiveRuleCondition
-            rules:
-            - Vampire
           - !type:PlayerCountCondition
             min: 25
         - id: NukeopsLate
@@ -447,6 +447,7 @@
             min: 25
         - id: Nukeops
           weight: 7
+          prob: 0.95 # Every main gamemode will have a very small chance to fail
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -454,6 +455,7 @@
             min: 20
         - id: Revolutionary
           weight: 7
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -461,6 +463,7 @@
             min: 15
         - id: CosmicCult
           weight: 7
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -468,6 +471,7 @@
             min: 20
         - id: Zombie
           weight: 7
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -475,6 +479,7 @@
             min: 20
         - id: WizardDuel
           weight: 6
+          prob: 0.95
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -59,7 +59,7 @@
             min: 5
         - id: Vampire
           weight: 15
-          prob: 0.90 # Vampire can have a small chance to fail too, it's the other "most likely" gamemode
+          prob: 0.90 # Vampire can have a slightly higher chance to fail than the other gamemodes, it's the other "most likely" gamemode
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition


### PR DESCRIPTION
## Short description
Minor dynamic tweak before it goes to live.

## Why we need to add this
Being cautious, don't want it to be too chaotic.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: All antags in Dynamic/DynamicLP now have a small chance to fail to roll, so it's not guaranteed to always roll a roundstart antag.
