### PR TITLE
Experimental Alcohol fix 2

### DIFF
--- a/Content.Client/Drunk/DrunkOverlay.cs
+++ b/Content.Client/Drunk/DrunkOverlay.cs
@@ -1,27 +1,33 @@
 using Content.Shared.Drunk;
-using Content.Shared.StatusEffect;
 using Content.Shared.StatusEffectNew;
 using Robust.Client.Graphics;
 using Robust.Client.Player;
 using Robust.Shared.Enums;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared._Starlight.CCVar;
+using Robust.Shared.Configuration;
 
 namespace Content.Client.Drunk;
 
 public sealed partial class DrunkOverlay : Overlay
 {
     private static readonly ProtoId<ShaderPrototype> Shader = "Drunk";
+    private static readonly TimeSpan _screenCaptureInterval = TimeSpan.FromSeconds(1.0 / 30.0); // Starlight
 
     [Dependency] private IEntityManager _entityManager = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private IPlayerManager _playerManager = default!;
     [Dependency] private IEntitySystemManager _sysMan = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IConfigurationManager _cfg = default!; // Starlight
 
     public override OverlaySpace Space => OverlaySpace.WorldSpace;
     public override bool RequestScreenTexture => true;
+    // Starlight Start
     private readonly ShaderInstance _drunkShader;
+    private readonly StatusEffectsSystem _statusEffects;
+    // Starlight End
 
     public float CurrentBoozePower = 0.0f;
 
@@ -39,11 +45,33 @@ public sealed partial class DrunkOverlay : Overlay
 
     private float _visualScale = 0;
 
+    // Starlight Start
+    private bool _drunkRenderFix;
+    private TimeSpan _nextScreenCapture;
+    private Texture? _cachedScreenTexture;
+    // Starlight End
+
     public DrunkOverlay()
     {
         IoCManager.InjectDependencies(this);
         _drunkShader = _prototypeManager.Index(Shader).InstanceUnique();
+        // Starlight Start: cache status effect system and register cvar listener
+        _statusEffects = _sysMan.GetEntitySystem<StatusEffectsSystem>();
+        _cfg.OnValueChanged(StarlightCCVars.DrunkRenderFix, OnDrunkRenderFixChanged, invokeImmediately: true);
+        // Starlight End
     }
+
+    // Starlight Start
+    private void OnDrunkRenderFixChanged(bool enabled)
+    {
+        _drunkRenderFix = enabled;
+
+        if (!enabled)
+        {
+            _cachedScreenTexture = null;
+        }
+    }
+    // Starlight End
 
     protected override void FrameUpdate(FrameEventArgs args)
     {
@@ -53,8 +81,7 @@ public sealed partial class DrunkOverlay : Overlay
         if (playerEntity == null)
             return;
 
-        var statusSys = _sysMan.GetEntitySystem<Shared.StatusEffectNew.StatusEffectsSystem>();
-        if (!statusSys.TryGetMaxTime<DrunkStatusEffectComponent>(playerEntity.Value, out var status))
+        if (!_statusEffects.TryGetMaxTime<DrunkStatusEffectComponent>(playerEntity.Value, out var status)) // Starlight Edit: use cached status system
             return;
 
         var time = status.Item2;
@@ -78,11 +105,26 @@ public sealed partial class DrunkOverlay : Overlay
 
     protected override void Draw(in OverlayDrawArgs args)
     {
-        if (ScreenTexture == null)
+        // Starlight edit Start: capture frame update every 30Hz if render fix on, otherwise everyframe
+        var screen = ScreenTexture;
+
+        if (_drunkRenderFix)
+        {
+            if (_cachedScreenTexture == null || _timing.RealTime >= _nextScreenCapture)
+            {
+                _cachedScreenTexture = ScreenTexture;
+                _nextScreenCapture = _timing.RealTime + _screenCaptureInterval;
+            }
+
+            screen = _cachedScreenTexture;
+        }
+
+        if (screen == null)
+        // Starlight edit End
             return;
 
         var handle = args.WorldHandle;
-        _drunkShader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _drunkShader.SetParameter("SCREEN_TEXTURE", screen); // Starlight Edit: ScreenTexture -> screen
         _drunkShader.SetParameter("boozePower", _visualScale);
         handle.UseShader(_drunkShader);
         handle.DrawRect(args.WorldBounds, Color.White);

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Graphics.cs
@@ -11,6 +11,12 @@ public sealed partial class StarlightCCVars
     /// </summary>
     public static readonly CVarDef<int> InteractionParticlesMode =
         CVarDef.Create("opt.interaction_particles_mode", (int) InteractionParticleMode.WithoutInHand, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    /// Experimental fix: rate-limits drunk overlay screen-texture copies to ~30Hz instead of every render frame.
+    /// </summary>
+    public static readonly CVarDef<bool> DrunkRenderFix =
+        CVarDef.Create("opt.drunk_render_fix", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 }
 
 /// <summary>


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Redo of https://github.com/ss14Starlight/space-station-14/pull/5069
With fixes and better commenting. 

> Adds an experimental fix for the alcohol lag that has been reported numerous times, disabled by default enabled by setting opt.drunk_render_fix to true.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
> This will hopefully fix https://github.com/ss14Starlight/space-station-14/issues/5038, [this thread](https://discord.com/channels/1272545509562777621/1509365322757439554), [this thread](https://discord.com/channels/1272545509562777621/1523743383594467390), [this thread](https://discord.com/channels/1272545509562777621/1515343691995152474), and [this thread](https://discord.com/channels/1272545509562777621/1519592978597806162).
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
The drunk effect looks the exact same, and nobody can replicate the lag in dev.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: CrazyPhantom
- fix: Experimental fix for alcohol lag can be enabled with the command ``cvar opt.drunk_render_fix true``.