### PR TITLE
Xenoborgs and EventLight

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -26,36 +26,42 @@
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: SpaceCash1000
       conditions:
       - !type:GamemodeCondition
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: SpaceCash1000
       conditions:
       - !type:GamemodeCondition
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: SpaceCash1000
       conditions:
       - !type:GamemodeCondition
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: SpaceCash1000
       conditions:
       - !type:GamemodeCondition
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: SpaceCash1000
       conditions:
       - !type:GamemodeCondition
         presets:
         - Greenshift
-        - Sandbox #Starlight end
+        - Sandbox
+        - EventLight #Starlight end
 
 - type: entity
   id: LockerQuarterMasterFilled
@@ -100,20 +106,19 @@
       conditions:
       - !type:PlayerCountCondition
         max: 15
-    - id: PrintedDocumentGreenshiftAlert #SL
-      conditions: #SL
-      - !type:GamemodeCondition #SL
-        presets: #SL
-        - Greenshift #SL
-        - Sandbox #SL
-    #region Starlight
+    - id: PrintedDocumentGreenshiftAlert #Starlight start
+      conditions:
+      - !type:GamemodeCondition
+        presets:
+        - Greenshift
+        - Sandbox
+        - EventLight
     # - id: PaperEndGreenshift
     #   conditions:
     #   - !type:GamemodeCondition
     #     presets:
     #     - Greenshift
-    #     - Sandbox
-    #endregion Starlight
+    #     - Sandbox # Starlight end
 
 
 # No laser table + Laser table
@@ -216,6 +221,7 @@
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: FloraTreeChristmas02Flatpack
       conditions:
         - !type:HolidayActiveCondition
@@ -261,12 +267,13 @@
     - id: RubberStampCE
     - id: MetalFoamGrenade
     - id: PlushieMatthew #starlight
-    - id: PrintedDocumentGreenshiftAlert #SL
-      conditions: #SL
-      - !type:GamemodeCondition #SL
-        presets: #SL
-        - Greenshift #SL
-        - Sandbox #SL
+    - id: PrintedDocumentGreenshiftAlert # Starlight start
+      conditions:
+      - !type:GamemodeCondition
+        presets:
+        - Greenshift
+        - Sandbox
+        - EventLight # Starlight end
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable
@@ -340,6 +347,7 @@
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: JawsOfLifeMed #Starlight end
 
 # Hardsuit table, used for suit storage as well
@@ -403,6 +411,7 @@
         presets:
         - Greenshift
         - Sandbox
+        - EventLight
     - id: RDDiploma
     - id: XenobiologyConsoleCameraTagger
     #- id: PaperIonstormBorgs
@@ -483,7 +492,8 @@
       - !type:GamemodeCondition
         presets:
         - Greenshift
-        - Sandbox # Starlight end
+        - Sandbox
+        - EventLight # Starlight end
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -387,16 +387,19 @@
   - type: AntagMultipleRoleSpawner
     antagRoleToPrototypes:
       MothershipCore: [ MothershipCore ]
-      Xenoborg: [ XenoborgEngi, XenoborgHeavy, XenoborgScout, XenoborgStealth ]
+      Xenoborg: [ XenoborgEngi, XenoborgHeavy, XenoborgScout, XenoborgStealth, XenoborgEngi, XenoborgHeavy, XenoborgScout, XenoborgStealth ] # Starlight
     pickAndTake: true
   - type: AntagSelection
     selectionTime: PrePlayerSpawn
     antags:
     - !type:FixedAntagCount
       proto: MothershipCore
-    - !type:FixedAntagCount
+    - !type:LinearAntagCount # Starlight
       proto: Xenoborg
-      count: 4
+      playerRatio: 20 # Starlight start
+      range:
+        min: 4
+        max: 8 # Starlight end
   - type: DynamicRuleCost
     cost: 200
 

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -54,8 +54,8 @@
   parent: BaseXenoborgsRule # Starlight
   id: SubXenoborgs
   components:
-  - type: XenoborgsRule
-  - type: RuleGrids
+  #- type: XenoborgsRule  # Starlight
+  #- type: RuleGrids  # Starlight
   - type: GameRule
     minPlayers: 20 # Starlight
     cancelPresetOnTooFewPlayers: false

