### PR TITLE
Gas tank tweaks & fixes

### DIFF
--- a/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
+++ b/Content.Server/Mech/Equipment/Components/MechGrabberComponent.cs
@@ -65,6 +65,7 @@ public sealed partial class MechGrabberComponent : Component
             "Anomaly",
             "Mech",
         ],
+        Tags = ["NoMechGrab"], // Starlight
     };
 
     public EntityUid? AudioStream;

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -143,16 +143,22 @@
       enable: true
     - type: Fixtures
       fixtures:
-        fix1:
+        fix1: # Collidable circle following the sprite
           shape:
             !type:PhysShapeCircle
             radius: 0.27
-            position: 0,0.25
-          density: 500
+          density: 600
           mask:
             - MachineMask
           layer:
             - MachineLayer
+        fix2: # Non-collidable rectangle that makes the entire bottom half clickable.
+          shape:
+            !type:PhysShapeAabb
+            bounds: "-0.5,-0.5,0.5,0.5" # Only the bottom tile
+          hard: true
+          mask: [ ]
+          layer: [ Opaque ]
     - type: AtmosPipeLayers
       spriteLayersRsiPaths:
         enum.PipeVisualLayers.Pipe:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Piping/Atmospherics/pipes.yml
@@ -8,6 +8,10 @@
   placement:
     mode: AlignAtmosPipeLayers
   components:
+  - type: AtmosUnsafeUnanchor
+    enabled: false # Retains gas when unanchored.
+  - type: Item
+    allowDirectHandPickup: false # No pickup allowed because it can retain gas.
   - type: Sprite
     sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe.rsi
     drawdepth: ThinPipe
@@ -17,6 +21,19 @@
       - sprite: _Starlight/Structures/Piping/Atmospherics/subfloortank.rsi
         state: subFloorTank
         map: [ "enum.SubfloorLayers.FirstLayer" ]
+  - type: Physics
+    canCollide: false
+  - type: Fixtures
+    fixtures:
+      fix1: # Fixture, non-colliding, just for setting mass.
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.27 # Matching tall gas tank for comparison convenience.
+          position: 0,0
+        density: 700
+        hard: false
+        mask: [ ]
+        layer: [ ]
   - type: AtmosPipeLayers
     spriteLayersRsiPaths:
       enum.PipeVisualLayers.Pipe:
@@ -40,6 +57,7 @@
     tags:
     - Pipe
     - Unstackable
+    - NoMechGrab
   - type: NodeContainer
     nodes:
       pipe:
@@ -118,9 +136,11 @@
   placement:
     mode: AlignAtmosPipeLayers
   components:
+    - type: AtmosUnsafeUnanchor
+      enabled: false # Retains gas when unanchored.
     - type: Sprite
       sprite: _Carpmosia/Structures/Piping/Atmospherics/pipe.rsi
-      drawdepth: Mobs
+      drawdepth: Overdoors
       offset: 0,0.55
       noRot: true
       layers:
@@ -147,7 +167,7 @@
           shape:
             !type:PhysShapeCircle
             radius: 0.27
-          density: 600
+          density: 1700 # Quite heavy; it's not meant to be a superior canister. Heavy enough that you won't want to bring it outside your department.
           mask:
             - MachineMask
           layer:
@@ -188,6 +208,7 @@
       tags:
         - Pipe
         - Unstackable
+        - NoMechGrab
     - type: NodeContainer
       nodes:
         pipe:

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -530,6 +530,9 @@
   id: Nexus
 
 - type: Tag
+  id: NoMechGrab # Disallows MechGrabberSystem from picking something up.
+
+- type: Tag
   id: NonLethalMech # Used to allow nonlethal mech equipment on a mech.
 
 - type: Tag


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

- Subfloor tank
  - Now retains gas when unanchored
  - Can no longer be picked up by hand
  - Can no longer be picked up by mechs
  - Has significant mass to deter dragging it around as canister alternative
- Tall gas tank
  - Now retains gas when unanchored
  - Can no longer be picked up by mechs
  - Entire bottom half is now clickable instead of only a small area
  - Clickable area no longer moves when rotated
  - Has significant mass to deter dragging it around as canister alternative

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

- Tall gas tank fixture fixes are bugfixes
- The other stuff is to make them better match expected behavior (I got feedback on this) and to improve their QoL while retaining balance (allowing gas retention, but with weight increase and no pickup possible).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

### Subfloor tank gas retention & mass

https://github.com/user-attachments/assets/e04b5a8c-3720-4f26-8f7f-a9c5719382aa

### Tall tank: Collision, Visual targeting

https://github.com/user-attachments/assets/685ba83a-bbdc-4254-bad6-a5a2c1e756bd

### Tall tank: Unanchoring, Drag weight

https://github.com/user-attachments/assets/6681cea9-5ad4-4a1d-98e6-d98cb87c8ac6

### Tall tank: No mech pickup

https://github.com/user-attachments/assets/e006fd86-549a-40a2-8d94-2d5e31ef83b5

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: redmushie
- add: Subfloor- and tall gas tanks now retain gas when unanchored.
- add: Subfloor- and tall gas tanks are now quite heavy to drag around.
- tweak: Subfloor- and tall gas tanks can no longer be picked up by hand or by hydraulic clamp.
- fix: Tall gas tanks no longer have their clickable section move when oriented differently.
- fix: Tall gas tanks are now properly clickable on their lower half.
