### PR TITLE
Tweaked the access conditions on the shuttle a bit

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/base_structurecomputers.yml
@@ -45,7 +45,6 @@
         whitelist:
           components:
           - PAI
-  - type: LockedWiresPanel
   # Starlight End
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/machines/computer.yml
@@ -129,6 +129,8 @@
           #Starlight start
           conditions:
             - !type:WirePanel
+            - !type:Locked
+              locked: false
           #Starlight end
           steps:
             - tool: Prying


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Made it so you can now hack the shuttle console without it having to be unlocked while maintaining that requirement to deconstruct it 

## Why we need to add this
As the shuttle PR was my very first PR i wasn't aware of some component's workings and accidentally ended up making it a bit too difficult to mess with the shuttle. This PR aims to resolve that oversight

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- tweak: Changed shuttle console's maintenance panel to be accessible even when locked.