--- a/Resources/Prototypes/GameRules/subgamemodes.yml
+++ b/Resources/Prototypes/GameRules/subgamemodes.yml
@@ -51,7 +51,7 @@
         max: 4 # Starlight end
 
 - type: entity
-  parent: BaseGameRule
+  parent: BaseXenoborgsRule # Starlight
   id: SubXenoborgs
   components:
   - type: XenoborgsRule
@@ -59,5 +59,13 @@
   - type: GameRule
     minPlayers: 20 # Starlight
     cancelPresetOnTooFewPlayers: false
-  - type: DynamicRuleCost # Starlight
-    cost: 150 # Starlight
+  - type: AntagSelection  # Starlight start
+    selectionTime: PrePlayerSpawn
+    antags:
+    - !type:FixedAntagCount
+      proto: MothershipCore
+    - !type:FixedAntagCount
+      proto: Xenoborg
+      count: 4
+  - type: DynamicRuleCost
+    cost: 150 # Starlight end

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -50,7 +50,7 @@
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
         - id: TraitorLess # We'll use TraitorLess instead of Traitor, at least on Alpha, since they tend to lump in with a lot of other things.
-          weight: 31
+          weight: 35
           prob: 0.80 # Give traitor a chance to fail, since it's so common. In essence, this means we have a chance at getting Extended.
           conditions:
           - !type:HasBudgetCondition
@@ -104,7 +104,7 @@
           - !type:PlayerCountCondition
             min: 20
         - id: WizardDuel
-          weight: 9
+          weight: 5
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition
@@ -458,7 +458,7 @@
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
         - id: TraitorLess
-          weight: 40
+          weight: 41
           prob: 0.75 # Beta has an innate chance at Extended, so we give TraitorLes and Vampire a higher chance to fail to roll here. It roughly equals their Secret chance at Extended.
           conditions:
           - !type:HasBudgetCondition
@@ -466,7 +466,7 @@
           - !type:PlayerCountCondition
             min: 5
         - id: Vampire # We can count Vampires as being a major on Beta.
-          weight: 20
+          weight: 21
           prob: 0.75
           conditions:
           - !type:HasBudgetCondition
@@ -477,7 +477,7 @@
           - !type:PlayerCountCondition
             min: 25
         - id: Nukeops
-          weight: 6
+          weight: 7
           prob: 0.95 # Every main gamemode will have a very small chance to fail
           conditions:
           - !type:HasBudgetCondition
@@ -512,7 +512,7 @@
           - !type:PlayerCountCondition
             min: 20
         - id: WizardDuel
-          weight: 6
+          weight: 5
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition

--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -50,7 +50,7 @@
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
         - id: TraitorLess # We'll use TraitorLess instead of Traitor, at least on Alpha, since they tend to lump in with a lot of other things.
-          weight: 35
+          weight: 31
           prob: 0.80 # Give traitor a chance to fail, since it's so common. In essence, this means we have a chance at getting Extended.
           conditions:
           - !type:HasBudgetCondition
@@ -69,15 +69,18 @@
           - !type:PlayerCountCondition
             min: 25
         - id: Nukeops
-          weight: 10
+          weight: 9
           prob: 0.95 # Every main gamemode will have a very small chance to fail
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - NukeopsLate # Just... don't roll double Nukies.
           - !type:PlayerCountCondition
             min: 20
         - id: Revolutionary
-          weight: 10
+          weight: 9
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition
@@ -85,7 +88,7 @@
           - !type:PlayerCountCondition
             min: 15
         - id: CosmicCult
-          weight: 10
+          weight: 9
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition
@@ -93,7 +96,7 @@
           - !type:PlayerCountCondition
             min: 20
         - id: Zombie
-          weight: 10
+          weight: 9
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition
@@ -101,7 +104,7 @@
           - !type:PlayerCountCondition
             min: 20
         - id: WizardDuel
-          weight: 10
+          weight: 9
           prob: 0.95
           conditions:
           - !type:HasBudgetCondition
@@ -111,6 +114,17 @@
             - Zombie # Wizards don't lose their abilities in Zombie games, so they can't be allowed together
           - !type:PlayerCountCondition
             min: 35
