### PR TITLE
Restricting hos to not have the blind trait

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -20,6 +20,7 @@
       traits:
         - Iterator
         - Muted
+        - Blindness
       inverted: true
   weight: 10
   startingGear: HoSGear


### PR DESCRIPTION
## Short description
Disallows the head of security to be blind

## Why we need to add this
There is an explicit ban of it on HoS specifically via §5 of their SOP. Allowing the head of security to be blind would basically be asking for people to be breaking the rules.

## Media (Video/Screenshots)
<img width="749" height="40" alt="image" src="https://github.com/user-attachments/assets/2a8f93b9-4be2-4e6d-add1-515d6ef96837" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: The head of security cannot be blind anymore.
