### PR TITLE
Add prefilled air subfloor gas tank, tall gas tank

### DIFF
--- a/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
@@ -1,0 +1,71 @@
+using Content.Server.NodeContainer.EntitySystems;
+using Content.Server.NodeContainer.Nodes;
+using Content.Shared._Starlight.Atmos;
+using Content.Shared.Atmos;
+using Content.Shared.NodeContainer;
+
+namespace Content.Server._Starlight.Atmos.EntitySystems;
+
+/// <summary>
+/// Handles <see cref="PipePrefillComponent"/>: fills the entity's pipe segment with gas once, then removes the component.
+/// </summary>
+public sealed partial class PipePrefillSystem : EntitySystem
+{
+    [Dependency] private NodeGroupSystem _nodeGroup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PipePrefillComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<PipePrefillComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
+    }
+
+    private void OnMapInit(Entity<PipePrefillComponent> ent, ref MapInitEvent args)
+    {
+        if (!Transform(ent).Anchored) return; // Not anchored = no pipenet
+        PrefillPipeSegment(ent);
+    }
+
+    private void OnAnchorStateChanged(Entity<PipePrefillComponent> ent, ref AnchorStateChangedEvent args)
+    {
+        if (!args.Anchored) return; // Not anchored = no pipenet
+        PrefillPipeSegment(ent);
+    }
+
+    private void PrefillPipeSegment(Entity<PipePrefillComponent> ent)
+    {
+        RemComp<PipePrefillComponent>(ent);
+
+        // If we don't even have a node that *could* be part of a pipenet, just quit.
+        if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
+            return;
+
+        // Force an update so the PipeNet actually exists before we try to mutate it.
+        _nodeGroup.ForceUpdate();
+
+        var fractionTotal = 0f;
+        foreach (var fraction in ent.Comp.Mixture.Values)
+            fractionTotal += fraction;
+        if (fractionTotal <= 0)
+            return;
+
+        // Does this run for every node on an entity? Yes. Is that bad? Probably not. For example, if we would use this
+        // on a gas mixer, that'd be both inlets and the outlet. No big deal if you ask me. (Though why you would want
+        // to use this on multi-node entities is beyond me).
+        foreach (var node in nodeContainer.Nodes.Values)
+        {
+            if (node is not PipeNode pipeNode)
+                continue;
+
+            // Given the target pressure + our volume, calculate how many mols that would take to achieve.
+            var totalMoles = ent.Comp.Pressure * pipeNode.Volume / (Atmospherics.R * ent.Comp.Temperature);
+
+            // Add one gas at a time, proportional to the relative mixture.
+            var air = pipeNode.Air;
+            foreach (var (gas, fraction) in ent.Comp.Mixture)
+                air.AdjustMoles(gas, totalMoles * fraction / fractionTotal);
+        }
+    }
+
+}

--- a/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
@@ -41,9 +41,6 @@ public sealed partial class PipePrefillSystem : EntitySystem
         if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
             return;
 
-        // Force an update so the PipeNet actually exists before we try to mutate it.
-        _nodeGroup.ForceUpdate();
-
         var fractionTotal = 0f;
         foreach (var fraction in ent.Comp.Mixture.Values)
             fractionTotal += fraction;
@@ -57,6 +54,12 @@ public sealed partial class PipePrefillSystem : EntitySystem
         {
             if (node is not PipeNode pipeNode)
                 continue;
+
+            // Give this node a PipeNet immediately (no-op if it already has one) so its Air mixture
+            // actually exists before we mutate it, without forcing a full update of every other
+            // queued node group on the map. It'll get properly merged with any connected neighbours,
+            // gas and all, next time the node group system processes its queue.
+            _nodeGroup.CreateSingleNetImmediate(pipeNode);
 
             // Given the target pressure + our volume, calculate how many mols that would take to achieve.
             var totalMoles = ent.Comp.Pressure * pipeNode.Volume / (Atmospherics.R * ent.Comp.Temperature);

--- a/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.NodeContainer.Nodes;
 using Content.Shared._Starlight.Atmos;
 using Content.Shared.Atmos;
 using Content.Shared.NodeContainer;
+using Robust.Shared.Map;
 
 namespace Content.Server._Starlight.Atmos.EntitySystems;
 
@@ -21,20 +22,18 @@ public sealed partial class PipePrefillSystem : EntitySystem
         SubscribeLocalEvent<PipePrefillComponent, AnchorStateChangedEvent>(OnAnchorStateChanged);
     }
 
