### PR TITLE
Security Paddy Mech Nerfs/changes

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -166,6 +166,8 @@
   #- type: AmmoCounter #Starlight - Mechs can't see this anyway
   # region starlight
   - type: Tag
+    tags:
+    - NonLethalMech
   # end region
 
 - type: entity
@@ -184,6 +186,9 @@
     selectedMode: FullAuto
     availableModes:
       - FullAuto
+  - type: Tag
+    tags:
+    - NonLethalMech
 # 🌟Starlight-end🌟
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
@@ -456,6 +461,8 @@
   #- type: AmmoCounter #Starlight - Mechs can't see this anyway
   # region starlight
   - type: Tag
+    tags:
+    - NonLethalMech
   # end region
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/combat.yml
@@ -186,9 +186,7 @@
     selectedMode: FullAuto
     availableModes:
       - FullAuto
-  - type: Tag
-    tags:
-    - NonLethalMech
+
 # 🌟Starlight-end🌟
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
@@ -196,6 +194,11 @@
     proto: TaserBolt
     fireCost: 40
   - type: Appearance
+ # Starlight start
+  - type: Tag
+    tags:
+    - NonLethalMech
+ # Starlight end
   #- type: AmmoCounter #Starlight - Mechs can't see this anyway
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/equipment.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/equipment.yml
@@ -47,6 +47,9 @@
     startSound:
       path: /Audio/Mecha/sound_mecha_hydraulic.ogg
   - type: SurgeryTool
+  - type: Tag
+    tags:
+    - NonLethalMech
 
 - type: entity
   id: MechEquipmentCamera

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -225,7 +225,6 @@
       startingEquipment:
         - WeaponMechCombatDisabler
         - WeaponMechCombatFlashbangLauncher
-        - MechEquipmentSecGrabber
 
 # Clarke
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -7,6 +7,7 @@
     equipmentWhitelist:
       tags:
       - CombatMech
+      - NonLethalMech
 
 - type: entity
   id: IndustrialMech
@@ -172,7 +173,7 @@
       equipmentWhitelist:
         tags:
           - IndustrialMech
-          - CombatMech
+          - NonLethalMech
       baseState: base
       openState: base-open
       brokenState: base-broken
@@ -190,10 +191,10 @@
       bluntStaminaDamageFactor: 1.5
       damage:
         types:
-          Blunt: 30 #Decent for a loader, but without the high structural damage of a combat mech. #
+          Blunt: 18 # Lowered from 30 to 18 to emphasize it to be nonlethal.
     - type: MovementSpeedModifier
       baseWalkSpeed: 2
-      baseSprintSpeed: 4
+      baseSprintSpeed: 3.6 # Lowered from 4 to 3.6 because its a biggin.
     - type: PointLight
       mask: /Textures/Effects/LightMasks/cone.png
       autoRot: true
@@ -224,6 +225,7 @@
       startingEquipment:
         - WeaponMechCombatDisabler
         - WeaponMechCombatFlashbangLauncher
+        - MechEquipmentSecGrabber
 
 # Clarke
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -191,7 +191,7 @@
       bluntStaminaDamageFactor: 1.5
       damage:
         types:
-          Blunt: 18 # Lowered from 30 to 18 to emphasize it to be nonlethal.
+          Blunt: 20 # Lowered from 30 to 20 to emphasize it to be nonlethal and put it onpar with a truncheon.
     - type: MovementSpeedModifier
       baseWalkSpeed: 2
       baseSprintSpeed: 4

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -188,7 +188,7 @@
     - type: MeleeWeapon
       hidden: true
       attackRate: 1
-      bluntStaminaDamageFactor: 1.5
+      bluntStaminaDamageFactor: 2 # Raised from 1.5 to give it more nonlethal capacity.
       damage:
         types:
           Blunt: 20 # Lowered from 30 to 20 to emphasize it to be nonlethal and put it onpar with a truncheon.

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -194,7 +194,7 @@
           Blunt: 18 # Lowered from 30 to 18 to emphasize it to be nonlethal.
     - type: MovementSpeedModifier
       baseWalkSpeed: 2
-      baseSprintSpeed: 3.6 # Lowered from 4 to 3.6 because its a biggin.
+      baseSprintSpeed: 4
     - type: PointLight
       mask: /Textures/Effects/LightMasks/cone.png
       autoRot: true

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -442,9 +442,6 @@
   id: PaddyUpgradeKit
 
 - type: Tag
-  id: NonLethalMech # Used to allow nonlethal mech equipment on a mech.
-
-- type: Tag
   id: PowerCageOmega
 
 - type: Tag
@@ -531,6 +528,9 @@
 
 - type: Tag
   id: Nexus
+
+- type: Tag
+  id: NonLethalMech # Used to allow nonlethal mech equipment on a mech.
 
 - type: Tag
   id: NotLabelable

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -442,6 +442,9 @@
   id: PaddyUpgradeKit
 
 - type: Tag
+  id: NonLethalMech # Used to allow nonlethal mech equipment on a mech.
+
+- type: Tag
   id: PowerCageOmega
 
 - type: Tag


### PR DESCRIPTION
## Short description
In this PR i plan to make the paddy go back to only being able to use nonlethal mech weaponry, along with nerfing its damage. Along with that, giving the paddy the little personnel grabber because the personnel grabber was just in the code not being used?

This PR can be closed if https://github.com/ss14Starlight/space-station-14/pull/5485 goes through, as security wouldnt have a roundstart mech anyway.

## Why we need to add this
The paddy is made to be a nonlethal mech for security to use to help with crowd control and riots. It being able to 4 hit crit people with 30 blunt along with being able to chain people to death with a sword is not nonlethal. https://discord.com/channels/1272545509562777621/1533034434725548074

## Media (Video/Screenshots)
There is pictures and videos in https://discord.com/channels/1272545509562777621/1533034434725548074

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Changed the paddy mech to only be able to accept nonlethal mech armaments.
- tweak: Changed the paddy mech to do less blunt damage with its fist.
- tweak: Changed paddies melee to do more stamina damage, around same as a truncheon.