### PR TITLE
Allow Avali, Reptillians, and Moths to eat Birthday Cake

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -877,7 +877,7 @@
   - type: Tag
     tags:
     - Cake
-    - Birthday
+    - Birthday # Starlight
   - type: Item
     heldPrefix: birthday
 
@@ -892,7 +892,7 @@
   - type: Tag
     tags:
     - Cake
-    - Birthday
+    - Birthday # Starlight
     - Slice
   - type: Item
     heldPrefix: birthday-slice

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -874,6 +874,10 @@
     state: birthday
   - type: SliceableFood
     slice: FoodCakeBirthdaySlice
+  - type: Tag
+    tags:
+    - Cake
+    - Birthday
   - type: Item
     heldPrefix: birthday
 
@@ -885,6 +889,10 @@
   components:
   - type: Sprite
     state: birthday-slice
+  - type: Tag
+    tags:
+    - Cake
+    - Birthday
   - type: Item
     heldPrefix: birthday-slice
 # Tastes like sweetness, cake, christmas.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -889,11 +889,13 @@
   components:
   - type: Sprite
     state: birthday-slice
+  # Starlight-start
   - type: Tag
     tags:
     - Cake
-    - Birthday # Starlight
+    - Birthday
     - Slice
+  # Starlight-end
   - type: Item
     heldPrefix: birthday-slice
 # Tastes like sweetness, cake, christmas.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -874,10 +874,12 @@
     state: birthday
   - type: SliceableFood
     slice: FoodCakeBirthdaySlice
+  # Starlight-start 
   - type: Tag
     tags:
     - Cake
-    - Birthday # Starlight
+    - Birthday
+  # Starlight-end
   - type: Item
     heldPrefix: birthday
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -893,6 +893,7 @@
     tags:
     - Cake
     - Birthday
+    - Slice
   - type: Item
     heldPrefix: birthday-slice
 # Tastes like sweetness, cake, christmas.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -874,7 +874,7 @@
     state: birthday
   - type: SliceableFood
     slice: FoodCakeBirthdaySlice
-  # Starlight-start 
+  # Starlight-start
   - type: Tag
     tags:
     - Cake

--- a/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/avali.yml
@@ -14,6 +14,7 @@
       - Paper
       - AvianFood
       - IceCream
+      - Birthday
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
@@ -24,6 +24,7 @@
       - Paper
       - Pill
       - IceCream
+      - Birthday
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
@@ -14,6 +14,7 @@
       - Crayon
       - Paper
       - IceCream
+      - Birthday
   - type: SolutionContainerManager
     solutions:
       stomach:

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -33,6 +33,9 @@
   id: BibleThwackRemovable
 
 - type: Tag
+  id: Birthday
+
+- type: Tag
   id: BladePlasteel
 
 - type: Tag


### PR DESCRIPTION
## Short description
Adds a new tag for Birthday related food items, and allows avali, reptillians, and moths to eat them.

## Why we need to add this
Doesn't it suck when your friends make you a birthday cake and you can't eat it because biology? I think it does, and NanoTrasen thinks so too! 

This PR makes the NanoTrasen sanctioned Birthday Cake edible by all NanoTrasen personnel. Additionally, to future-proof this in the case of us adding more birthday foods, like cupcakes or something, birthday-related food items can now be tagged with the "Birthday" tag to indicate that they should be made to be edible by our friends with dietary restrictions.

Generally, this is being done for the same reasons as the Ice Cream change. Everyone should be able to enjoy their birthday cake.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Orhu
- tweak: Birthday Cake can now be eaten by all species.
