### PR TITLE
Minor phenyl tweak

### DIFF
--- a/Resources/Prototypes/_Mono/Reagents/narcotics.yml
+++ b/Resources/Prototypes/_Mono/Reagents/narcotics.yml
@@ -53,10 +53,10 @@
         key: Stutter
         component: StutteringAccent
       - !type:Jitter
-      - !type:GenericStatusEffect
-        key: ForcedSleep
-        time: 5
-        type: Add
+      #- !type:GenericStatusEffect # Starlight start
+      #  key: ForcedSleep # It doesn't work due to using the wrong status effect, but I think fixing it would just make it noct 2, so I'd rather just not have the effect.
+      #  time: 5
+      #  type: Add # Starlight end
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
         type: Add


### PR DESCRIPTION
## Short description
Removes the (non-functional) forced sleep from Phenylpiperidine.

## Why we need to add this
It doesn't actually work due to using the wrong type, but I think fixing it would just make it old Noct 2, so I'd rather just remove the effect.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Phenylpiperidine no longer says it applies forced sleep when it actually doesn't.

