### PR TITLE
Give corgis AstroNav mass scanner BUI hook

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3142,6 +3142,9 @@
     interfaces:
       enum.ScentSniffUiKey.Key:
         type: ScentSniffBoundUserInterface
+      enum.RadarConsoleUiKey.Key: # dog descendants may potentially have mass scanners
+        type: RadarConsoleBoundUserInterface
+        requireInputValidation: false
   # Starlight End
   - type: Fixtures
     fixtures:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue where smart corgis in possession of the improved AstroNav with mass scanner can't actually bring up the mass scanner BUI.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Smart Corgis are in the sandbox and playable by people, even supporting many of the same jobs that have this: miner, salvager, and paramedic are all well-supported for smart corgis.
This allows them to be functional in these roles given the new tool.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1371" height="670" alt="image" src="https://github.com/user-attachments/assets/7343c5fe-e44c-4ca8-88bf-46fb21dd642d" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: Smart corgis with the new AstroNav mass scanner can now actually use the mass scanner UI.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
