### PR TITLE
welcome pop up clipping

### DIFF
--- a/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
+++ b/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
@@ -1,8 +1,8 @@
 <controls:FancyWindow xmlns="https://spacestation14.io"
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'content-warning-title'}"
-                      MinSize="520 750"
-                      MaxSize="520 750">
+                      MinSize="520 775"
+                      MaxSize="520 775">
     <BoxContainer Orientation="Vertical" Margin="20">
         <Label Name="TitleLabel1"
                StyleClasses="LabelBig"

--- a/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
+++ b/Content.Client/_Funkystation/ContentWarning/ContentWarningPopup.xaml
@@ -2,7 +2,7 @@
                       xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
                       Title="{Loc 'content-warning-title'}"
                       MinSize="520 775"
-                      MaxSize="520 775">
+                      MaxSize="520 775"><!-- Starlight: Changed size -->
     <BoxContainer Orientation="Vertical" Margin="20">
         <Label Name="TitleLabel1"
                StyleClasses="LabelBig"


### PR DESCRIPTION
## Short description
increases length of welcome popup so a button isnt cut off

## Why we need to add this
fix clipping. last second change to pr dark asked for meant i didnt see this 

## Media (Video/Screenshots)
NA

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed welcome popup buttons clipping.

