### PR TITLE
Finally add decal preview to spray painter

### DIFF
--- a/Content.Client/Crayon/CrayonSystem.cs
+++ b/Content.Client/Crayon/CrayonSystem.cs
@@ -80,11 +80,6 @@ public sealed partial class CrayonSystem : SharedCrayonSystem
 
             _label.SetMarkup(Robust.Shared.Localization.Loc.GetString("crayon-drawing-label",
                 ("color",_crayon.Comp.Color),
-                // Starlight-start
-                ("rotation",_crayon.Comp.Rotation),
-                ("previewEnabled",_crayon.Comp.PreviewEnabled),
-                ("previewVisible",_crayon.Comp.PreviewVisible),
-                // Starlight-end
                 ("state",_crayon.Comp.SelectedState),
                 ("charges", _charges.GetCurrentCharges(_crayon.Owner)),
                 ("capacity", _capacity)));

--- a/Content.Client/SprayPainter/SprayPainterSystem.cs
+++ b/Content.Client/SprayPainter/SprayPainterSystem.cs
@@ -1,14 +1,23 @@
 using System.Linq;
+using Content.Client._Starlight.SprayPainter;
+using Content.Client.Decals;
+using Content.Client.Hands.Systems;
 using Content.Client.Items;
 using Content.Client.Message;
 using Content.Client.Stylesheets;
+using Content.Shared._Starlight.SprayPainter;
 using Content.Shared.Decals;
+using Content.Shared.GameTicking;
+using Content.Shared.Hands;
+using Content.Shared.Interaction;
 using Content.Shared.SprayPainter;
 using Content.Shared.SprayPainter.Components;
 using Content.Shared.SprayPainter.Prototypes;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
 using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -21,6 +30,15 @@ namespace Content.Client.SprayPainter;
 public sealed partial class SprayPainterSystem : SharedSprayPainterSystem
 {
     [Dependency] private UserInterfaceSystem _ui = default!;
+    // Starlight begin
+    [Dependency] private IOverlayManager _overlay = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
+    [Dependency] private DecalPlacementSystem _placement = default!;
+    [Dependency] private IPrototypeManager _prototypeManager = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private HandsSystem _hands = default!;
+    // Starlight end
 
     public List<SprayPainterDecalEntry> Decals = [];
     public Dictionary<string, List<string>> PaintableGroupsByCategory = new();
@@ -33,6 +51,18 @@ public sealed partial class SprayPainterSystem : SharedSprayPainterSystem
         Subs.ItemStatus<SprayPainterComponent>(ent => new StatusControl(ent));
         SubscribeLocalEvent<SprayPainterComponent, AfterAutoHandleStateEvent>(OnStateUpdate);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
+
+        // Starlight begin
+        SubscribeLocalEvent<SprayPainterComponent, SprayPainterUpdateDecalEvent>(OnDecalUpdated);
+        SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnLocalPlayerAttached);
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+        SubscribeLocalEvent<SprayPainterComponent, HandDeselectedEvent>(OnHandDeselected);
+        SubscribeLocalEvent<SprayPainterComponent, HandSelectedEvent>(OnHandSelected);
+        SubscribeLocalEvent<SprayPainterComponent, GotEquippedHandEvent>(OnGotEquippedHand);
+        SubscribeLocalEvent<SprayPainterComponent, GotUnequippedHandEvent>(OnGotUnequippedHand);
+        SubscribeLocalEvent<SprayPainterComponent, ComponentShutdown>(OnComponentShutdown);
+        // Starlight end
 
         CachePrototypes();
     }
@@ -121,6 +151,59 @@ public sealed partial class SprayPainterSystem : SharedSprayPainterSystem
                 ("mode", Robust.Shared.Localization.Loc.GetString(modeLocString))));
         }
     }