-    private void OnMapInit(Entity<PipePrefillComponent> ent, ref MapInitEvent args)
-    {
-        if (!Transform(ent).Anchored) return; // Not anchored = no pipenet
+    private void OnMapInit(Entity<PipePrefillComponent> ent, ref MapInitEvent args) =>
         PrefillPipeSegment(ent);
-    }
 
-    private void OnAnchorStateChanged(Entity<PipePrefillComponent> ent, ref AnchorStateChangedEvent args)
-    {
-        if (!args.Anchored) return; // Not anchored = no pipenet
+    private void OnAnchorStateChanged(Entity<PipePrefillComponent> ent, ref AnchorStateChangedEvent args) =>
         PrefillPipeSegment(ent);
-    }
 
     private void PrefillPipeSegment(Entity<PipePrefillComponent> ent)
     {
+        var xform = Transform(ent);
+        if (!xform.Anchored) return; // Not anchored = no pipenet
+        if (xform.MapID == MapId.Nullspace) return;
+        if (LifeStage(ent) < EntityLifeStage.MapInitialized) return;
         RemComp<PipePrefillComponent>(ent);
 
         // If we don't even have a node that *could* be part of a pipenet, just quit.

--- a/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/PipePrefillSystem.cs
@@ -47,6 +47,10 @@ public sealed partial class PipePrefillSystem : EntitySystem
         if (fractionTotal <= 0)
             return;
 
+        // No target? Do nothing.
+        if (!ent.Comp.TargetPressure.HasValue && !ent.Comp.TargetMoles.HasValue)
+            return;
+
         // Does this run for every node on an entity? Yes. Is that bad? Probably not. For example, if we would use this
         // on a gas mixer, that'd be both inlets and the outlet. No big deal if you ask me. (Though why you would want
         // to use this on multi-node entities is beyond me).
@@ -62,12 +66,16 @@ public sealed partial class PipePrefillSystem : EntitySystem
             _nodeGroup.CreateSingleNetImmediate(pipeNode);
 
             // Given the target pressure + our volume, calculate how many mols that would take to achieve.
-            var totalMoles = ent.Comp.Pressure * pipeNode.Volume / (Atmospherics.R * ent.Comp.Temperature);
+            var targetMoles = 0f;
+            if (ent.Comp.TargetMoles.HasValue)
+                targetMoles = ent.Comp.TargetMoles.Value;
+            if (ent.Comp.TargetPressure.HasValue)
+                targetMoles = ent.Comp.TargetPressure.Value * pipeNode.Volume / (Atmospherics.R * ent.Comp.Temperature);
 
             // Add one gas at a time, proportional to the relative mixture.
             var air = pipeNode.Air;
             foreach (var (gas, fraction) in ent.Comp.Mixture)
-                air.AdjustMoles(gas, totalMoles * fraction / fractionTotal);
+                air.AdjustMoles(gas, targetMoles * fraction / fractionTotal);
         }
     }
 

--- a/Content.Shared/_Starlight/Atmos/PipePrefillComponent.cs
+++ b/Content.Shared/_Starlight/Atmos/PipePrefillComponent.cs
@@ -1,0 +1,27 @@
+using Content.Shared.Atmos;
+
+namespace Content.Shared._Starlight.Atmos;
+
+/// <summary>
+/// Prefills a singular pipenet node with the specified mixture and parameters.
+/// Note that this is additive with multiple <see cref="PipePrefillComponent"/>s that are connected to the same
+/// resulting pipenet.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PipePrefillComponent : Component
+{
+    /// <summary>
+    /// Fraction of each gas in the final mixture. Numbers are relative to one another.
+    /// </summary>
+    [DataField(required: true)] public Dictionary<Gas, float> Mixture = new();
+
+    /// <summary>
+    /// Target pressure, in kPa, at <see cref="Temperature"/> for the node or network's actual volume.
+    /// </summary>
+    [DataField] public float Pressure = Atmospherics.OneAtmosphere;
+
+    /// <summary>
+    /// The temperature that the added mixture should be at.
+    /// </summary>
+    [DataField] public float Temperature = Atmospherics.T20C;
+}

--- a/Content.Shared/_Starlight/Atmos/PipePrefillComponent.cs
+++ b/Content.Shared/_Starlight/Atmos/PipePrefillComponent.cs
@@ -16,12 +16,17 @@ public sealed partial class PipePrefillComponent : Component
     [DataField(required: true)] public Dictionary<Gas, float> Mixture = new();
 
     /// <summary>
