### PR TITLE
CE now gets an Engi Techfab Flatpack

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -261,6 +261,7 @@
     - id: RubberStampCE
     - id: MetalFoamGrenade
     - id: PlushieMatthew #starlight
+    - id: EngineeringTechFabFlatpack # Starlight
     - id: PrintedDocumentGreenshiftAlert #SL
       conditions: #SL
       - !type:GamemodeCondition #SL


### PR DESCRIPTION
## Short description
Somehow I missed this.

## Why we need to add this
To be fair, CE can probably build their own, but they should still get the flatpack since the fabs aren't mapped yet.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: CE now gets an Engi Techfab Flatpack in their locker.

