### PR TITLE
Random name restoration

### DIFF
--- a/Resources/Locale/en-US/datasets/names/dragon.ftl
+++ b/Resources/Locale/en-US/datasets/names/dragon.ftl
@@ -29,4 +29,5 @@ names-dragon-dataset-28 = Embergill
 names-dragon-dataset-29 = Doomwing
 names-dragon-dataset-30 = Celesteus
 names-dragon-dataset-31 = Jharon
+## Starlight
 names-dragon-dataset-32 = Draco

--- a/Resources/Locale/en-US/datasets/names/dragon.ftl
+++ b/Resources/Locale/en-US/datasets/names/dragon.ftl
@@ -6,8 +6,7 @@ names-dragon-dataset-5 = Aldooin
 names-dragon-dataset-6 = Wrathalos
 names-dragon-dataset-7 = Four-Eyes
 names-dragon-dataset-8 = Flamespew
-## Starlight
-names-dragon-dataset-9 = Draco
+names-dragon-dataset-9 = Daniel
 names-dragon-dataset-10 = Blacksmoke
 names-dragon-dataset-11 = Spacemaw
 names-dragon-dataset-12 = Cyprinidus
@@ -30,3 +29,4 @@ names-dragon-dataset-28 = Embergill
 names-dragon-dataset-29 = Doomwing
 names-dragon-dataset-30 = Celesteus
 names-dragon-dataset-31 = Jharon
+names-dragon-dataset-32 = Draco

--- a/Resources/Locale/en-US/datasets/names/ninja.ftl
+++ b/Resources/Locale/en-US/datasets/names/ninja.ftl
@@ -15,8 +15,7 @@ names-ninja-dataset-14 = Hiryu
 names-ninja-dataset-15 = Hayabusa
 names-ninja-dataset-16 = Midnight
 names-ninja-dataset-17 = Seven
-## Starlight
-names-ninja-dataset-18 = Oni
+names-ninja-dataset-18 = McNinja
 names-ninja-dataset-19 = Hanzo
 names-ninja-dataset-20 = Blood
 names-ninja-dataset-21 = Iga
@@ -28,8 +27,7 @@ names-ninja-dataset-26 = Baki
 names-ninja-dataset-27 = Ogre
 names-ninja-dataset-28 = Daemon
 names-ninja-dataset-29 = Goemon
-## Starlight
-names-ninja-dataset-30 = Nagato
+names-ninja-dataset-30 = McAwesome
 ## Starlight
 names-ninja-dataset-31 = Kotaro
 names-ninja-dataset-32 = Death
@@ -40,3 +38,5 @@ names-ninja-dataset-36 = Samurai
 names-ninja-dataset-37 = Eater
 names-ninja-dataset-38 = Ryu
 names-ninja-dataset-39 = Raiden
+names-ninja-dataset-40 = Oni
+names-ninja-dataset-41 = Nagato

--- a/Resources/Locale/en-US/datasets/names/ninja.ftl
+++ b/Resources/Locale/en-US/datasets/names/ninja.ftl
@@ -38,5 +38,7 @@ names-ninja-dataset-36 = Samurai
 names-ninja-dataset-37 = Eater
 names-ninja-dataset-38 = Ryu
 names-ninja-dataset-39 = Raiden
+## Starlight
 names-ninja-dataset-40 = Oni
+## Starlight
 names-ninja-dataset-41 = Nagato

--- a/Resources/Locale/en-US/datasets/names/ninja_title.ftl
+++ b/Resources/Locale/en-US/datasets/names/ninja_title.ftl
@@ -21,12 +21,10 @@ names-ninja-title-dataset-20 = Grandmaster
 names-ninja-title-dataset-21 = Strider
 names-ninja-title-dataset-22 = Striker
 names-ninja-title-dataset-23 = Slayer
-## Starlight
-names-ninja-title-dataset-24 = Iron
+names-ninja-title-dataset-24 = Awesome
 names-ninja-title-dataset-25 = Ender
 names-ninja-title-dataset-26 = Dr.
-## Starlight
-names-ninja-title-dataset-27 = Evening
+names-ninja-title-dataset-27 = Noob
 names-ninja-title-dataset-28 = Night
 names-ninja-title-dataset-29 = Crimson
 names-ninja-title-dataset-30 = Grappler
@@ -46,3 +44,5 @@ names-ninja-title-dataset-43 = Nickel
 names-ninja-title-dataset-44 = Silver
 names-ninja-title-dataset-45 = Singing
 names-ninja-title-dataset-46 = Snake
+names-ninja-title-dataset-47 = Iron
+names-ninja-title-dataset-48 = Evening

--- a/Resources/Locale/en-US/datasets/names/regalrat_title.ftl
+++ b/Resources/Locale/en-US/datasets/names/regalrat_title.ftl
@@ -8,12 +8,14 @@ names-regal-rat-title-dataset-7 = Master
 names-regal-rat-title-dataset-8 = Shogun
 names-regal-rat-title-dataset-9 = Bojar
 names-regal-rat-title-dataset-10 = Tsar
-## Starlight
-names-regal-rat-title-dataset-11 = Monarch
-## Starlight
-names-regal-rat-title-dataset-12 = Baron
+names-regal-rat-title-dataset-11 = Fan
+names-regal-rat-title-dataset-12 = Enjoyer
 names-regal-rat-title-dataset-13 = President
 names-regal-rat-title-dataset-14 = Mayor
 names-regal-rat-title-dataset-15 = Boss
 names-regal-rat-title-dataset-16 = Prophet
 names-regal-rat-title-dataset-17 = Cheese
+## Starlight
+names-regal-rat-title-dataset-18 = Monarch
+## Starlight
+names-regal-rat-title-dataset-19 = Baron

--- a/Resources/Prototypes/Datasets/Names/dragon.yml
+++ b/Resources/Prototypes/Datasets/Names/dragon.yml
@@ -2,7 +2,7 @@
   id: NamesDragon
   values:
     prefix: names-dragon-dataset-
-    count: 31
+    count: 32 # Starlight
 
 - type: localizedDataset
   id: NamesDragonTitle

--- a/Resources/Prototypes/Datasets/Names/ninja.yml
+++ b/Resources/Prototypes/Datasets/Names/ninja.yml
@@ -2,10 +2,10 @@
   id: NamesNinja
   values:
     prefix: names-ninja-dataset-
-    count: 39
+    count: 41 # Starlight
 
 - type: localizedDataset
   id: NamesNinjaTitle
   values:
     prefix: names-ninja-title-dataset-
-    count: 46
+    count: 48 # Starlight

--- a/Resources/Prototypes/Datasets/Names/regalrat.yml
+++ b/Resources/Prototypes/Datasets/Names/regalrat.yml
@@ -8,4 +8,4 @@
   id: NamesRegalratTitle
   values:
     prefix: names-regal-rat-title-dataset-
-    count: 17
+    count: 19 # Starlight


### PR DESCRIPTION
## Short description
Restores the random Ninja, Dragon, and Rat King names removed by [this pr](https://github.com/ss14Starlight/space-station-14/pull/1137).

## Why we need to add this
They're really not LRP, when the lore for Ninjas is they're space weebs who dress like ninjas, Dragons are *space dragons*, and, does the giant talking rat with the mob boss accent being named Cheese Enjoyer really break your immersion, but Disposals President doesn't?

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Removed ghost role names restored.