+        - id: Xenoborgs
+          weight: 9
+          prob: 0.95
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - SubXenoborgs  # Two motherships would be funny, but no.
+          - !type:PlayerCountCondition
+            min: 30
       # Minor Rules
       - !type:GroupSelector
         conditions:
@@ -221,6 +235,17 @@
             - Zombie # Wizards don't lose their abilities in Zombie games, so they can't be allowed together
           - !type:PlayerCountCondition
             min: 35
+        - id: SubXenoborgs
+          weight: 4
+          prob: 0.40
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - Xenoborgs  # Two motherships would be funny, but no.
+          - !type:PlayerCountCondition
+            min: 20
         - id: ThiefLess
           weight: 8
           prob: 0.50
@@ -433,7 +458,7 @@
           max: 5 # 5 seconds, really just here to ensure it rolls roundstart and then doesn't roll again
         children:
         - id: TraitorLess
-          weight: 43
+          weight: 40
           prob: 0.75 # Beta has an innate chance at Extended, so we give TraitorLes and Vampire a higher chance to fail to roll here. It roughly equals their Secret chance at Extended.
           conditions:
           - !type:HasBudgetCondition
@@ -441,7 +466,7 @@
           - !type:PlayerCountCondition
             min: 5
         - id: Vampire # We can count Vampires as being a major on Beta.
-          weight: 23
+          weight: 20
           prob: 0.75
           conditions:
           - !type:HasBudgetCondition
@@ -452,11 +477,14 @@
           - !type:PlayerCountCondition
             min: 25
         - id: Nukeops
-          weight: 7
+          weight: 6
           prob: 0.95 # Every main gamemode will have a very small chance to fail
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - NukeopsLate # Just... don't roll double Nukies.
           - !type:PlayerCountCondition
             min: 20
         - id: Revolutionary
@@ -494,6 +522,17 @@
             - Zombie # Wizards don't lose their abilities in Zombie games, so they can't be allowed together
           - !type:PlayerCountCondition
             min: 35
+        - id: SubXenoborgs
+          weight: 7
+          prob: 0.95
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - Xenoborgs # Don't double Xenoborgs
+          - !type:PlayerCountCondition
+            min: 20
       # Minor Rules, Beta can keep the same as Alpha since these aren't split normally anyways
       - !type:GroupSelector
         conditions:
@@ -604,6 +643,17 @@
             - Zombie # Wizards don't lose their abilities in Zombie games, so they can't be allowed together
           - !type:PlayerCountCondition
             min: 35
+        - id: SubXenoborgs
+          weight: 6
+          prob: 0.40
+          conditions:
+          - !type:HasBudgetCondition
+          - !type:MaxRuleOccurenceCondition
+          - !type:MutuallyExclusiveRuleCondition
+            rules:
+            - Xenoborgs # Two motherships would be funny, but no.
+          - !type:PlayerCountCondition
+            min: 20
         - id: ThiefLess
           weight: 8
           prob: 0.50

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -198,8 +198,8 @@
       prob: 0.20
     - id: SLChangelingLess # I have managed to make changelings lose their abilities when they turn into zombies, so the concern with them is gone.
       prob: 0.20
-    #- id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
-    #  prob: 0.05
+    - id: SubXenoborgs # I think there's interesting roleplay opportunity if Xenoborgs spawn. You could willingly choose to get borged to prevent infection. I want to see how this plays out.
+      prob: 0.05
     #- id: SubBrighteye
     #  prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: SiliconLiberation # I mean technically there's nothing inherently wrong with them showing up.
@@ -219,8 +219,8 @@
       prob: 0.15
     - id: SubWizard
       prob: 0.05
-    #- id: SubXenoborgs
-    #  prob: 0.05
+    - id: SubXenoborgs
+      prob: 0.05
     # No SELF Agents in Nukie games because of the FREEmag = free guns!!!
 
 - type: entity

--- a/Resources/Prototypes/_Starlight/game_presets.yml
+++ b/Resources/Prototypes/_Starlight/game_presets.yml
@@ -8,6 +8,7 @@
   name: eventlight-title
   description: eventlight-description
   minPlayers: 5
+  voteCooldown: 40
   showInVote: false
   rules:
     - SpaceTrafficControlEventScheduler
@@ -136,13 +137,14 @@
   - allexceptroundenders
   name: all-at-once-except-zombieteors-title
   minPlayers: 60