+
+    #region Starlight
+
+    private void UpdateOverlay(SprayPainterComponent comp)
+    {
+        _overlay.RemoveOverlay<SprayPainterDecalGhostOverlay>();
+        if (!comp.ShowDecalPreview) return;
+        if (!_prototypeManager.HasIndex(comp.SelectedDecal)) return;
+        var decal = _prototypeManager.Index(comp.SelectedDecal);
+        var color = comp.SelectedDecalColor ?? Color.White;
+        if (comp.OpaqueGhost) color.A /= 2;
+        _overlay.AddOverlay(new SprayPainterDecalGhostOverlay(_placement, _transform, _sprite, _interaction, decal,
+            comp.SelectedDecalAngle, color, comp.SnapDecals));
+    }
+
+    private void OnDecalUpdated(Entity<SprayPainterComponent> ent, ref SprayPainterUpdateDecalEvent args) =>
+        UpdateOverlay(ent);
+
+    private void OnLocalPlayerAttached(LocalPlayerAttachedEvent args)
+    {
+        if (!TryComp<SprayPainterComponent>(_hands.GetActiveHandEntity(), out var comp)) return;
+        UpdateOverlay(comp);
+    }
+
+    private void OnLocalPlayerDetached(LocalPlayerDetachedEvent args) => RemoveOverlay();
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent args) => RemoveOverlay();
+
+    private void OnHandDeselected(Entity<SprayPainterComponent> ent, ref HandDeselectedEvent args) =>
+        RemoveOverlay();
+
+    private void OnHandSelected(Entity<SprayPainterComponent> ent, ref HandSelectedEvent args) =>
+        UpdateOverlay(ent);
+
+    private void OnGotEquippedHand(Entity<SprayPainterComponent> ent, ref GotEquippedHandEvent args)
+    {
+        if (_hands.GetActiveHandEntity() != ent) return;
+        UpdateOverlay(ent);
+    }
+
+    private void OnGotUnequippedHand(Entity<SprayPainterComponent> ent, ref GotUnequippedHandEvent args)
+    {
+        if (args.Unequipped != ent.Owner) return;
+        RemoveOverlay();
+    }
+
+    private void OnComponentShutdown(Entity<SprayPainterComponent> ent, ref ComponentShutdown args) =>
+        RemoveOverlay();
+
+    private void RemoveOverlay() => _overlay.RemoveOverlay<SprayPainterDecalGhostOverlay>();
+
+    #endregion
+
 }
 
 /// <summary>

--- a/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
+++ b/Content.Client/SprayPainter/UI/SprayPainterBoundUserInterface.cs
@@ -30,6 +30,7 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
             _window.OnDecalColorChanged += OnDecalColorChanged;
             _window.OnDecalAngleChanged += OnDecalAngleChanged;
             _window.OnDecalSnapChanged += OnDecalSnapChanged;
+            _window.OnPreviewToggleChanged += OnPreviewToggleChanged;
         }
 
         var sprayPainter = EntMan.System<SprayPainterSystem>();
@@ -56,6 +57,7 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
         _window.SetDecalAngle(sprayPainter.SelectedDecalAngle);
         _window.SetDecalColor(sprayPainter.SelectedDecalColor);
         _window.SetDecalSnap(sprayPainter.SnapDecals);
+        _window.SetPreviewToggle(sprayPainter.ShowDecalPreview); // Starlight
     }
 
     private void OnDecalSnapChanged(bool snap)
@@ -63,7 +65,7 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
         SendPredictedMessage(new SprayPainterSetDecalSnapMessage(snap));
     }
 
-    private void OnDecalAngleChanged(int angle)
+    private void OnDecalAngleChanged(float angle) // Starlight edit
     {
         SendPredictedMessage(new SprayPainterSetDecalAngleMessage(angle));
     }
@@ -93,4 +95,11 @@ public sealed class SprayPainterBoundUserInterface(EntityUid owner, Enum uiKey) 
         var key = _window?.IndexToColorKey(args.ItemIndex);
         SendPredictedMessage(new SprayPainterSetPipeColorMessage(key));
     }
+
+    #region Starlight
+
+    private void OnPreviewToggleChanged(bool state) =>
+        SendPredictedMessage(new SprayPainterDecalPreviewToggleMessage(state));
+
+    #endregion
 }

--- a/Content.Client/SprayPainter/UI/SprayPainterDecals.xaml
+++ b/Content.Client/SprayPainter/UI/SprayPainterDecals.xaml
@@ -15,12 +15,23 @@
             <CheckBox Name="SnapToTileCheckBox" Text="{Loc 'spray-painter-use-snap-to-tile'}" />
         </BoxContainer>
 
