### PR TITLE
Removing pirate access from cc/borgs

### DIFF
--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -46,7 +46,6 @@
   - Mining
   - SalvageLead
   - Mail
-  - Pirate # Adding another access? Make sure to also assign it to CyborgAllAccess.
   - Debrief
   - Shuttle # Starlight end
 

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -40,7 +40,7 @@
   - IAA
   - Brigmedic
   - BlueShield
-  - Robotics
+  - Robotics # Adding another access? Make sure to also assign it to CyborgAllAccess.
   - Surgery
   - Paramedic
   - Mining

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -35,7 +35,6 @@
     - Mining
     - SalvageLead
     - Mail
-    - Pirate
     - Shuttle
 
 - type: accessLevel


### PR DESCRIPTION
## Short description
Removing pirate access from cc, borgs, and others who use the "allaccess" category

## Why we need to add this
Makes no sense for them to have access to pirate stuff, and also can mess up admemes/events regarding it

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- remove: Removed pirate access from borgs and CC personnel, no longer will CC have ties to pirate organizations.