-    /// Target pressure, in kPa, at <see cref="Temperature"/> for the node or network's actual volume.
-    /// </summary>
-    [DataField] public float Pressure = Atmospherics.OneAtmosphere;
-
-    /// <summary>
     /// The temperature that the added mixture should be at.
     /// </summary>
     [DataField] public float Temperature = Atmospherics.T20C;
+
+    /// <summary>
+    /// Target total amount of mols to have at <see cref="Temperature"/>.
+    /// </summary>
+    [DataField] public float? TargetMoles;
+
+    /// <summary>
+    /// Target pressure, in kPa, at <see cref="Temperature"/>.
+    /// </summary>
+    [DataField] public float? TargetPressure;
 }

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -3,7 +3,8 @@
 - type: entity
   parent: GasPipeTankSubfloor
   id: GasPipeTankSubfloorFilledAir4500
-  suffix: Air, 4500kPa
+  suffix: DO NOT MAP, Air, 4500kPa
+  categories: [ DoNotMap ]
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
@@ -21,7 +22,7 @@
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir4500]
   id: GasPipeTankSubfloorFilledAir4500Alt1
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       drawdepth: ThinPipeAlt1
@@ -30,7 +31,7 @@
 - type: entity
   parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir4500]
   id: GasPipeTankSubfloorFilledAir4500Alt2
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       drawdepth: ThinPipeAlt2
@@ -39,7 +40,7 @@
 - type: entity
   parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir4500]
   id: GasPipeTankSubfloorFilledAir4500Alt3
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       drawdepth: ThinPipeAlt3
@@ -48,7 +49,7 @@
 - type: entity
   parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir4500]
   id: GasPipeTankSubfloorFilledAir4500Alt4
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       drawdepth: ThinPipeAlt4
@@ -60,7 +61,8 @@
 - type: entity
   parent: GasPipeTankSubfloor
   id: GasPipeTankSubfloorFilledAir9000
-  suffix: Air, 9000kPa
+  suffix: DO NOT MAP, Air, 9000kPa
+  categories: [ DoNotMap ]
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
@@ -78,7 +80,7 @@
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir9000]
   id: GasPipeTankSubfloorFilledAir9000Alt1
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
   - type: Sprite
     drawdepth: ThinPipeAlt1
@@ -87,7 +89,7 @@
 - type: entity
   parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir9000]
   id: GasPipeTankSubfloorFilledAir9000Alt2
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
   - type: Sprite
     drawdepth: ThinPipeAlt2
@@ -96,7 +98,7 @@
 - type: entity
   parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir9000]
   id: GasPipeTankSubfloorFilledAir9000Alt3
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
   - type: Sprite
     drawdepth: ThinPipeAlt3
@@ -105,7 +107,7 @@
 - type: entity
   parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir9000]
   id: GasPipeTankSubfloorFilledAir9000Alt4
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
   - type: Sprite
     drawdepth: ThinPipeAlt4
@@ -117,7 +119,8 @@
 - type: entity
   parent: GasPipeTankTall
   id: GasPipeTankTallFilledAir4500
-  suffix: Air, 4500kPa
+  suffix: DO NOT MAP, Air, 4500kPa
+  categories: [ DoNotMap ]
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
@@ -135,7 +138,7 @@
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir4500]
   id: GasPipeTankTallFilledAir4500Alt1
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
@@ -143,7 +146,7 @@
 - type: entity
   parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir4500]
   id: GasPipeTankTallFilledAir4500Alt2
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
@@ -151,7 +154,7 @@
 - type: entity
   parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir4500]
   id: GasPipeTankTallFilledAir4500Alt3
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
@@ -159,7 +162,7 @@
 - type: entity
   parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir4500]
   id: GasPipeTankTallFilledAir4500Alt4
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
@@ -170,7 +173,8 @@
 - type: entity
   parent: GasPipeTankTall
   id: GasPipeTankTallFilledAir9000
-  suffix: Air, 9000kPa
+  suffix: DO NOT MAP, Air, 9000kPa
+  categories: [ DoNotMap ]
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
@@ -188,7 +192,7 @@
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir9000]
   id: GasPipeTankTallFilledAir9000Alt1
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
@@ -196,7 +200,7 @@
 - type: entity
   parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir9000]
   id: GasPipeTankTallFilledAir9000Alt2
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
@@ -204,7 +208,7 @@
 - type: entity
   parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir9000]
   id: GasPipeTankTallFilledAir9000Alt3
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
@@ -212,7 +216,7 @@
 - type: entity
   parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir9000]
   id: GasPipeTankTallFilledAir9000Alt4
