### PR TITLE
HoS SOP - Perma Over 30m

### DIFF
--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
@@ -61,6 +61,6 @@ The Head of Security should refrain from combat operations unless tactically nec
 The Head of Security is cleared to confine sentenced criminals in the Brig for up to 30 minutes.\n\n
 7.1\n
 The Head of Security is furthermore allowed to overrule the sentences of other members of Security as long as the sentence hasn't already been handed out to the detainee.
-7/2\n
+7.2\n
 Sentences that would exceed 30 minutes may be made permanent at the Head of Security's discretion, but should be reserved for extreme cases and repeat offenders.
 </Document>

--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/HeadOfSecurity.xml
@@ -61,4 +61,6 @@ The Head of Security should refrain from combat operations unless tactically nec
 The Head of Security is cleared to confine sentenced criminals in the Brig for up to 30 minutes.\n\n
 7.1\n
 The Head of Security is furthermore allowed to overrule the sentences of other members of Security as long as the sentence hasn't already been handed out to the detainee.
+7/2\n
+Sentences that would exceed 30 minutes may be made permanent at the Head of Security's discretion, but should be reserved for extreme cases and repeat offenders.
 </Document>


### PR DESCRIPTION
## Short description
Restores an OLD clause in SOP allowing HoS to sign off on a perma sentence if someone's sentence exceeds 30 minutes in extreme cases or cases of repeat offenders.

## Why we need to add this
This used to be policy when I started playing, but back then brig times were super low so it was '20 or more = perma'. The specifications for extreme or repeat offenders only should stop abuse. This is VERY needed for cases of Genpop shitters who just break shit and assault officers / other inmates non stop.

## Media (Video/Screenshots)
<img width="759" height="102" alt="image" src="https://github.com/user-attachments/assets/9015cfd5-2a14-4640-b135-bead8a604b0c" />


## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Restored a very old clause to HoS SOP. "Sentences that would exceed 30 minutes may be made permanent at the Head of Security's discretion, but should be reserved for extreme cases and repeat offenders." This is so HoS can handle brig shitters who non-stop break things and attack secoffs/other inmates.

