### PR TITLE
Give Cargo Techs Shuttle Access by Default

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/cargo_technician.yml
@@ -10,11 +10,11 @@
   access:
   - Cargo
   - Maintenance
+  - Shuttle # Starlight
   extendedAccess:
   - Salvage
   - Mining # Starlight
   - Mail # Starlight
-  - Shuttle # Starlight
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Cargo/mail_technician.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Cargo/mail_technician.yml
@@ -14,6 +14,7 @@
   extendedAccess:
   - Salvage
   - Mining
+  - Shuttle
   special:
   - !type:GiveItemOnHolidaySpecial
     holiday: BoxingDay


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Gave cargo techs shuttle access by default, and gave mail techs shuttle access on skeleton crew.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Currently, cargo techs only get shuttle access on skeleton crew, which doesn't make sense. This allows them to use the shuttle—AKA do their job—without having to get someone else's help. 

I'm giving mail techs shuttle access on skeleton crew because they'll likely end up doing the work of a cargo tech.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CommanderAlex365
- tweak: Gave Mail Technicians shuttle access on skeleton crew.
- fix: Gave Cargo Technicians shuttle access by default.
