### PR TITLE
Slime Colour Matters

### DIFF
--- a/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
+++ b/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
@@ -1,9 +1,8 @@
 using Content.Shared._Starfall.Particles;
+using Content.Shared._Starlight.Medical.Body.Systems;
 using Content.Shared.Body.Components;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Gibbing;
 using Robust.Shared.Player;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server._Starfall.Particles;
 
@@ -21,7 +20,7 @@ namespace Content.Server._Starfall.Particles;
 /// TODO: KILL WHEN GIBBING IS PREDICTED/SHARED I BEG
 public sealed class GibMistParticleSystem : EntitySystem
 {
-    [Dependency] private readonly IPrototypeManager _proto = default!;
+    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -32,10 +31,10 @@ public sealed class GibMistParticleSystem : EntitySystem
 
     private void OnBeingGibbed(Entity<BloodstreamComponent> ent, ref BeingGibbedEvent args)
     {
-        var color = Color.Red;
         var contents = ent.Comp.BloodReferenceSolution.Contents;
-        if (contents.Count > 0 && _proto.TryIndex(contents[0].Reagent.Prototype, out ReagentPrototype? reagentProto))
-            color = reagentProto.SubstanceColor;
+        var color = contents.Count > 0
+            ? _bloodstream.GetBloodColor((ent.Owner, ent.Comp))
+            : Color.Red;
 
         RaiseNetworkEvent(new GibMistParticleEvent(_transform.GetMapCoordinates(ent), color), Filter.Pvs(ent.Owner));
     }

--- a/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
+++ b/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
@@ -1,5 +1,5 @@
 using Content.Shared._Starfall.Particles;
-using Content.Shared._Starlight.Medical.Body.Systems; // Starlight
+using Content.Shared._Starlight.Medical.Body.Systems;
 using Content.Shared.Body.Components;
 using Content.Shared.Gibbing;
 using Robust.Shared.Player;

--- a/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
+++ b/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
@@ -20,9 +20,7 @@ namespace Content.Server._Starfall.Particles;
 /// TODO: KILL WHEN GIBBING IS PREDICTED/SHARED I BEG
 public sealed class GibMistParticleSystem : EntitySystem
 {
-    #region Starlight
-    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
-    #endregion
+    [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!; // Starlight-edit
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()
@@ -36,7 +34,7 @@ public sealed class GibMistParticleSystem : EntitySystem
         var contents = ent.Comp.BloodReferenceSolution.Contents;
         var color = contents.Count > 0
             ? _bloodstream.GetBloodColor((ent.Owner, ent.Comp))
-            : Color.Red;
+            : Color.Red; // Starlight-edit
 
         RaiseNetworkEvent(new GibMistParticleEvent(_transform.GetMapCoordinates(ent), color), Filter.Pvs(ent.Owner));
     }

--- a/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
+++ b/Content.Server/_Starfall/Particles/Visuals/GibMistParticleSystem.cs
@@ -1,5 +1,5 @@
 using Content.Shared._Starfall.Particles;
-using Content.Shared._Starlight.Medical.Body.Systems;
+using Content.Shared._Starlight.Medical.Body.Systems; // Starlight
 using Content.Shared.Body.Components;
 using Content.Shared.Gibbing;
 using Robust.Shared.Player;
@@ -20,7 +20,9 @@ namespace Content.Server._Starfall.Particles;
 /// TODO: KILL WHEN GIBBING IS PREDICTED/SHARED I BEG
 public sealed class GibMistParticleSystem : EntitySystem
 {
+    #region Starlight
     [Dependency] private readonly SharedBloodstreamSystem _bloodstream = default!;
+    #endregion
     [Dependency] private readonly SharedTransformSystem _transform = default!;
 
     public override void Initialize()

--- a/Content.Server/_Starlight/Medical/Body/Systems/BloodstreamSystem.cs
+++ b/Content.Server/_Starlight/Medical/Body/Systems/BloodstreamSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared._Starlight.Medical.Body.Systems;
 using Content.Shared.Body.Components;
-using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Forensics;
 
 namespace Content.Server._Starlight.Medical.Body.Systems;
@@ -42,19 +41,7 @@ public sealed class BloodstreamSystem : SharedBloodstreamSystem
     // forensics is not predicted yet
     private void OnDnaGenerated(Entity<BloodstreamComponent> entity, ref GenerateDnaEvent args)
     {
-        if (SolutionContainer.ResolveSolution(entity.Owner, entity.Comp.BloodSolutionName, ref entity.Comp.BloodSolution, out var bloodSolution))
-        {
-            var data = NewEntityBloodData(entity);
-            entity.Comp.BloodReferenceSolution.SetReagentData(data);
-
-            foreach (var reagent in bloodSolution.Contents)
-            {
-                List<ReagentData> reagentData = reagent.Reagent.EnsureReagentData();
-                reagentData.RemoveAll(x => x is DnaData);
-                reagentData.AddRange(data);
-            }
-        }
-        else
+        if (!RefreshBloodData(entity))
             Log.Error("Unable to set bloodstream DNA, solution entity could not be resolved");
     }
 }

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Linq;
+using Content.Shared._Blimpuf.Chemistry.Reagent;
 using Content.Shared.Chemistry.Components.SolutionManager;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
@@ -908,12 +909,12 @@ namespace Content.Shared.Chemistry.Components
                 if (first)
                 {
                     first = false;
-                    mixColor = proto.SubstanceColor;
+                    mixColor = GetReagentColor(proto, reagent);
                     continue;
                 }
 
                 var interpolateValue = quantity.Float() / runningTotalQuantity.Float();
-                mixColor = Color.InterpolateBetween(mixColor, proto.SubstanceColor, interpolateValue);
+                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue);
             }
             return mixColor;
         }
