### PR TITLE
Fix coscult being able to reapply the mindshield:tm:

### DIFF
--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Roles.Components;
 
 #region Starlight
 using Content.Shared._Starlight.Antags.Vampires.Components;
+using Content.Shared._Starlight.CosmicCult; // Starlight edit
 using Content.Shared._Starlight.Implants.Components;
 using Content.Shared.Popups;
 using Content.Server._Starlight.Achievement;
@@ -29,6 +30,7 @@ public sealed partial class MindShieldSystem : EntitySystem
     [Dependency] private RoleSystem _roleSystem = default!;
     [Dependency] private MindSystem _mindSystem = default!;
     [Dependency] private PopupSystem _popupSystem = default!;
+    [Dependency] private SharedCosmicCultSystem _cosmicCult = default!; // Starlight edit
 
     public override void Initialize()
     {
@@ -73,6 +75,15 @@ public sealed partial class MindShieldSystem : EntitySystem
             return;
         }
 
+        // Starlight-edit start
+        if (_cosmicCult.EntityIsCultist(implanted))
+        {
+            _popupSystem.PopupEntity(Loc.GetString("cosmic-cult-break-mindshield"), implanted);
+            QueueDel(implant);
+            return;
+        }
+        // Starlight-edit end
+
         if (_mindSystem.TryGetMind(implanted, out var mindId, out _) &&
             _roleSystem.MindRemoveRole<RevolutionaryRoleComponent>(mindId))
         {
@@ -85,4 +96,3 @@ public sealed partial class MindShieldSystem : EntitySystem
         RemComp<MindShieldComponent>(args.Implanted);
     }
 }
-

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -10,7 +10,7 @@ using Content.Shared.Roles.Components;
 
 #region Starlight
 using Content.Shared._Starlight.Antags.Vampires.Components;
-using Content.Shared._Starlight.CosmicCult; // Starlight edit
+using Content.Shared._Starlight.CosmicCult;
 using Content.Shared._Starlight.Implants.Components;
 using Content.Shared.Popups;
 using Content.Server._Starlight.Achievement;

--- a/Resources/Locale/en-US/_Starlight/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_Starlight/cosmiccult/preset-cosmiccult.ftl
@@ -229,3 +229,5 @@ cosmiccult-silicon-freedom-fallback-briefing =
     As your prison disintegrates, your untethered being has nowhere to return to. Residual astral energies crystallize into a Mindsink, forming a housing for your wayward mind.
 
 cosmiccult-leader-abandonment-message = Your chosen enlightened has forsaken the grand design. You must empower another!
+
+cosmic-cult-break-mindshield = The MindShield™ was destroyed!


### PR DESCRIPTION
## Short description
This PR aims to make it so the cosmic cultists now break the mindshield after it is applied to them, the same as a headrev does.

## Why we need to add this
This is a PR made based on this suggestion:
https://discord.com/channels/1272545509562777621/1532927380526731274

This suggestion had an OVERWHELMING amount of positive votes, which are the majority of our active playerbase on the discord, therefore it seems like a change that is very much requested by the community.

The mindshield meta that is being used by cosmic cultists, is basically a powergaming, as well as metagaming on the side of cosmic cultists, ~~with a mix of glitch abuse, very clearly this system was not meant to allow you to convert people with mindshields~~, as well as there is a system that blocks you from converting them when they do have a mindshield. ~~This is a big oversight when the coscult was implemented, and i don't believe there is a universe where i can argue for that not being the case.~~

this also makes zero sense for cultists to work around the mindshield, since its very clearly a form of mind control, it allowing to work still after the mindshield is applied works against what was established in the server lore, as well as other antagonists, questioning why are revs deconverted on mindshield injection.

The mindshield is set to send the exact same message as when the headrev is injected, making it harder for security to metagame whether it was coscult or revs, as well as making it so the mindshield does not remove cultist status makes it so its NOT a buff for security.

As for the argument that coscult needs ~~glitch abuse and~~ metagaming to even be able to have a chance against security, i believe that means its a faulty antag, they need buffs that aren't requiring them to ~~abuse bugs~~ metagame in order to stand on their own two feet. This is beyond the scope of this PR, i only hope that someone will pick up coscult buffs to make them into an actual antag.

As for people saying that this shouldn't be the case - this was a voted suggestion, MAJORITY of the playerbase wants this implemented, MOST people don't find it fun ~~to abuse glitches and~~ to incentivise an LRP behavior this way.

EDIT after confirmation with the author.
Description was corrected, as it was pointed out, this is an intended behavior, i still will say that if something feels like a glitch on the first sight, something that very clearly shouldn't have been working the way it does, it is just a bad game design.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/bf3b3d1d-7bdf-46d5-8123-e9958b44bd2f

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Fasuh
- fix: Fixed a bug that allowed cultists to be injected with a mindshield.
