### PR TITLE
Very minor nitpick comment fix

### DIFF
--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -185,7 +185,7 @@
             min: 25
         - id: NukeopsLate
           weight: 9
-          prob: 0.40 # Have a 40% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
+          prob: 0.40 # Have a 60% chance to fail to add the gamemode, even if it wins the roll. Mostly a failsafe so the actual midrounds can trigger, but also to stop them from always rolling even if cost rolls high. We don't want things to be predictable, no?
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition


### PR DESCRIPTION
## Short description
0.4 chance to roll is a 60% chance to fail.

## Why we need to add this
It's technically wrong.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Nothing player facing down here.