-        <BoxContainer Orientation="Horizontal">
-            <Label Text="{Loc 'spray-painter-angle-rotation'}" />
-            <SpinBox Name="AngleSpinBox" HorizontalExpand="True" />
-            <Button Text="{Loc 'spray-painter-angle-rotation-90-sub'}" Name="SubAngleButton" />
-            <Button Text="{Loc 'spray-painter-angle-rotation-reset'}" Name="SetZeroAngleButton" />
-            <Button Text="{Loc 'spray-painter-angle-rotation-90-add'}" Name="AddAngleButton" />
+        <Label Text="{Loc 'crayon-window-rotation'}" Margin="0 0 0 1" />
+        <BoxContainer Name="RotationContainer" Orientation="Horizontal" Margin="0 0 0 4">
+            <Button Name="Neg180Btn" Text="-180" SetWidth="40" SetHeight="30"></Button>
+            <Button Name="Neg90Btn" Text="-90" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg45Btn" Text="-45" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg10Btn" Text="-10" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Neg1Btn" Text="-1" SetWidth="30" SetHeight="30"></Button>
+            <LineEdit Name="RotationValue" Margin="0 0 0 0" Text="0" HorizontalExpand="True"></LineEdit>
+            <Button Name="Pos1Btn" Text="+1" SetWidth="30" SetHeight="30"></Button>
+            <Button Name="Pos10Btn" Text="+10" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos45Btn" Text="+45" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos90Btn" Text="+90" SetWidth="36" SetHeight="30"></Button>
+            <Button Name="Pos180Btn" Text="+180" SetWidth="40" SetHeight="30"></Button>
+        </BoxContainer>
+		<BoxContainer>
+            <Label Text="{Loc 'crayon-window-preview'}" Margin="0 6 8 0" />
+            <CheckBox Name="PreviewCheckbox" Margin="0 8 0 0"></CheckBox>
         </BoxContainer>
     </BoxContainer>
 </controls:SprayPainterDecals>

--- a/Content.Client/SprayPainter/UI/SprayPainterDecals.xaml.cs
+++ b/Content.Client/SprayPainter/UI/SprayPainterDecals.xaml.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Linq;
 using System.Numerics;
 using Content.Client.Stylesheets;
 using Content.Shared.Decals;