+  voteCooldown: 40
   description: all-at-once-except-zombieteors-description
   showInVote: false
   rules:
     - Nukeops
     - Traitor
     - Revolutionary
-    - WizardDuel
+    - SubWizard
     #- Xenoborgs
     - RampingStationEventScheduler
     - SLChangeling

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -3,20 +3,21 @@
   id: Secret
   weights:
     Nukeops: 0.088 # SL
-    Traitor: 0.24 # SL
+    Traitor: 0.21 # SL
     Zombie: 0.078 # SL
     Zombieteors: 0.01 # SL
     Survival: 0.078 # SL
     KesslerSyndrome: 0.01 # SL
     Revolutionary: 0.088 # SL
     CosmicCult: 0.088 # SL
-    Vampire: 0.07 # SL
-    WizardDuel: 0.07 # SL + Moff Station
-    Traitorling: 0.07 #SL
-    ShitStation: 0.07 #SL
-    #Xenoborgs: 0.05 #SL
+    Vampire: 0.06 # SL
+    WizardDuel: 0.06 # SL + Moff Station
+    Traitorling: 0.06 #SL
+    ShitStation: 0.06 #SL
+    Xenoborgs: 0.06 #SL
     Vamptraitorling: 0.03 #SL
     AlmostAllAtOnce: 0.01 #SL
+    EventLight: 0.01 # SL, same as AAAO. Scales must be balanced.
     #TerrorSpiders: 0.05 # SL: Should be changed if too high
     Dynamic: 0.50 # SL, 1/3rd of rounds
 
@@ -25,7 +26,7 @@
   id: SecretLP
   weights:
     Nukeops: 0.07
-    Traitor: 0.27
+    Traitor: 0.25
     Zombie: 0.07
     Vampire: 0.09
     Zombieteors: 0.01
@@ -33,11 +34,11 @@
     KesslerSyndrome: 0.01
     Revolutionary: 0.06
     CosmicCult: 0.06
-    Extended: 0.17
+    Extended: 0.15
     WizardDuel: 0.04 # SL + Moff Station
-    Traitorling: 0.09
-    #SubXenoborgs: 0.07
-    ShitStation: 0.08 #SL, ShitStation for Beta. Try it out, see if they find it fun. If they don't, easy to remove. I've heard a couple people say they wanted it, at least.
+    Traitorling: 0.08
+    SubXenoborgs: 0.06
+    ShitStation: 0.07 #SL, ShitStation for Beta. Try it out, see if they find it fun. If they don't, easy to remove. I've heard a couple people say they wanted it, at least.
     Vamptraitorling: 0.04 # SL, I was told to add it, so...
     #TerrorSpiders: 0.07 # SL: Should be changed if too high
     DynamicLP: 0.30 # SL, 1/5th of rounds

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -10,7 +10,7 @@
     NinjaBackup: 0.75
     Rod: 0.75
     Wizard: 0.1
-    #Xenoborgs: 0.05
+    Xenoborgs: 0.05
     Eeeplet: 0.5
     Colossus: 0.2
     # Starlight End


### PR DESCRIPTION
## Short description
Adds a 0.67% chance of EventLight to Alpha.

More importantly, re-enables Xenoborgs, with a couple tweaks. They'll no longer roll as a subgamemode outside of Nukeops and Zombie, where I think they have some interesting opportunities to get involved without overpowering the entire gamemode.

## Why we need to add this
According to Red, the Xenoborg lag problem's been fixed, so their main blocker to being re-enabled is cleared now.

As for EventLight, it's the same chance as AAAO, so the opposite extreme, to balance each other out.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- add: Return of Xenoborgs.
- add: Added a 0.67% chance of EventLight to Alpha, to parallel the chance of AAAO.
- add: The Greenshift paper in heads' lockers will now also be given on EventLight.
- remove: Xenoborgs will no longer show up as subgamemodes outside of Nukeops, Zombies, Dynamic, and Ninja calls.
- tweak: Xenoborgs in their main Alpha gamemode now scale 1:20, roughly up 20%, coinciding with our other scaling increases.
- tweak: Wizard Duel in AAAO has been replaced with SubWizard.
- tweak: AAAO and EventLight now have cooldowns.