-  categories: [ HideSpawnMenu ]
+  categories: [ DoNotMap, HideSpawnMenu ]
   components:
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -1,0 +1,220 @@
+# Subfloor gas tank (4500kPa) BEGIN
+
+- type: entity
+  parent: GasPipeTankSubfloor
+  id: GasPipeTankSubfloorFilledAir4500
+  suffix: Air, 4500kPa
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankSubfloorFilledAir4500
+        Secondary: GasPipeTankSubfloorFilledAir4500Alt1
+        Tertiary: GasPipeTankSubfloorFilledAir4500Alt2
+        Quaternary: GasPipeTankSubfloorFilledAir4500Alt3
+        Quinary: GasPipeTankSubfloorFilledAir4500Alt4
+    - type: PipePrefill
+      pressure: 4500
+      mixture:
+        Oxygen: 21
+        Nitrogen: 79
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir4500]
+  id: GasPipeTankSubfloorFilledAir4500Alt1
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt1
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir4500]
+  id: GasPipeTankSubfloorFilledAir4500Alt2
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt2
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir4500]
+  id: GasPipeTankSubfloorFilledAir4500Alt3
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt3
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir4500]
+  id: GasPipeTankSubfloorFilledAir4500Alt4
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt4
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+
+# Subfloor gas tank (4500kPa) END
+# Subfloor gas tank (9000kPa) BEGIN
+
+- type: entity
+  parent: GasPipeTankSubfloor
+  id: GasPipeTankSubfloorFilledAir9000
+  suffix: Air, 9000kPa
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankSubfloorFilledAir9000
+        Secondary: GasPipeTankSubfloorFilledAir9000Alt1
+        Tertiary: GasPipeTankSubfloorFilledAir9000Alt2
+        Quaternary: GasPipeTankSubfloorFilledAir9000Alt3
+        Quinary: GasPipeTankSubfloorFilledAir9000Alt4
+    - type: PipePrefill
+      pressure: 9000
+      mixture:
+        Oxygen: 21
+        Nitrogen: 79
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir9000]
+  id: GasPipeTankSubfloorFilledAir9000Alt1
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: ThinPipeAlt1
+    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir9000]
+  id: GasPipeTankSubfloorFilledAir9000Alt2
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: ThinPipeAlt2
+    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir9000]
+  id: GasPipeTankSubfloorFilledAir9000Alt3
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: ThinPipeAlt3
+    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir9000]
+  id: GasPipeTankSubfloorFilledAir9000Alt4
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Sprite
+    drawdepth: ThinPipeAlt4
+    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+
+# Subfloor gas tank (9000kPa) END
+# Tall gas tank (4500kPa) BEGIN
+
+- type: entity
+  parent: GasPipeTankTall
+  id: GasPipeTankTallFilledAir4500
+  suffix: Air, 4500kPa
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankTallFilledAir4500
+        Secondary: GasPipeTankTallFilledAir4500Alt1
+        Tertiary: GasPipeTankTallFilledAir4500Alt2
+        Quaternary: GasPipeTankTallFilledAir4500Alt3
+        Quinary: GasPipeTankTallFilledAir4500Alt4
+    - type: PipePrefill
+      pressure: 4500
+      mixture:
+        Oxygen: 21
+        Nitrogen: 79
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir4500]
+  id: GasPipeTankTallFilledAir4500Alt1
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir4500]
+  id: GasPipeTankTallFilledAir4500Alt2
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir4500]
+  id: GasPipeTankTallFilledAir4500Alt3
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir4500]
+  id: GasPipeTankTallFilledAir4500Alt4
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+
+# Tall gas tank (4500kPa) END
+# Tall gas tank (9000kPa) BEGIN
+
+- type: entity
+  parent: GasPipeTankTall
+  id: GasPipeTankTallFilledAir9000
+  suffix: Air, 9000kPa
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankTallFilledAir9000
+        Secondary: GasPipeTankTallFilledAir9000Alt1
+        Tertiary: GasPipeTankTallFilledAir9000Alt2
+        Quaternary: GasPipeTankTallFilledAir9000Alt3
+        Quinary: GasPipeTankTallFilledAir9000Alt4
+    - type: PipePrefill
+      pressure: 9000
+      mixture:
+        Oxygen: 21
+        Nitrogen: 79
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir9000]
+  id: GasPipeTankTallFilledAir9000Alt1
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir9000]
+  id: GasPipeTankTallFilledAir9000Alt2
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir9000]
+  id: GasPipeTankTallFilledAir9000Alt3
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir9000]
+  id: GasPipeTankTallFilledAir9000Alt4
+  categories: [ HideSpawnMenu ]
+  components:
+    - type: Sprite
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+
+# Tall gas tank (9000kPa) END

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -145,7 +145,7 @@
   components: *subfloorAlt4
 
 # Subfloor gas tank (1500mol) END