@@ -19,21 +21,30 @@ public sealed partial class SprayPainterDecals : Control
 {
     public Action<ProtoId<DecalPrototype>>? OnDecalSelected;
     public Action<Color?>? OnColorChanged;
-    public Action<int>? OnAngleChanged;
+    public Action<float>? OnAngleChanged; // Starlight edit
     public Action<bool>? OnSnapChanged;
 
     private SpriteSystem? _sprite;
     private string _selectedDecal = string.Empty;
     private List<SprayPainterDecalEntry> _decals = [];
+    public event Action<bool>? OnPreviewToggled; // Starlight
 
     public SprayPainterDecals()
     {
         RobustXamlLoader.Load(this);
 
-        AddAngleButton.OnButtonUp += _ => AngleSpinBox.Value += 90;
-        SubAngleButton.OnButtonUp += _ => AngleSpinBox.Value -= 90;
-        SetZeroAngleButton.OnButtonUp += _ => AngleSpinBox.Value = 0;
-        AngleSpinBox.ValueChanged += args => OnAngleChanged?.Invoke(args.Value);
+        // Starlight begin
+        foreach (var element in RotationContainer.Children)
+        {
+            if (element is not Button button)
+                continue;
+            button.OnPressed += RotationButtonPressed;
+        }
+
+        RotationValue.OnTextChanged += SelectRotation;
+
+        PreviewCheckbox.OnToggled += PreviewButtonToggled;
+        // Starlight end
 
         UseCustomColorCheckBox.OnPressed += UseCustomColorCheckBoxOnOnPressed;
         SnapToTileCheckBox.OnPressed += SnapToTileCheckBoxOnOnPressed;
@@ -154,10 +165,48 @@ public sealed partial class SprayPainterDecals : Control
         PopulateDecals(_decals, _sprite);
     }
 
-    public void SetAngle(int degrees)
+    #region Starlight
+
+    private void SelectRotation(LineEdit.LineEditEventArgs args)
     {
-        AngleSpinBox.OverrideValue(degrees);
+        var text = args.Text.Replace("+", "");
+
+        var numPart = new string(text.Where(char.IsDigit).ToArray());
+        if (string.IsNullOrEmpty(numPart) || !float.TryParse(numPart, out var value))
+        {
+            SetAngle(0);
+            OnAngleChanged?.Invoke(0);
+            return;
+        }
+
+        if (text.Count(c => c == '-') % 2 == 1)
+            value = -Math.Abs(value);
+
+        var nearest = MathF.Round(value);
+
+        if (Math.Abs(value - nearest) < 0.001f) value = nearest;
+
+        SetAngle(value);
+        OnAngleChanged?.Invoke(value);
     }
+
+    private void RotationButtonPressed(BaseButton.ButtonEventArgs args)
+    {
+        if (args.Button is not Button btn)
+            return;
+        if (!float.TryParse(btn.Text?.Replace("+",""), out var value))
+            return;
+        var finalVal = float.Clamp(float.Parse(RotationValue.Text) + value, -999999, 999999);
+        SetAngle(finalVal);
+        OnAngleChanged?.Invoke(finalVal);
+    }
+    public void SetAngle(float angle) => RotationValue.SetText(angle.ToString(CultureInfo.InvariantCulture));
+
+    private void PreviewButtonToggled(BaseButton.ButtonEventArgs args) => TogglePreview(args.Button.Pressed);
+    private void TogglePreview(bool state) => OnPreviewToggled?.Invoke(state);
+    public void SetPreviewToggle(bool state) => PreviewCheckbox.Pressed = state;
+
+    #endregion
 
     public void SetColor(Color? color)
     {

--- a/Content.Client/SprayPainter/UI/SprayPainterWindow.xaml.cs
+++ b/Content.Client/SprayPainter/UI/SprayPainterWindow.xaml.cs
@@ -28,8 +28,9 @@ public sealed partial class SprayPainterWindow : DefaultWindow
     public event Action<ProtoId<DecalPrototype>>? OnDecalChanged;
     public event Action<ItemList.ItemListSelectedEventArgs>? OnSetPipeColor;
     public event Action<Color?>? OnDecalColorChanged;
-    public event Action<int>? OnDecalAngleChanged;
+    public event Action<float>? OnDecalAngleChanged; // Starlight edit
     public event Action<bool>? OnDecalSnapChanged;
+    public event Action<bool>? OnPreviewToggleChanged; // Starlight
 
     // Pipe color data
     private ItemList _colorList = default!;
@@ -195,6 +196,7 @@ public sealed partial class SprayPainterWindow : DefaultWindow
                 _sprayPainterDecals.OnColorChanged += color => OnDecalColorChanged?.Invoke(color);
                 _sprayPainterDecals.OnAngleChanged += angle => OnDecalAngleChanged?.Invoke(angle);
                 _sprayPainterDecals.OnSnapChanged += snap => OnDecalSnapChanged?.Invoke(snap);
+                _sprayPainterDecals.OnPreviewToggled += state => OnPreviewToggleChanged?.Invoke(state); // Starlight
 
                 Tabs.AddChild(_sprayPainterDecals);
                 TabContainer.SetTabTitle(_sprayPainterDecals, Loc.GetString("spray-painter-tab-category-decals"));
@@ -281,7 +283,7 @@ public sealed partial class SprayPainterWindow : DefaultWindow
             _sprayPainterDecals.SetSelectedDecal(decal);
     }
 
-    public void SetDecalAngle(int angle)
+    public void SetDecalAngle(float angle) // Starlight edit
     {
         if (_sprayPainterDecals != null)
             _sprayPainterDecals.SetAngle(angle);
@@ -298,6 +300,17 @@ public sealed partial class SprayPainterWindow : DefaultWindow
         if (_sprayPainterDecals != null)
             _sprayPainterDecals.SetSnap(snap);
     }
+
+    #region Starlight
+
+    public void SetPreviewToggle(bool state)
+    {
+        if (_sprayPainterDecals is not null)
+            _sprayPainterDecals.SetPreviewToggle(state);
+    }
+
+    #endregion
+
     # endregion
 }
 