@@ -951,15 +952,31 @@ namespace Content.Shared.Chemistry.Components
                 if (first)
                 {
                     first = false;
-                    mixColor = proto.SubstanceColor;
+                    mixColor = GetReagentColor(proto, reagent);
                     continue;
                 }
 
                 var interpolateValue = quantity.Float() / runningTotalQuantity.Float();
-                mixColor = Color.InterpolateBetween(mixColor, proto.SubstanceColor, interpolateValue);
+                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue);
             }
             return mixColor;
         }
+
+        // Blimpuf start
+        private static Color GetReagentColor(ReagentPrototype proto, ReagentId reagent)
+        {
+            if (reagent.Data == null)
+                return proto.SubstanceColor;
+
+            foreach (var data in reagent.Data)
+            {
+                if (data is ReagentColorData colorData)
+                    return colorData.Color;
+            }
+
+            return proto.SubstanceColor;
+        }
+        // Blimpuf end
 
         #region Enumeration
 

--- a/Content.Shared/Chemistry/Components/Solution.cs
+++ b/Content.Shared/Chemistry/Components/Solution.cs
@@ -909,12 +909,12 @@ namespace Content.Shared.Chemistry.Components
                 if (first)
                 {
                     first = false;
-                    mixColor = GetReagentColor(proto, reagent);
+                    mixColor = GetReagentColor(proto, reagent); // Blimpuf edit
                     continue;
                 }
 
                 var interpolateValue = quantity.Float() / runningTotalQuantity.Float();
-                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue);
+                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue); // Blimpuf edit
             }
             return mixColor;
         }
@@ -952,12 +952,12 @@ namespace Content.Shared.Chemistry.Components
                 if (first)
                 {
                     first = false;
-                    mixColor = GetReagentColor(proto, reagent);
+                    mixColor = GetReagentColor(proto, reagent); // Blimpuf edit
                     continue;
                 }
 
                 var interpolateValue = quantity.Float() / runningTotalQuantity.Float();
-                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue);
+                mixColor = Color.InterpolateBetween(mixColor, GetReagentColor(proto, reagent), interpolateValue); // Blimpuf edit
             }
             return mixColor;
         }

