### PR TITLE
Flakey test fixes

### DIFF
--- a/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
@@ -269,7 +269,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
     }
 
     /// <summary>
-    /// Testing this to see if this solves memory issues.
+    /// Returns the IDs of all loaded maps so maps created during a test can be identified and deleted afterward.
     /// </summary>
     private HashSet<MapId> MapIds() => SEntMan.AllComponents<MapComponent>().Select(x => x.Component.MapId).ToHashSet();
     #endregion

--- a/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
+++ b/Content.IntegrationTests/Tests/GameRules/AntagGhostRoleTest.cs
@@ -14,6 +14,7 @@ using Content.Shared.CCVar;
 using Content.Shared._Starlight.CCVar;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Map.Components; // Starlight
 using Robust.Shared.Maths;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -32,6 +33,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
 
     [SidedDependency(Side.Server)] private IRobustRandom _random = default!;
     [SidedDependency(Side.Server)] private GhostRoleSystem _ghostRole = default!;
+    [SidedDependency(Side.Server)] private SharedMapSystem _map = default!; // Starlight
 
     #region Starlight
     /// <summary>
@@ -94,6 +96,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
     {
         Server.CfgMan.SetCVar(StarlightCCVars.DisableLoadMapRule, false); // Starlight
         Server.CfgMan.SetCVar(CCVars.GameRoleTimers, false); // Starlight
+        var mapsBefore = MapIds(); // Starlight
         var rule = SProtoMan.Index<EntityPrototype>(ruleId);
         Assert.That(rule.TryGetComponent<AntagSelectionComponent>(out var antag, SEntMan.ComponentFactory), Is.True);
 
@@ -145,6 +148,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
         // End all rules
         STicker.ClearGameRules();
         Assert.That(STicker.GetAddedGameRules(), Is.Empty);
+        foreach (var map in MapIds().Except(mapsBefore)) _map.DeleteMap(map); // Starlight
         Server.CfgMan.SetCVar(StarlightCCVars.DisableLoadMapRule, true); // Starlight
         Server.CfgMan.SetCVar(CCVars.GameRoleTimers, true); // Starlight
     }
@@ -157,6 +161,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
     {
         Server.CfgMan.SetCVar(StarlightCCVars.DisableLoadMapRule, false); // Starlight
         Server.CfgMan.SetCVar(CCVars.GameRoleTimers, false); // Starlight
+        var mapsBefore = MapIds(); // Starlight
         foreach (var ruleId in AntagGameRules)
         {
             var rule = SProtoMan.Index<EntityPrototype>(ruleId);
@@ -187,6 +192,7 @@ public sealed partial class AntagGhostRoleTest : AntagTest
         // End all rules
         STicker.ClearGameRules();
         Assert.That(STicker.GetAddedGameRules(), Is.Empty);
+        foreach (var map in MapIds().Except(mapsBefore)) _map.DeleteMap(map); // Starlight
         Server.CfgMan.SetCVar(StarlightCCVars.DisableLoadMapRule, true); // Starlight
         Server.CfgMan.SetCVar(CCVars.GameRoleTimers, true); // Starlight
     }
@@ -261,5 +267,10 @@ public sealed partial class AntagGhostRoleTest : AntagTest
     {
         return spawner.Definition is { } definition && IgnoredAntagSpecifiers.Contains(definition.Id);
     }
+
+    /// <summary>
+    /// Testing this to see if this solves memory issues.
+    /// </summary>
+    private HashSet<MapId> MapIds() => SEntMan.AllComponents<MapComponent>().Select(x => x.Component.MapId).ToHashSet();
     #endregion
 }

--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -29,13 +29,6 @@ using Robust.Shared.Map.Events;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
-// Starlight-start
-using YamlDotNet.RepresentationModel;
-using Robust.Shared.Map.Events;
-using Robust.Packaging.AssetProcessing;
-using Content.Shared.Mobs;
-// Starlight-end
-
 namespace Content.IntegrationTests.Tests
 {
     [TestFixture]
@@ -110,20 +103,7 @@ namespace Content.IntegrationTests.Tests
             #endregion
         };
 
-        // starlight start
-        private static readonly ProtoId<EntityCategoryPrototype> ShouldMapCategory = "ShouldMapStation";
-
-        /// <summary>
-        /// list of map filenames that shouldn't be checked against necessary entities
-        /// </summary>
-        private static readonly string[] ShouldMapWhitelist =
-        {
-            "/Maps/_Starlight/Stations/StationBuilding.yml", // event map
-            "/Maps/_Starlight/Stations/Reach.yml",           // very small, can't fit everything
-            "/Maps/_Starlight/Stations/Cork.yml",            // very small, can't fit everything
-            "/Maps/_Starlight/Stations/Boxcars.yml",         // no longer in map rotation / admeme only
-        };
-        // starlight end
+        private static readonly ProtoId<EntityCategoryPrototype> ShouldMapCategory = "ShouldMapStation"; // Starlight
 
         /// <summary>
         /// Converts the above globs into regex so your eyes dont bleed trying to add filepaths.
@@ -288,6 +268,8 @@ namespace Content.IntegrationTests.Tests
             await server.WaitPost(() => mapSys.InitializeMap(id));
             Assert.That(loader.TrySaveMap(id, path));
             Assert.That(IsPreInit(path, loader, deps, ev.RenamedPrototypes, ev.DeletedPrototypes), Is.False);
