### PR TITLE
Reduce rate of the Nightshift event

### DIFF
--- a/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/passiveevent.yml
@@ -156,7 +156,7 @@
   - type: StationEvent
     occursDuringRoundEnd: false
     globalAnnouncement: false
-    weight: 50
+    weight: 20
     startAnnouncement: station-event-nightshift-start-announcement
     startAudio:
       path: /Audio/Announcements/attention.ogg


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reduces the weight of the nightshift event from 50 to 20

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The chances of Nightshift event are crazy high, this results in the event going off almost every shift without fail. The event is not very impactful but can be a bit annoying to always have the station be dark. Especially since it goes off every shift. It had a higher chance than meteors to put in perspective how high the rate was.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Musiklie

- tweak: Reduced the weight of the nightshift event by 60%.