--- a/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/SharedSolutionContainerSystem.cs
@@ -878,7 +878,7 @@ public abstract partial class SharedSolutionContainerSystem : EntitySystem
                 }
 
                 recognized.Add(Loc.GetString("examinable-solution-recognized",
-                                            ("color", proto.SubstanceColor.ToHexNoAlpha()),
+                                            ("color", solution.GetColorWithOnly(PrototypeManager, proto.ID).ToHexNoAlpha()),
                                             ("chemical", proto.LocalizedName)));
             }
 

--- a/Content.Shared/Chemistry/Reagent/DNAData.cs
+++ b/Content.Shared/Chemistry/Reagent/DNAData.cs
@@ -18,12 +18,7 @@ public sealed partial class DnaData : ReagentData
 
     public override bool Equals(ReagentData? other)
     {
-        if (other == null)
-        {
-            return false;
-        }
-
-        return ((DnaData) other).DNA == DNA;
+        return other is DnaData dnaData && dnaData.DNA == DNA;
     }
 
     public override int GetHashCode()

--- a/Content.Shared/Chemistry/Reagent/DNAData.cs
+++ b/Content.Shared/Chemistry/Reagent/DNAData.cs
@@ -17,9 +17,7 @@ public sealed partial class DnaData : ReagentData
     }
 
     public override bool Equals(ReagentData? other)
-    {
-        return other is DnaData dnaData && dnaData.DNA == DNA;
-    }
+        => other is DnaData dnaData && dnaData.DNA == DNA; // Blimpuf edit
 
     public override int GetHashCode()
     {

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -214,7 +214,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
 
                 var interpolateValue = quantity.Float() / solution.Volume.Float();
                 color = Color.InterpolateBetween(color,
-                    solution.GetColorWithOnly(_prototypeManager, standout),
+                    solution.GetColorWithOnly(_prototypeManager, standout), // Blimpuf edit
                     interpolateValue);
             }
         }

--- a/Content.Shared/Fluids/SharedPuddleSystem.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.cs
@@ -214,7 +214,7 @@ public abstract partial class SharedPuddleSystem : EntitySystem
 
                 var interpolateValue = quantity.Float() / solution.Volume.Float();
                 color = Color.InterpolateBetween(color,
-                    _prototypeManager.Index<ReagentPrototype>(standout).SubstanceColor,
+                    solution.GetColorWithOnly(_prototypeManager, standout),
                     interpolateValue);
             }
         }

--- a/Content.Shared/_Blimpuf/Chemistry/Reagent/ReagentColorData.cs
+++ b/Content.Shared/_Blimpuf/Chemistry/Reagent/ReagentColorData.cs
@@ -1,0 +1,40 @@
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Blimpuf.Chemistry.Reagent;
+
+[ImplicitDataDefinitionForInheritors, Serializable, NetSerializable]
+public sealed partial class ReagentColorData : ReagentData
+{
+    [DataField]
+    public Color Color = Color.White;
+
+    public override ReagentData Clone()
+    {
+        return new ReagentColorData
+        {
+            Color = Color,
+        };
+    }
+
+    public override bool Equals(ReagentData? other)
+    {
+        return other is ReagentColorData colorData && colorData.Color == Color;
+    }
+
+    public override int GetHashCode()
+    {
+        return Color.GetHashCode();
+    }
+
+    public override string ToString(string prototype, FixedPoint2 quantity)
+    {
+        return $"{prototype}:{GetType().Name}:{Color.ToHex()}:{quantity}";
+    }
+
+    public override string ToString(string prototype)
+    {
+        return $"{prototype}:{GetType().Name}:{Color.ToHex()}";
+    }
+}

--- a/Content.Shared/_Starlight/Medical/Body/Components/BloodstreamComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Components/BloodstreamComponent.cs
@@ -154,6 +154,13 @@ public sealed partial class BloodstreamComponent : Component
     public Solution BloodReferenceSolution = new([new("Blood", 300)]);
 
     /// <summary>
+    /// Optional visual color for blood reagents from this entity.
+    /// This is stored on the reagent instance, so transferred blood keeps its color.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Color? BloodReagentColor;
+
+    /// <summary>
     /// Caches the blood data of an entity.
     /// This is modified by DNA on init so it's not savable.
     /// </summary>