+
+            await server.WaitPost(() => mapSys.DeleteMap(id)); // Starlight
         }
 
         private bool IsWhitelistedForMap(EntProtoId protoId, ResPath map)
@@ -517,9 +499,8 @@ namespace Content.IntegrationTests.Tests
 
                 TestContext.Out.WriteLine($"{sw.Elapsed.TotalMilliseconds} ms: Deleted map {mapProto}");
             });
+
         }
-
-
 
         private static int GetCountLateSpawn<T>(List<EntityUid> gridUids, IEntityManager entManager)
             where T : ISpawnPoint, IComponent

--- a/Content.IntegrationTests/Tests/_Starlight/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Round/CharacterSelectionTest.cs
@@ -113,11 +113,11 @@ public sealed class CharacterSelectionTest : GameTest
         public bool ExpectTraitor;
         public int? SetSeed;
 
-        public SelectionTestData WithCharacters(IEnumerable<TestCharacter> newCharacters)
+        public SelectionTestData WithCharacters(IEnumerable<TestCharacter> newCharacters, string variant)
         {
             return new SelectionTestData()
             {
-                Description = Description,
+                Description = $"{Description} [{variant}]",
                 HighPrioJob = HighPrioJob,
                 MediumPrioJobs = MediumPrioJobs,
                 LowPrioJobs = LowPrioJobs,
@@ -312,7 +312,7 @@ public sealed class CharacterSelectionTest : GameTest
             {
                 var reversedCharacters = testCase.Characters.ShallowClone();
                 reversedCharacters.Reverse();
-                yield return testCase.WithCharacters(reversedCharacters).ToTestCaseData();
+                yield return testCase.WithCharacters(reversedCharacters, "reversed").ToTestCaseData();
             }
 
             if (testCase.Characters.Count > 2)
@@ -323,7 +323,7 @@ public sealed class CharacterSelectionTest : GameTest
                     var movingCharacter = rotatedCharacters[0];
                     rotatedCharacters.RemoveAt(0);
                     rotatedCharacters.Add(movingCharacter);
-                    yield return testCase.WithCharacters(rotatedCharacters).ToTestCaseData();
+                    yield return testCase.WithCharacters(rotatedCharacters, $"rotated {i}").ToTestCaseData();
                 }
             }
         }

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenPrefab.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.DunGenPrefab.cs
@@ -76,6 +76,33 @@ public sealed partial class DungeonJob
         var packTransforms = new Matrix3x2[gen.RoomPacks.Count];
         var packRotations = new Angle[gen.RoomPacks.Count];
 
+        // Starlight Start
+        void AddFillablePacks(List<DungeonRoomPackPrototype> candidatePacks)
+        {
+            foreach (var candidate in candidatePacks)
+            {
+                var fillable = true;
+
+                foreach (var candidateRoom in candidate.Rooms)
+                {
+                    var roomDims = new Vector2i(candidateRoom.Width, candidateRoom.Height);
+
+                    if (roomProtos.ContainsKey(roomDims) ||
+                        roomProtos.ContainsKey(new Vector2i(roomDims.Y, roomDims.X)))
+                    {
+                        continue;
+                    }
+
+                    fillable = false;
+                    break;
+                }
+
+                if (fillable)
+                    availablePacks.Add(candidate);
+            }
+        }
+        // Starlight End
+
         // Actually pick the room packs and rooms
         for (var i = 0; i < gen.RoomPacks.Count; i++)
         {
@@ -85,7 +112,7 @@ public sealed partial class DungeonJob
             // Try every pack rotation
             if (roomPackProtos.TryGetValue(dimensions, out var roomPacks))
             {
-                availablePacks.AddRange(roomPacks);
+                AddFillablePacks(roomPacks); // Starlight
             }
 
             // Try rotated versions if there are any.
@@ -95,7 +122,7 @@ public sealed partial class DungeonJob
 
                 if (roomPackProtos.TryGetValue(rotatedDimensions, out roomPacks))
                 {
-                    availablePacks.AddRange(roomPacks);
+                    AddFillablePacks(roomPacks); // Starlight
                 }
             }
 

--- a/Content.Shared/_Starlight/Medical/Body/Systems/SharedBodySystem.Parts.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Systems/SharedBodySystem.Parts.cs
@@ -198,6 +198,8 @@ public partial class SharedBodySystem
         if (!Resolve(bodyEnt, ref bodyEnt.Comp, logMissing: false))
             return;
 
+        if (TerminatingOrDeleted(bodyEnt.Owner)) return;
+
         if (!_timing.ApplyingState
             && partEnt.Comp.IsVital
             && !GetBodyChildrenOfType(bodyEnt, partEnt.Comp.PartType, bodyEnt.Comp).Any()


### PR DESCRIPTION
## Short description
Fixes a few tests

## Why we need to add this
Dungeons needed to be updated to allow for non-standard sizes without causing errors. SovietDungeonWeh has a 17x9 room and a 17x5 room that was causing errors.

AntagGhostRoles Never removed its maps, causing massive memory usage, same with PostMapInit.

CharacterSelectionTest.cs created tests with the same names.

Doing damage to a body while it's being deleted causes an error

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
