### PR TITLE
Fix PDA astronav shrinking ghost mass scanner range

### DIFF
--- a/Content.Shared/_Starlight/Astronav/AstroNavSystem.cs
+++ b/Content.Shared/_Starlight/Astronav/AstroNavSystem.cs
@@ -23,9 +23,15 @@ public sealed partial class AstroNavSystem : EntitySystem
     {
         if(args.Slot != "id")
             return;
+
         _alerts.ShowAlert(args.EquipTarget, ent.Comp.GPSAlert);
         EnsureComp<AstroNavMobComponent>(args.EquipTarget);
-        RadarConsoleComponent radarComp = EnsureComp<RadarConsoleComponent>(args.EquipTarget);
+
+        // Do not override existing radar console (such as ghosts have)
+        if (HasComp<RadarConsoleComponent>(args.EquipTarget))
+            return;
+
+        var radarComp = EnsureComp<RadarConsoleComponent>(args.EquipTarget);
         radarComp.FollowEntity = true;
         radarComp.MaxRange = ent.Comp.MaxRange;
     }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Title

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

https://github.com/ss14Starlight/space-station-14/pull/5299 broke this, it overrode the range and didn't check if the component was pre-existing.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Too lazy to record but I tested it and it works

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- fix: Admin ghost PDA no longer shrinks the ghost mass scanner range.