--- a/Content.Shared/_Starlight/Medical/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Systems/SharedBloodstreamSystem.cs
@@ -1,4 +1,5 @@
 using Content.Shared._Starlight.Medical.Body.Events;
+using Content.Shared._Blimpuf.Chemistry.Reagent;
 using Content.Shared.Alert;
 using Content.Shared.Body.Components;
 using Content.Shared.Chemistry.Components;
@@ -14,6 +15,7 @@ using Content.Shared.Fluids;
 using Content.Shared.Forensics.Components;
 using Content.Shared.Gibbing;
 using Content.Shared.HealthExaminable;
+using Content.Shared.Humanoid;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Random.Helpers;
@@ -30,6 +32,7 @@ namespace Content.Shared._Starlight.Medical.Body.Systems;
 public abstract partial class SharedBloodstreamSystem : EntitySystem
 {
     public static readonly EntProtoId Bloodloss = "StatusEffectBloodloss";
+    private static readonly ProtoId<ReagentPrototype> SlimeReagent = "Slime";
 
     [Dependency] protected IPrototypeManager PrototypeManager = default!;
     [Dependency] protected SharedSolutionContainerSystem SolutionContainer = default!;
@@ -56,6 +59,7 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
         SubscribeLocalEvent<BloodstreamComponent, ApplyMetabolicMultiplierEvent>(OnApplyMetabolicMultiplier);
         SubscribeLocalEvent<BloodstreamComponent, RejuvenateEvent>(OnRejuvenate);
         SubscribeLocalEvent<BloodstreamComponent, MetabolismExclusionEvent>(OnMetabolismExclusion);
+        SubscribeLocalEvent<BloodstreamComponent, MarkingsUpdateEvent>(OnMarkingsUpdate);
     }
 
     public override void Update(float frameTime)
@@ -293,6 +297,17 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
         {
             args.Reagents.Add(reagent);
         }
+    }
+
+    private void OnMarkingsUpdate(Entity<BloodstreamComponent> ent, ref MarkingsUpdateEvent args)
+    {
+        if (ent.Comp.BloodReagentColor != null
+            || !ent.Comp.BloodReferenceSolution.ContainsPrototype(SlimeReagent))
+        {
+            return;
+        }
+
+        RefreshBloodData(ent);
     }
 
     /// <summary>
@@ -598,8 +613,73 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
             dnaData.DNA = Loc.GetString("forensics-dna-unknown");
 
         bloodData.Add(dnaData);
+
+        // Blimpuf start
+        if (TryGetBloodReagentColor(uid, out var color))
+        {
+            bloodData.Add(new ReagentColorData
+            {
+                Color = color,
+            });
+        }
+
         return bloodData;
     }
+
+    public bool RefreshBloodData(Entity<BloodstreamComponent> ent)
+    {
+        var data = NewEntityBloodData(ent.Owner);
+        ent.Comp.BloodReferenceSolution.SetReagentData(data);
+        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReferenceSolution));
+
+        if (!SolutionContainer.ResolveSolution(ent.Owner, ent.Comp.BloodSolutionName, ref ent.Comp.BloodSolution, out var bloodSolution))
+            return false;
+
+        foreach (var reagent in bloodSolution.Contents)
+        {
+            if (!ent.Comp.BloodReferenceSolution.ContainsPrototype(reagent.Reagent.Prototype))
+                continue;
+
+            var reagentData = reagent.Reagent.EnsureReagentData();
+            reagentData.RemoveAll(x => x is DnaData or ReagentColorData);
+            reagentData.AddRange(data);
+        }
+
+        SolutionContainer.UpdateChemicals(ent.Comp.BloodSolution.Value);
+        return true;
+    }
+
+    public void SetBloodReagentColor(Entity<BloodstreamComponent> ent, Color? color)
+    {
+        ent.Comp.BloodReagentColor = color;
+        DirtyField(ent, ent.Comp, nameof(BloodstreamComponent.BloodReagentColor));
+        RefreshBloodData(ent);
+    }
+
+    private bool TryGetBloodReagentColor(EntityUid uid, out Color color)
+    {
+        color = Color.White;
+
+        BloodstreamComponent? bloodstream = null;
+        if (!Resolve(uid, ref bloodstream, logMissing: false))
+            return false;
+
+        if (bloodstream.BloodReagentColor != null)
+        {
+            color = bloodstream.BloodReagentColor.Value;
+            return true;
+        }
+
+        if (!bloodstream.BloodReferenceSolution.ContainsPrototype(SlimeReagent)
+            || !TryComp<HumanoidAppearanceComponent>(uid, out var humanoid))
+        {
+            return false;
+        }
+
+        color = humanoid.SkinColor;
+        return true;
+    }
+    // Blimpuf end
 
     //starlight start
     public Color GetBloodColor(Entity<BloodstreamComponent?> ent)

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -1046,6 +1046,7 @@
   - type: Damageable
     damageModifierSet: SlimePet
   - type: Bloodstream