-# Tall gas tank (1500mol) BEGIN
+# Tall gas tank (1000mol) BEGIN
 
 - type: entity
   parent: GasPipeTankTall

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -294,7 +294,7 @@
   parent: GasPipeTankTall
   id: GasPipeTankTallFilledAir7500
   categories: [ DoNotMap ]
-  suffix: Air, 7500mol
+  suffix: Air, 7500mol, DO NOT MAP
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -1,9 +1,9 @@
-# Subfloor gas tank (500kPa) BEGIN
+# Subfloor gas tank (500mol) BEGIN
 
 - type: entity
   parent: GasPipeTankSubfloor
   id: GasPipeTankSubfloorFilledAir500
-  suffix: Shuttle, Air, 500kPa
+  suffix: Air, 500mol
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
@@ -13,7 +13,7 @@
         Quaternary: GasPipeTankSubfloorFilledAir500Alt3
         Quinary: GasPipeTankSubfloorFilledAir500Alt4
     - type: PipePrefill
-      pressure: 500
+      targetMoles: 500
       mixture:
         Oxygen: 25
         Nitrogen: 75
@@ -21,8 +21,8 @@
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir500]
   id: GasPipeTankSubfloorFilledAir500Alt1
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  categories: [ HideSpawnMenu ]
+  components: &subfloorAlt1
     - type: Sprite
       drawdepth: ThinPipeAlt1
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
@@ -30,8 +30,8 @@
 - type: entity
   parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir500]
   id: GasPipeTankSubfloorFilledAir500Alt2
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  categories: [ HideSpawnMenu ]
+  components: &subfloorAlt2
     - type: Sprite
       drawdepth: ThinPipeAlt2
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
@@ -39,8 +39,8 @@
 - type: entity
   parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir500]
   id: GasPipeTankSubfloorFilledAir500Alt3
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  categories: [ HideSpawnMenu ]
+  components: &subfloorAlt3
     - type: Sprite
       drawdepth: ThinPipeAlt3
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
@@ -48,234 +48,289 @@
 - type: entity
   parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir500]
   id: GasPipeTankSubfloorFilledAir500Alt4
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  categories: [ HideSpawnMenu ]
+  components: &subfloorAlt4
     - type: Sprite
       drawdepth: ThinPipeAlt4
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
 
-# Subfloor gas tank (500kPa) END
-# Subfloor gas tank (4500kPa) BEGIN
+# Subfloor gas tank (500mol) END
+# Subfloor gas tank (1000mol) BEGIN
 
 - type: entity
   parent: GasPipeTankSubfloor
-  id: GasPipeTankSubfloorFilledAir4500
-  suffix: DO NOT MAP, Air, 4500kPa
-  categories: [ DoNotMap ]
+  id: GasPipeTankSubfloorFilledAir1000
+  suffix: Air, 1000mol
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
-        Primary: GasPipeTankSubfloorFilledAir4500
-        Secondary: GasPipeTankSubfloorFilledAir4500Alt1
-        Tertiary: GasPipeTankSubfloorFilledAir4500Alt2
-        Quaternary: GasPipeTankSubfloorFilledAir4500Alt3
-        Quinary: GasPipeTankSubfloorFilledAir4500Alt4
+        Primary: GasPipeTankSubfloorFilledAir1000
+        Secondary: GasPipeTankSubfloorFilledAir1000Alt1
+        Tertiary: GasPipeTankSubfloorFilledAir1000Alt2
+        Quaternary: GasPipeTankSubfloorFilledAir1000Alt3
+        Quinary: GasPipeTankSubfloorFilledAir1000Alt4
     - type: PipePrefill
-      pressure: 4500
+      targetMoles: 1000
       mixture:
         Oxygen: 25
         Nitrogen: 75
 
 - type: entity
-  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir4500]
-  id: GasPipeTankSubfloorFilledAir4500Alt1
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      drawdepth: ThinPipeAlt1
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir1000]
+  id: GasPipeTankSubfloorFilledAir1000Alt1
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt1
 
 - type: entity
-  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir4500]
-  id: GasPipeTankSubfloorFilledAir4500Alt2
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      drawdepth: ThinPipeAlt2
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir1000]
+  id: GasPipeTankSubfloorFilledAir1000Alt2
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt2
 
 - type: entity