--- a/Content.Client/_Starlight/SprayPainter/SprayPainterDecalGhostOverlay.cs
+++ b/Content.Client/_Starlight/SprayPainter/SprayPainterDecalGhostOverlay.cs
@@ -1,0 +1,51 @@
+using Content.Client.Decals;
+using Content.Client.Decals.Overlays;
+using Content.Shared.Decals;
+using Content.Shared.Interaction;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Input;
+using Robust.Client.Player;
+
+namespace Content.Client._Starlight.SprayPainter;
+
+public sealed partial class SprayPainterDecalGhostOverlay : DecalPlacementOverlay
+{
+    [Dependency] private IEyeManager _eyeManager = default!;
+    [Dependency] private IInputManager _inputManager = default!;
+    [Dependency] private IPlayerManager _playerManager = default!;
+    private SharedInteractionSystem _interaction;
+    private readonly DecalPrototype? _decalPrototype;
+    private readonly Angle _rotation;
+    private readonly Color? _color;
+    private readonly bool _gridSnap;
+
+    public SprayPainterDecalGhostOverlay(DecalPlacementSystem placement, SharedTransformSystem transform, SpriteSystem sprite, SharedInteractionSystem interaction, DecalPrototype? decalPrototype, Angle rotation, Color? color, bool gridSnap) : base(placement, transform, sprite)
+    {
+        IoCManager.InjectDependencies(this);
+        _interaction = interaction;
+        _decalPrototype = decalPrototype;
+        _rotation = float.DegreesToRadians((float)rotation);
+        _color = color;
+        _gridSnap = gridSnap;
+    }
+
+    protected override bool BeforeDraw(in OverlayDrawArgs args)
+    {
+        var mouseScreenPos = _inputManager.MouseScreenPosition;
+        var mousePos = _eyeManager.PixelToMap(mouseScreenPos);
+
+        var player = _playerManager.LocalEntity;
+        if (player is null)
+            return false;
+        return _interaction.InRangeUnobstructed(player.Value, mousePos);
+    }
+
+    protected override void LoadDecal()
+    {
+        decal = _decalPrototype;
+        snap = _gridSnap;
+        rotation = _rotation;
+        color = _color;
+    }
+}

--- a/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
+++ b/Content.Shared/SprayPainter/Components/SprayPainterComponent.cs
@@ -80,7 +80,7 @@ public sealed partial class SprayPainterComponent : Component
     /// The angle at which to paint the decal.
     /// </summary>
     [DataField, AutoNetworkedField]
-    public int SelectedDecalAngle;
+    public float SelectedDecalAngle; // Starlight edit
 
     /// <summary>
     /// The angle at which to paint the decal.
@@ -105,6 +105,20 @@ public sealed partial class SprayPainterComponent : Component
     /// </summary>
     [DataField]
     public SoundSpecifier SoundSwitchDecalMode = new SoundPathSpecifier("/Audio/Machines/quickbeep.ogg", AudioParams.Default.WithVolume(1.5f));
+
+    #region Starlight
+
+    /// <summary>
+    /// Shows a preview of the decal at the cursor.
+    /// </summary>
+    [DataField, AutoNetworkedField] public bool ShowDecalPreview;
+
+    /// <summary>
+    /// Makes the preview ghost opaque if true.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField] public bool OpaqueGhost;
+
+    #endregion
 }
 
 /// <summary>

--- a/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
+++ b/Content.Shared/SprayPainter/SharedSprayPainterSystem.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 using System.Linq;
+using Content.Shared._Starlight.SprayPainter;
 
 namespace Content.Shared.SprayPainter;
 
@@ -42,6 +43,10 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
         SubscribeLocalEvent<SprayPainterComponent, GetVerbsEvent<AlternativeVerb>>(OnPainterGetAltVerbs);
         SubscribeLocalEvent<PaintableComponent, InteractUsingEvent>(OnPaintableInteract);
         SubscribeLocalEvent<PaintedComponent, ExaminedEvent>(OnPainedExamined);
+        // Starlight begin
+        SubscribeLocalEvent<SprayPainterComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+        SubscribeLocalEvent<SprayPainterComponent, BoundUIClosedEvent>(OnBoundUIClosed);
+        // Starlight end
 
         Subs.BuiEvents<SprayPainterComponent>(SprayPainterUiKey.Key,
             subs =>
@@ -53,6 +58,7 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
                 subs.Event<SprayPainterSetDecalColorMessage>(OnSetDecalColor);
                 subs.Event<SprayPainterSetDecalAngleMessage>(OnSetDecalAngle);
                 subs.Event<SprayPainterSetDecalSnapMessage>(OnSetDecalSnap);
+                subs.Event<SprayPainterDecalPreviewToggleMessage>(OnUIPreviewToggled); // Starlight
             });
     }
 
