### PR TITLE
Fix tall tank build ghost

### DIFF
--- a/Content.Client/Construction/ConstructionSystem.cs
+++ b/Content.Client/Construction/ConstructionSystem.cs
@@ -317,6 +317,7 @@ namespace Content.Client.Construction
                 var targetSprite = EnsureComp<SpriteComponent>(dummy);
                 EntityManager.System<AppearanceSystem>().OnChangeData(dummy, targetSprite);
 
+                var destIndex = 0; // Starlight: Track how many layers we've actually added
                 for (var i = 0; i < targetSprite.AllLayers.Count(); i++)
                 {
                     if (!targetSprite[i].Visible || !targetSprite[i].RsiState.IsValid)
@@ -327,12 +328,21 @@ namespace Content.Client.Construction
                         state.StateId.Name is null)
                         continue;
 
-                    _sprite.AddBlankLayer((ghost.Value, sprite), i);
-                    _sprite.LayerSetSprite((ghost.Value, sprite), i, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
-                    sprite.LayerSetShader(i, "unshaded");
-                    _sprite.LayerSetVisible((ghost.Value, sprite), i, true);
-                    _sprite.LayerSetOffset((ghost.Value, sprite), i, // Starlight: Fix offset not being copied
-                        targetSprite.Offset + ((SpriteComponent.Layer)targetSprite[i]).Offset); // Starlight
+                    // Starlight START
+                    // Most of these lines only changed i => destIndex. By counting how many layers we add we prevent
+                    // empty layers since empty/missing layer indices causes bugs *elsewhere*. Yay.
+                    _sprite.AddBlankLayer((ghost.Value, sprite), destIndex);
+                    _sprite.LayerSetSprite((ghost.Value, sprite), destIndex, new SpriteSpecifier.Rsi(rsi.Path, state.StateId.Name));
+                    sprite.LayerSetShader(destIndex, "unshaded");
+                    _sprite.LayerSetVisible((ghost.Value, sprite), destIndex, true);
+
+                    // This is new: Fix offset not being copied
+                    _sprite.LayerSetOffset((ghost.Value, sprite), destIndex,
+                        targetSprite.Offset + ((SpriteComponent.Layer)targetSprite[i]).Offset);
+
+                    // Count the added layer
+                    destIndex++;
+                    // Starlight END
                 }
 
                 sprite.NoRotation = targetSprite.NoRotation; // Starlight: Fix NoRotation also being ignored.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers I hate sprite layers

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Apparently skipping a layer index makes upstream code related to rendering the construction ghost upset, so this makes *this* upstream code *not* skip the layer indexes. Yeah. I don't want to talk about it.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Before

<img width="1246" height="896" alt="image" src="https://github.com/user-attachments/assets/7fb020f7-0f9c-4196-9082-ecd9ead7a95e" />


### After

Behold, my client didn't crash and burn violently.

<img width="503" height="487" alt="image" src="https://github.com/user-attachments/assets/301e71e5-326e-496e-9d17-4e2302b5ed11" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

No CL because 10 tiny bug fixes relating to the single same thing interests nobody