-  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir4500]
-  id: GasPipeTankSubfloorFilledAir4500Alt3
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      drawdepth: ThinPipeAlt3
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir1000]
+  id: GasPipeTankSubfloorFilledAir1000Alt3
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt3
 
 - type: entity
-  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir4500]
-  id: GasPipeTankSubfloorFilledAir4500Alt4
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      drawdepth: ThinPipeAlt4
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir1000]
+  id: GasPipeTankSubfloorFilledAir1000Alt4
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt4
 
-# Subfloor gas tank (4500kPa) END
-# Subfloor gas tank (9000kPa) BEGIN
+# Subfloor gas tank (1000mol) END
+# Subfloor gas tank (1500mol) BEGIN
 
 - type: entity
   parent: GasPipeTankSubfloor
-  id: GasPipeTankSubfloorFilledAir9000
-  suffix: DO NOT MAP, Air, 9000kPa
-  categories: [ DoNotMap ]
+  id: GasPipeTankSubfloorFilledAir1500
+  suffix: Air, 1500mol
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
-        Primary: GasPipeTankSubfloorFilledAir9000
-        Secondary: GasPipeTankSubfloorFilledAir9000Alt1
-        Tertiary: GasPipeTankSubfloorFilledAir9000Alt2
-        Quaternary: GasPipeTankSubfloorFilledAir9000Alt3
-        Quinary: GasPipeTankSubfloorFilledAir9000Alt4
+        Primary: GasPipeTankSubfloorFilledAir1500
+        Secondary: GasPipeTankSubfloorFilledAir1500Alt1
+        Tertiary: GasPipeTankSubfloorFilledAir1500Alt2
+        Quaternary: GasPipeTankSubfloorFilledAir1500Alt3
+        Quinary: GasPipeTankSubfloorFilledAir1500Alt4
     - type: PipePrefill
-      pressure: 9000
+      targetMoles: 1500
       mixture:
         Oxygen: 25
         Nitrogen: 75
 
 - type: entity
-  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir9000]
-  id: GasPipeTankSubfloorFilledAir9000Alt1
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-  - type: Sprite
-    drawdepth: ThinPipeAlt1
-    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir1500]
+  id: GasPipeTankSubfloorFilledAir1500Alt1
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt1
 
 - type: entity
-  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir9000]
-  id: GasPipeTankSubfloorFilledAir9000Alt2
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-  - type: Sprite
-    drawdepth: ThinPipeAlt2
-    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir1500]
+  id: GasPipeTankSubfloorFilledAir1500Alt2
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt2
 
 - type: entity
-  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir9000]
-  id: GasPipeTankSubfloorFilledAir9000Alt3
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-  - type: Sprite
-    drawdepth: ThinPipeAlt3
-    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir1500]
+  id: GasPipeTankSubfloorFilledAir1500Alt3
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt3
 
 - type: entity
-  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir9000]
-  id: GasPipeTankSubfloorFilledAir9000Alt4
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-  - type: Sprite
-    drawdepth: ThinPipeAlt4
-    sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir1500]
+  id: GasPipeTankSubfloorFilledAir1500Alt4
+  categories: [ HideSpawnMenu ]
+  components: *subfloorAlt4
 
-# Subfloor gas tank (9000kPa) END
-# Tall gas tank (4500kPa) BEGIN
+# Subfloor gas tank (1500mol) END
+# Tall gas tank (1500mol) BEGIN
 
 - type: entity
   parent: GasPipeTankTall
-  id: GasPipeTankTallFilledAir4500
-  suffix: DO NOT MAP, Air, 4500kPa
-  categories: [ DoNotMap ]
+  id: GasPipeTankTallFilledAir1000
+  suffix: Air, 1000mol
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
-        Primary: GasPipeTankTallFilledAir4500
-        Secondary: GasPipeTankTallFilledAir4500Alt1
-        Tertiary: GasPipeTankTallFilledAir4500Alt2
-        Quaternary: GasPipeTankTallFilledAir4500Alt3
-        Quinary: GasPipeTankTallFilledAir4500Alt4
+        Primary: GasPipeTankTallFilledAir1000
+        Secondary: GasPipeTankTallFilledAir1000Alt1
+        Tertiary: GasPipeTankTallFilledAir1000Alt2
+        Quaternary: GasPipeTankTallFilledAir1000Alt3
+        Quinary: GasPipeTankTallFilledAir1000Alt4
     - type: PipePrefill
-      pressure: 4500
+      targetMoles: 1000
       mixture:
-        Oxygen: 21
-        Nitrogen: 79
+        Oxygen: 25
+        Nitrogen: 75
 
 - type: entity
-  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir4500]
-  id: GasPipeTankTallFilledAir4500Alt1
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir1000]
+  id: GasPipeTankTallFilledAir1000Alt1
+  categories: [ HideSpawnMenu ]
+  components: &tallAlt1
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
 
 - type: entity
-  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir4500]
-  id: GasPipeTankTallFilledAir4500Alt2
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir1000]
+  id: GasPipeTankTallFilledAir1000Alt2
+  categories: [ HideSpawnMenu ]
+  components: &tallAlt2
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
 
 - type: entity
-  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir4500]
-  id: GasPipeTankTallFilledAir4500Alt3
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir1000]
+  id: GasPipeTankTallFilledAir1000Alt3
+  categories: [ HideSpawnMenu ]
+  components: &tallAlt3
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
 
 - type: entity
-  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir4500]
-  id: GasPipeTankTallFilledAir4500Alt4
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir1000]
+  id: GasPipeTankTallFilledAir1000Alt4
+  categories: [ HideSpawnMenu ]
+  components: &tallAlt4
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
 
-# Tall gas tank (4500kPa) END
-# Tall gas tank (9000kPa) BEGIN
+# Tall gas tank (1000mol) END
+# Tall gas tank (2500mol) BEGIN
 
 - type: entity
   parent: GasPipeTankTall
-  id: GasPipeTankTallFilledAir9000
-  suffix: DO NOT MAP, Air, 9000kPa
-  categories: [ DoNotMap ]
+  id: GasPipeTankTallFilledAir2500
+  suffix: Air, 2500mol
   components:
     - type: AtmosPipeLayers
       alternativePrototypes:
-        Primary: GasPipeTankTallFilledAir9000
-        Secondary: GasPipeTankTallFilledAir9000Alt1
-        Tertiary: GasPipeTankTallFilledAir9000Alt2
-        Quaternary: GasPipeTankTallFilledAir9000Alt3
-        Quinary: GasPipeTankTallFilledAir9000Alt4
+        Primary: GasPipeTankTallFilledAir2500
+        Secondary: GasPipeTankTallFilledAir2500Alt1
+        Tertiary: GasPipeTankTallFilledAir2500Alt2
+        Quaternary: GasPipeTankTallFilledAir2500Alt3
+        Quinary: GasPipeTankTallFilledAir2500Alt4
     - type: PipePrefill
-      pressure: 9000
+      targetMoles: 2500
       mixture:
-        Oxygen: 21
-        Nitrogen: 79
+        Oxygen: 25
+        Nitrogen: 75
 
 - type: entity
-  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir9000]
-  id: GasPipeTankTallFilledAir9000Alt1
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir2500]
+  id: GasPipeTankTallFilledAir2500Alt1
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt1
 
 - type: entity
-  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir9000]
-  id: GasPipeTankTallFilledAir9000Alt2
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir2500]
+  id: GasPipeTankTallFilledAir2500Alt2
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt2
 
 - type: entity
-  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir9000]
-  id: GasPipeTankTallFilledAir9000Alt3
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir2500]
+  id: GasPipeTankTallFilledAir2500Alt3
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt3
 
 - type: entity
-  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir9000]
-  id: GasPipeTankTallFilledAir9000Alt4
-  categories: [ DoNotMap, HideSpawnMenu ]
-  components:
-    - type: Sprite
-      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir2500]
+  id: GasPipeTankTallFilledAir2500Alt4
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt4
 