@@ -278,6 +284,7 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
         ent.Comp.SelectedDecal = args.DecalPrototype;
         Dirty(ent);
         UpdateUi(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent()); // Starlight
     }
 
     /// <summary>
@@ -288,6 +295,7 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
         ent.Comp.SelectedDecalAngle = args.Angle;
         Dirty(ent);
         UpdateUi(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent()); // Starlight
     }
 
     /// <summary>
@@ -298,6 +306,7 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
         ent.Comp.SnapDecals = args.Snap;
         Dirty(ent);
         UpdateUi(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent()); // Starlight
     }
 
     /// <summary>
@@ -308,11 +317,38 @@ public abstract partial class SharedSprayPainterSystem : EntitySystem
         ent.Comp.SelectedDecalColor = args.Color;
         Dirty(ent);
         UpdateUi(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent()); // Starlight
     }
 
     protected virtual void UpdateUi(Entity<SprayPainterComponent> ent)
     {
     }
+
+    #region Starlight
+
+    private void OnUIPreviewToggled(Entity<SprayPainterComponent> ent, ref SprayPainterDecalPreviewToggleMessage args)
+    {
+        ent.Comp.ShowDecalPreview = args.State;
+        Dirty(ent);
+        UpdateUi(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent());
+    }
+
+    private void OnBoundUIOpened(Entity<SprayPainterComponent> ent, ref BoundUIOpenedEvent args)
+    {
+        ent.Comp.OpaqueGhost = false;
+        Dirty(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent());
+    }
+
+    private void OnBoundUIClosed(Entity<SprayPainterComponent> ent, ref BoundUIClosedEvent args)
+    {
+        ent.Comp.OpaqueGhost = true;
+        Dirty(ent);
+        RaiseLocalEvent(ent, new SprayPainterUpdateDecalEvent());
+    }
+
+    #endregion
 
     #endregion
 }

--- a/Content.Shared/SprayPainter/SprayPainterEvents.cs
+++ b/Content.Shared/SprayPainter/SprayPainterEvents.cs
@@ -31,9 +31,9 @@ public sealed class SprayPainterSetDecalSnapMessage(bool snap) : BoundUserInterf
 }
 
 [Serializable, NetSerializable]
-public sealed class SprayPainterSetDecalAngleMessage(int angle) : BoundUserInterfaceMessage
+public sealed class SprayPainterSetDecalAngleMessage(float angle) : BoundUserInterfaceMessage // Starlight edit
 {
-    public int Angle = angle;
+    public float Angle = angle; // Starlight edit
 }
 
 [Serializable, NetSerializable]
@@ -117,3 +117,13 @@ public partial record struct EntityPaintedEvent(
     EntityUid Tool,
     EntProtoId Prototype,
     ProtoId<PaintableGroupPrototype> Group);
+
+#region Starlight
+
+[Serializable, NetSerializable]
+public sealed class SprayPainterDecalPreviewToggleMessage(bool state) : BoundUserInterfaceMessage
+{
+    public bool State = state;
+}
+
+#endregion

--- a/Content.Shared/_Starlight/SprayPainter/SprayPainterPreviewEvents.cs
+++ b/Content.Shared/_Starlight/SprayPainter/SprayPainterPreviewEvents.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Starlight.SprayPainter;
+
+[Serializable, NetSerializable]
+public sealed class SprayPainterUpdateDecalEvent : EntityEventArgs;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Implementation of my crayon decal preview for the spray painter, a bit more optimized this time.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Actually being able to see where your decal will be placed is good, duh.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="687" height="366" alt="image" src="https://github.com/user-attachments/assets/3f7ad650-6e77-454c-8979-51f4d40eaded" />
<img width="302" height="170" alt="image" src="https://github.com/user-attachments/assets/d73442ad-1707-4251-b76c-9642f34c3d29" />
<img width="336" height="131" alt="image" src="https://github.com/user-attachments/assets/c29ea005-2cbe-45c7-a5f2-e5ee1386f9bb" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- add: Adds the same preview ghost feature and rotation buttons that crayons were given to the spray painter.