+    bloodReagentColor: "#ffffff"
     bloodlossHealDamage:
       types:
         Bloodloss:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -1046,7 +1046,7 @@
   - type: Damageable
     damageModifierSet: SlimePet
   - type: Bloodstream
-    bloodReagentColor: "#ffffff"
+    bloodReagentColor: "#ffffff" # Blimpuf edit
     bloodlossHealDamage:
       types:
         Bloodloss:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -68,6 +68,7 @@
     damageContainer: Biological
     damageModifierSet: Slime
   - type: Bloodstream
+    bloodReagentColor: "#52b4e9"
     bloodReferenceSolution:
       reagents:
       - ReagentId: Slime
@@ -202,6 +203,8 @@
           Base: green_adult_slime
         Dead:
           Base: green_adult_slime_dead
+    - type: Bloodstream
+      bloodReagentColor: "#2cf274"
     - type: MeleeWeapon
       damage:
         types:
@@ -242,6 +245,8 @@
           Base: yellow_adult_slime
         Dead:
           Base: yellow_adult_slime_dead
+    - type: Bloodstream
+      bloodReagentColor: "#f4e65a"
     - type: MeleeWeapon
       damage:
         types:

--- a/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/slimes.yml
@@ -68,7 +68,7 @@
     damageContainer: Biological
     damageModifierSet: Slime
   - type: Bloodstream
-    bloodReagentColor: "#52b4e9"
+    bloodReagentColor: "#52b4e9" # Blimpuf edit
     bloodReferenceSolution:
       reagents:
       - ReagentId: Slime
@@ -203,8 +203,10 @@
           Base: green_adult_slime
         Dead:
           Base: green_adult_slime_dead
+    # Blimpuf start
     - type: Bloodstream
       bloodReagentColor: "#2cf274"
+    # Blimpuf end
     - type: MeleeWeapon
       damage:
         types:
@@ -245,8 +247,10 @@
           Base: yellow_adult_slime
         Dead:
           Base: yellow_adult_slime_dead
+    # Blimpuf start
     - type: Bloodstream
       bloodReagentColor: "#f4e65a"
+    # Blimpuf end
     - type: MeleeWeapon
       damage:
         types:

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/slime.yml
@@ -97,7 +97,7 @@
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream
-    bloodReferenceSolution: # TODO Color slime blood based on their slime color or smth
+    bloodReferenceSolution:
       reagents:
       - ReagentId: Slime
         Quantity: 300


### PR DESCRIPTION
## Short description
Port of my own Blimpuf-Station/BlimpufStation#80, with some modifications made as SL does not have our Geras system.

Slime and slime people's internal slime reagent now actually inherits the colour of their slime.

## Why we need to add this
The TODO I removed from slime.yml implies this has literally always been an intended feature of the species that no one ever bothered with.

Precursor to larger slime chemistry and slime cooking update, which you guys are also welcome to have when we're done.

## Media (Video/Screenshots)
<img width="805" height="712" alt="image" src="https://github.com/user-attachments/assets/f639b48f-5db4-4ad4-bd8f-24aebe0e33a3" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Limerent-Sun
- add: Slime chemical now inherits colours from the slime it comes from.