-# Tall gas tank (9000kPa) END
+# Tall gas tank (2500mol) END
+# Tall gas tank (4000mol) BEGIN
+
+- type: entity
+  parent: GasPipeTankTall
+  id: GasPipeTankTallFilledAir4000
+  suffix: Air, 4000mol
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankTallFilledAir4000
+        Secondary: GasPipeTankTallFilledAir4000Alt1
+        Tertiary: GasPipeTankTallFilledAir4000Alt2
+        Quaternary: GasPipeTankTallFilledAir4000Alt3
+        Quinary: GasPipeTankTallFilledAir4000Alt4
+    - type: PipePrefill
+      targetMoles: 4000
+      mixture:
+        Oxygen: 25
+        Nitrogen: 75
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir4000]
+  id: GasPipeTankTallFilledAir4000Alt1
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir4000]
+  id: GasPipeTankTallFilledAir4000Alt2
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt2
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir4000]
+  id: GasPipeTankTallFilledAir4000Alt3
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt3
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir4000]
+  id: GasPipeTankTallFilledAir4000Alt4
+  categories: [ HideSpawnMenu ]
+  components: *tallAlt4
+
+# Tall gas tank (4000mol) END
+# Tall gas tank (7500mol) BEGIN
+
+- type: entity
+  parent: GasPipeTankTall
+  id: GasPipeTankTallFilledAir7500
+  categories: [ DoNotMap ]
+  suffix: Air, 7500mol
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankTallFilledAir7500
+        Secondary: GasPipeTankTallFilledAir7500Alt1
+        Tertiary: GasPipeTankTallFilledAir7500Alt2
+        Quaternary: GasPipeTankTallFilledAir7500Alt3
+        Quinary: GasPipeTankTallFilledAir7500Alt4
+    - type: PipePrefill
+      targetMoles: 7500
+      mixture:
+        Oxygen: 25
+        Nitrogen: 75
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankTallFilledAir7500]
+  id: GasPipeTankTallFilledAir7500Alt1
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components: *tallAlt1
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankTallFilledAir7500]
+  id: GasPipeTankTallFilledAir7500Alt2
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components: *tallAlt2
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankTallFilledAir7500]
+  id: GasPipeTankTallFilledAir7500Alt3
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components: *tallAlt3
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankTallFilledAir7500]
+  id: GasPipeTankTallFilledAir7500Alt4
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components: *tallAlt4
+
+# Tall gas tank (7500mol) END

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes_filled.yml
@@ -1,3 +1,60 @@
+# Subfloor gas tank (500kPa) BEGIN
+
+- type: entity
+  parent: GasPipeTankSubfloor
+  id: GasPipeTankSubfloorFilledAir500
+  suffix: Shuttle, Air, 500kPa
+  components:
+    - type: AtmosPipeLayers
+      alternativePrototypes:
+        Primary: GasPipeTankSubfloorFilledAir500
+        Secondary: GasPipeTankSubfloorFilledAir500Alt1
+        Tertiary: GasPipeTankSubfloorFilledAir500Alt2
+        Quaternary: GasPipeTankSubfloorFilledAir500Alt3
+        Quinary: GasPipeTankSubfloorFilledAir500Alt4
+    - type: PipePrefill
+      pressure: 500
+      mixture:
+        Oxygen: 25
+        Nitrogen: 75
+
+- type: entity
+  parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir500]
+  id: GasPipeTankSubfloorFilledAir500Alt1
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt1
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt1.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt2, GasPipeTankSubfloorFilledAir500]
+  id: GasPipeTankSubfloorFilledAir500Alt2
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt2
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt2.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt3, GasPipeTankSubfloorFilledAir500]
+  id: GasPipeTankSubfloorFilledAir500Alt3
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt3
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt3.rsi
+
+- type: entity
+  parent: [GasPipeLayerAlt4, GasPipeTankSubfloorFilledAir500]
+  id: GasPipeTankSubfloorFilledAir500Alt4
+  categories: [ DoNotMap, HideSpawnMenu ]
+  components:
+    - type: Sprite
+      drawdepth: ThinPipeAlt4
+      sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe_alt4.rsi
+
+# Subfloor gas tank (500kPa) END
 # Subfloor gas tank (4500kPa) BEGIN
 
 - type: entity
@@ -16,8 +73,8 @@
     - type: PipePrefill
       pressure: 4500
       mixture:
-        Oxygen: 21
-        Nitrogen: 79
+        Oxygen: 25
+        Nitrogen: 75
 
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir4500]
@@ -74,8 +131,8 @@
     - type: PipePrefill
       pressure: 9000
       mixture:
-        Oxygen: 21
-        Nitrogen: 79
+        Oxygen: 25
+        Nitrogen: 75
 
 - type: entity
   parent: [GasPipeLayerAlt1, GasPipeTankSubfloorFilledAir9000]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Adds prefilled air subfloor- and tall gas tanks.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Was originally requested for admeme use, but extended this to be viable for various use cases.

Shuttles should premap the smallest amount of air and rely on distro/waste pipe docking. The initial air is mostly for e.g. Salv/Mining so they can start off without running out of air early.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

<img width="542" height="403" alt="image" src="https://github.com/user-attachments/assets/5ade4434-9274-4267-959e-0306c1d1e236" />

<img width="1173" height="563" alt="image" src="https://github.com/user-attachments/assets/5463d9c4-4965-4802-a1ad-07e799e36fb1" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Mapping variants of subfloor- and tall gas tanks prefilled with air.
