### PR TITLE
Replace usages of Owner with Entity<T>

### DIFF
--- a/Content.Client/_Starlight/Overlay/Trail/TrailOverlay.cs
+++ b/Content.Client/_Starlight/Overlay/Trail/TrailOverlay.cs
@@ -39,13 +39,13 @@ public sealed class TrailOverlay : Robust.Client.Graphics.Overlay
 
         var drawn = 0;
         var query = _entMan.EntityQueryEnumerator<TrailComponent, SpriteComponent>();
-        while (query.MoveNext(out var comp, out var sprite))
+        while (query.MoveNext(out var uid, out var comp, out var sprite))
         {
             if (comp.Mode == TrailMode.SpriteGhost)
             {
                 if (comp.Samples.Count < 2)
                     continue;
-                DrawGhostTrail(handle, comp, sprite, args);
+                DrawGhostTrail(handle, (uid, comp, sprite), args);
             }
             else
             {
@@ -171,39 +171,37 @@ public sealed class TrailOverlay : Robust.Client.Graphics.Overlay
             handle.UseShader(null);
     }
 
-    private void DrawGhostTrail(DrawingHandleWorld handle, TrailComponent comp, SpriteComponent sprite, in OverlayDrawArgs args)
+    private void DrawGhostTrail(DrawingHandleWorld handle, Entity<TrailComponent, SpriteComponent> ent, in OverlayDrawArgs args)
     {
-        var samples = comp.Samples;
+        var samples = ent.Comp1.Samples;
         var count = samples.Count;
 
-        var oldColor = sprite.Color;
+        var oldColor = ent.Comp2.Color;
 
-        if (sprite.Icon == null || count == 0)
+        if (ent.Comp2.Icon == null || count == 0)
             return;
 
-        for (int i = 0; i < count; i++)
+        for (var i = 0; i < count; i++)
         {
-            if (comp.SkipSamples > 0 && (i % (comp.SkipSamples + 1)) != 0)
+            if (ent.Comp1.SkipSamples > 0 && (i % (ent.Comp1.SkipSamples + 1)) != 0)
                 continue;
 
             var sample = samples[i];
-            float t = i / (float)(count - 1);
+            var t = i / (float)(count - 1);
 
-            float alpha = t * t * (3f - 2f * t);
-            alpha *= comp.TrailColor.A;
+            var alpha = t * t * (3f - 2f * t);
+            alpha *= ent.Comp1.TrailColor.A;
 
             if (alpha < 0.05f)
                 continue;
 
-            var color = Color.InterpolateBetween(comp.FadeColor, comp.TrailColor, t).WithAlpha(alpha);
+            var color = Color.InterpolateBetween(ent.Comp1.FadeColor, ent.Comp1.TrailColor, t).WithAlpha(alpha);
 
-            var ent = (sprite.Owner, sprite);
+            _spriteSys.SetColor((ent, ent.Comp2), color);
 
-            ent.sprite.Color = color;
+            _spriteSys.RenderSprite((ent, ent.Comp2), handle, sample.EyeRotation, sample.Rotation, sample.Position, null);
 
-            _spriteSys.RenderSprite(ent, handle, sample.EyeRotation, sample.Rotation, sample.Position, null);
-
-            ent.sprite.Color = oldColor;
+            _spriteSys.SetColor((ent, ent.Comp2), oldColor);
         }
     }
 }

--- a/Content.Server/Shuttles/Events/DockEvent.cs
+++ b/Content.Server/Shuttles/Events/DockEvent.cs
@@ -7,8 +7,10 @@ namespace Content.Server.Shuttles.Events;
 /// </summary>
 public sealed class DockEvent : EntityEventArgs
 {
+    // Starlight-start
     public Entity<DockingComponent> DockA = default!;
     public Entity<DockingComponent> DockB = default!;
+    // Starlight-end
 
     public EntityUid GridAUid = default!;
     public EntityUid GridBUid = default!;

--- a/Content.Server/Shuttles/Events/DockEvent.cs
+++ b/Content.Server/Shuttles/Events/DockEvent.cs
@@ -7,8 +7,8 @@ namespace Content.Server.Shuttles.Events;
 /// </summary>
 public sealed class DockEvent : EntityEventArgs
 {
-    public DockingComponent DockA = default!;
-    public DockingComponent DockB = default!;
+    public Entity<DockingComponent> DockA = default!;
+    public Entity<DockingComponent> DockB = default!;
 
     public EntityUid GridAUid = default!;
     public EntityUid GridBUid = default!;

--- a/Content.Server/Shuttles/Events/UndockEvent.cs
+++ b/Content.Server/Shuttles/Events/UndockEvent.cs
@@ -7,8 +7,10 @@ namespace Content.Server.Shuttles.Events;
 /// </summary>
 public sealed class UndockEvent : EntityEventArgs
 {
+    // Starlight-start
     public Entity<DockingComponent> DockA = default!;
     public Entity<DockingComponent> DockB = default!;
+    // Starlight-end
 
     public EntityUid GridAUid = default!;
     public EntityUid GridBUid = default!;

--- a/Content.Server/Shuttles/Events/UndockEvent.cs
+++ b/Content.Server/Shuttles/Events/UndockEvent.cs
@@ -7,8 +7,8 @@ namespace Content.Server.Shuttles.Events;
 /// </summary>
 public sealed class UndockEvent : EntityEventArgs
 {
-    public DockingComponent DockA = default!;
-    public DockingComponent DockB = default!;
+    public Entity<DockingComponent> DockA = default!;
+    public Entity<DockingComponent> DockB = default!;
 
     public EntityUid GridAUid = default!;
     public EntityUid GridBUid = default!;

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -142,8 +142,8 @@ namespace Content.Server.Shuttles.Systems
 
             var msg = new UndockEvent
             {
-                DockA = dockA,
-                DockB = dockB,
+                DockA = (dockAUid, dockA),
+                DockB = (dockBUid.Value, dockB),
                 GridAUid = gridAUid!.Value,
                 GridBUid = gridBUid!.Value,
             };

--- a/Content.Server/Shuttles/Systems/DockingSystem.cs
+++ b/Content.Server/Shuttles/Systems/DockingSystem.cs
@@ -142,8 +142,10 @@ namespace Content.Server.Shuttles.Systems
 
             var msg = new UndockEvent
             {
+                // Starlight-start
                 DockA = (dockAUid, dockA),
                 DockB = (dockBUid.Value, dockB),
+                // Starlight-end
                 GridAUid = gridAUid!.Value,
                 GridBUid = gridBUid!.Value,
             };

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -37,11 +37,13 @@ public sealed partial class StoreSystem
             }
         }
 
+        // Starlight-start
         ent.Comp.FullListingsCatalog = newState;
 
         // STARLIGHT: Check if a rift has been destroyed and update the listing accordingly
         // This ensures the rift listing remains unavailable even after reopening the uplink
         _revSupplyRift.CheckRiftDestroyedAndUpdateListing(ent);
+        // Starlight-end
     }
 
     /// <summary>

--- a/Content.Server/Store/Systems/StoreSystem.Listings.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Listings.cs
@@ -13,10 +13,10 @@ public sealed partial class StoreSystem
     /// Refreshes all listings on a store.
     /// Do not use if you don't know what you're doing.
     /// </summary>
-    /// <param name="component">The store to refresh</param>
-    public void RefreshAllListings(StoreComponent component)
+    /// <param name="ent">The store to refresh</param>
+    public void RefreshAllListings(Entity<StoreComponent> ent)
     {
-        var previousState = component.FullListingsCatalog;
+        var previousState = ent.Comp.FullListingsCatalog;
         var newState = GetAllListings();
         // if we refresh list with existing cost modifiers - they will be removed,
         // need to restore them
@@ -37,11 +37,11 @@ public sealed partial class StoreSystem
             }
         }
 
-        component.FullListingsCatalog = newState;
+        ent.Comp.FullListingsCatalog = newState;
 
         // STARLIGHT: Check if a rift has been destroyed and update the listing accordingly
         // This ensures the rift listing remains unavailable even after reopening the uplink
-        _revSupplyRift.CheckRiftDestroyedAndUpdateListing(component);
+        _revSupplyRift.CheckRiftDestroyedAndUpdateListing(ent);
     }
 
     /// <summary>

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -110,7 +110,7 @@ public sealed partial class StoreSystem
 
         // STARLIGHT: Check if a rift has been destroyed and update the listing accordingly
         // This ensures the rift listing remains unavailable even when the UI is refreshed
-        _revSupplyRift.CheckRiftDestroyedAndUpdateListing(component);
+        _revSupplyRift.CheckRiftDestroyedAndUpdateListing((store, component));
 
         //this is the person who will be passed into logic for all listing filtering.
         if (user != null) //if we have no "buyer" for this update, then don't update the listings
@@ -391,7 +391,7 @@ public sealed partial class StoreSystem
                 continue;
 
             // Refresh all listings to ensure they have the latest stock count and last purchaser information
-            RefreshAllListings(storeComp);
+            RefreshAllListings((uid, storeComp));
 
             // Force a refresh of the available listings
             if (storeComp.AccountOwner != null)
@@ -543,7 +543,7 @@ public sealed partial class StoreSystem
         }
 
         // Reset store back to its original state
-        RefreshAllListings(component);
+        RefreshAllListings((uid, component));
         component.BalanceSpent = new();
         UpdateUserInterface(buyer, uid, component);
     }

--- a/Content.Server/Store/Systems/StoreSystem.Ui.cs
+++ b/Content.Server/Store/Systems/StoreSystem.Ui.cs
@@ -391,7 +391,9 @@ public sealed partial class StoreSystem
                 continue;
 
             // Refresh all listings to ensure they have the latest stock count and last purchaser information
+            // Starlight-start
             RefreshAllListings((uid, storeComp));
+            // Starlight-end
 
             // Force a refresh of the available listings
             if (storeComp.AccountOwner != null)
@@ -543,7 +545,9 @@ public sealed partial class StoreSystem
         }
 
         // Reset store back to its original state
+        // Starlight-start
         RefreshAllListings((uid, component));
+        // Starlight-end
         component.BalanceSpent = new();
         UpdateUserInterface(buyer, uid, component);
     }

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -60,10 +60,11 @@ public sealed partial class StoreSystem : EntitySystem
 
     private void OnMapInit(EntityUid uid, StoreComponent component, MapInitEvent args)
     {
-        // STARLIGHT: Ensure the store has a StockLimitedProcessingComponent
+        // Starlight-start: Ensure the store has a StockLimitedProcessingComponent
         EnsureComp<StockLimitedProcessingComponent>(uid);
 
         RefreshAllListings((uid, component));
+        // Starlight-end
         component.StartingMap = Transform(uid).MapUid;
     }
 
@@ -72,7 +73,9 @@ public sealed partial class StoreSystem : EntitySystem
         // for traitors, because the StoreComponent for the PDA can be added at any time.
         if (MetaData(uid).EntityLifeStage == EntityLifeStage.MapInitialized)
         {
+            // Starlight-start
             RefreshAllListings((uid, component));
+            // Starlight-end
         }
 
         var ev = new StoreAddedEvent();

--- a/Content.Server/Store/Systems/StoreSystem.cs
+++ b/Content.Server/Store/Systems/StoreSystem.cs
@@ -63,7 +63,7 @@ public sealed partial class StoreSystem : EntitySystem
         // STARLIGHT: Ensure the store has a StockLimitedProcessingComponent
         EnsureComp<StockLimitedProcessingComponent>(uid);
 
-        RefreshAllListings(component);
+        RefreshAllListings((uid, component));
         component.StartingMap = Transform(uid).MapUid;
     }
 
@@ -72,7 +72,7 @@ public sealed partial class StoreSystem : EntitySystem
         // for traitors, because the StoreComponent for the PDA can be added at any time.
         if (MetaData(uid).EntityLifeStage == EntityLifeStage.MapInitialized)
         {
-            RefreshAllListings(component);
+            RefreshAllListings((uid, component));
         }
 
         var ev = new StoreAddedEvent();

--- a/Content.Server/_Starlight/Atmos/EntitySystems/PipeDockingSystem.cs
+++ b/Content.Server/_Starlight/Atmos/EntitySystems/PipeDockingSystem.cs
@@ -53,11 +53,8 @@ public sealed partial class PipeDockingSystem : EntitySystem
         if (!DockPipes)
             return;
 
-        if (!TryGetDockEntity(ev.DockA, out var dockA) || !TryGetDockEntity(ev.DockB, out var dockB))
-            return;
-
-        GetDockConnectingPipes(dockA, _dockAPipes);
-        GetDockConnectingPipes(dockB, _dockBPipes);
+        GetDockConnectingPipes(ev.DockA, _dockAPipes);
+        GetDockConnectingPipes(ev.DockB, _dockBPipes);
 
         foreach (var pipeA in _dockAPipes)
         {
@@ -73,11 +70,8 @@ public sealed partial class PipeDockingSystem : EntitySystem
 
     private void OnUndocked(UndockEvent ev)
     {
-        if (!TryGetDockEntity(ev.DockA, out var dockA) || !TryGetDockEntity(ev.DockB, out var dockB))
-            return;
-
-        GetDockConnectingPipes(dockA, _dockAPipes, includeDisabled: true);
-        GetDockConnectingPipes(dockB, _dockBPipes, includeDisabled: true);
+        GetDockConnectingPipes(ev.DockA, _dockAPipes, includeDisabled: true);
+        GetDockConnectingPipes(ev.DockB, _dockBPipes, includeDisabled: true);
 
         foreach (var pipeA in _dockAPipes)
         {
@@ -334,14 +328,6 @@ public sealed partial class PipeDockingSystem : EntitySystem
         tile = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
         return true;
     }
-
-#pragma warning disable CS0618 // Using .Owner for Performance.
-    private static bool TryGetDockEntity(DockingComponent component, out EntityUid uid)
-    {
-        uid = component.Owner;
-        return true;
-    }
-#pragma warning restore CS0618
 
     private void LinkPipes(PipeNode a, PipeNode b)
     {

--- a/Content.Server/_Starlight/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Starlight/Changeling/ChangelingSystem.cs
@@ -396,7 +396,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         {
             Name = metadata.EntityName,
             DNA = dna.DNA,
-            Appearance = appearance
+            Appearance = (target, appearance)
         };
 
         if (fingerprint.Fingerprint != null)
@@ -444,7 +444,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
         if (data != null)
         {
-            if (!_proto.TryIndex(data.Appearance.Species, out var species))
+            if (!_proto.TryIndex(data.Appearance.Comp.Species, out var species))
                 return null;
             pid = species.Prototype;
         }

--- a/Content.Server/_Starlight/Power/CableDockingSystem.cs
+++ b/Content.Server/_Starlight/Power/CableDockingSystem.cs
@@ -57,11 +57,8 @@ public sealed partial class CableDockingSystem : EntitySystem
 
     private void OnDocked(DockEvent ev)
     {
-        if (!TryGetDockEntity(ev.DockA, out var dockA) || !TryGetDockEntity(ev.DockB, out var dockB))
-            return;
-
-        GetDockCableNodes(dockA, _dockACables);
-        GetDockCableNodes(dockB, _dockBCables);
+        GetDockCableNodes(ev.DockA, _dockACables);
+        GetDockCableNodes(ev.DockB, _dockBCables);
 
         foreach (var cableA in _dockACables)
         {
@@ -77,11 +74,8 @@ public sealed partial class CableDockingSystem : EntitySystem
 
     private void OnUndocked(UndockEvent ev)
     {
-        if (!TryGetDockEntity(ev.DockA, out var dockA) || !TryGetDockEntity(ev.DockB, out var dockB))
-            return;
-
-        GetDockCableNodes(dockA, _dockACables);
-        GetDockCableNodes(dockB, _dockBCables);
+        GetDockCableNodes(ev.DockA, _dockACables);
+        GetDockCableNodes(ev.DockB, _dockBCables);
 
         foreach (var cableA in _dockACables)
         {
@@ -96,14 +90,14 @@ public sealed partial class CableDockingSystem : EntitySystem
 
     #region Cable Query
 
-    public IEnumerable<CableNode> GetDockCableNodes(EntityUid dock)
+    public IEnumerable<CableNode> GetDockCableNodes(Entity<DockingComponent> dock)
     {
         var result = new List<CableNode>();
         GetDockCableNodes(dock, result);
         return result;
     }
 
-    private void GetDockCableNodes(EntityUid dock, List<CableNode> result)
+    private void GetDockCableNodes(Entity<DockingComponent> dock, List<CableNode> result)
     {
         result.Clear();
 
@@ -118,7 +112,7 @@ public sealed partial class CableDockingSystem : EntitySystem
 
         foreach (var ent in _mapSystem.GetAnchoredEntities(xform.GridUid.Value, grid, dockTile))
         {
-            if (ent == dock)
+            if (ent == dock.Owner)
                 continue;
 
             if (!TryComp<NodeContainerComponent>(ent, out var nodeContainer))
@@ -190,10 +184,14 @@ public sealed partial class CableDockingSystem : EntitySystem
             if (ent == node.Owner)
                 continue;
 
-            if (!TryComp<DockingComponent>(ent, out var docking) || docking.DockedWith is not { } otherDock)
+            if (!TryComp<DockingComponent>(ent, out var docking) ||
+                docking.DockedWith is not { } otherDock ||
+                !TryComp(otherDock, out DockingComponent? otherDockComp))
+            {
                 continue;
+            }
 
-            GetDockCableNodes(otherDock, _otherCables);
+            GetDockCableNodes((otherDock, otherDockComp), _otherCables);
 
             foreach (var otherCable in _otherCables)
             {
@@ -257,14 +255,6 @@ public sealed partial class CableDockingSystem : EntitySystem
         tile = _mapSystem.TileIndicesFor(gridUid, grid, xform.Coordinates);
         return true;
     }
-
-#pragma warning disable CS0618 // Using .Owner for Performance.
-    private static bool TryGetDockEntity(DockingComponent component, out EntityUid uid)
-    {
-        uid = component.Owner;
-        return true;
-    }
-#pragma warning restore CS0618
 
     private void LinkCables(CableNode a, CableNode b)
     {

--- a/Content.Server/_Starlight/Revolutionary/RevSupplyRiftSystem.cs
+++ b/Content.Server/_Starlight/Revolutionary/RevSupplyRiftSystem.cs
@@ -73,6 +73,8 @@ public sealed partial class RevSupplyRiftSystem : EntitySystem
     /// </summary>
     private bool _isProcessingRift = false;
 
+    private readonly List<EntityUid> _nearbyHumanoids = new();
+
     public override void Initialize()
     {
         base.Initialize();
@@ -209,20 +211,25 @@ public sealed partial class RevSupplyRiftSystem : EntitySystem
             var riftTransform = Transform(uid);
 
             // Get all entities with HumanoidAppearanceComponent within a small radius
-            var nearbyHumanoids = EntityManager.EntityQuery<HumanoidAppearanceComponent, TransformComponent>()
-                .Where(pair =>
+            _nearbyHumanoids.Clear();
+            var query = EntityQueryEnumerator<HumanoidAppearanceComponent, TransformComponent>();
+            while (query.MoveNext(out var nearbyUid, out var nearbyHumanoid, out var nearbyTransform))
+            {
+                // 2 unit radius
+                if (riftTransform.MapID != nearbyTransform.MapID ||
+                    (_transform.GetWorldPosition(riftTransform) - _transform.GetWorldPosition(nearbyTransform))
+                    .LengthSquared() >= 4)
                 {
-                    var (_, otherTransform) = pair;
-                    return riftTransform.MapID == otherTransform.MapID &&
-                           (_transform.GetWorldPosition(riftTransform) - _transform.GetWorldPosition(otherTransform)).LengthSquared() < 4; // 2 unit radius
-                })
-                .Select(pair => pair.Item1.Owner)
-                .ToList();
+                    continue;
+                }
 
-            if (nearbyHumanoids.Count > 0)
+                _nearbyHumanoids.Add(nearbyUid);
+            }
+
+            if (_nearbyHumanoids.Count > 0)
             {
                 // Use the first nearby humanoid
-                var humanoid = nearbyHumanoids[0];
+                var humanoid = _nearbyHumanoids[0];
                 var name = Identity.Name(humanoid, EntityManager);
 
                 if (!string.IsNullOrEmpty(name))
@@ -461,11 +468,11 @@ public sealed partial class RevSupplyRiftSystem : EntitySystem
         int activeRiftCount = 0;
         EntityUid rift = default; // there has to be a better way to do this? (starlight)
         var riftsQuery = EntityQueryEnumerator<RevSupplyRiftComponent, DragonRiftComponent>();
-        while (riftsQuery.MoveNext(out _, out var revRift, out var dragonRift))
+        while (riftsQuery.MoveNext(out var uid, out var revRift, out var dragonRift))
         {
             if (revRift.State == DragonRiftState.Finished)
             {
-                rift = revRift.Owner;
+                rift = uid;
                 activeRiftCount++;
             }
 
@@ -553,22 +560,22 @@ public sealed partial class RevSupplyRiftSystem : EntitySystem
     /// Checks if a rift has been destroyed and updates the listing accordingly.
     /// This is called by the StoreSystem whenever listings are refreshed.
     /// </summary>
-    /// <param name="storeComp">The store component being refreshed</param>
-    public void CheckRiftDestroyedAndUpdateListing(StoreComponent storeComp)
+    /// <param name="ent">The store being refreshed</param>
+    public void CheckRiftDestroyedAndUpdateListing(Entity<StoreComponent> ent)
     {
         // If no rift has been destroyed, we don't need to do anything
         if (!_riftDestroyed)
             return;
 
         // Find the supply rift listing
-        foreach (var listing in storeComp.FullListingsCatalog)
+        foreach (var listing in ent.Comp.FullListingsCatalog)
         {
             if (listing.ID == RevSupplyRiftListingId)
             {
                 // Store the original description if we haven't already
-                if (!_originalDescriptions.TryGetValue(storeComp.Owner, out _))
+                if (!_originalDescriptions.TryGetValue(ent, out _))
                 {
-                    _originalDescriptions[storeComp.Owner] = listing.Description ?? "";
+                    _originalDescriptions[ent] = listing.Description ?? "";
                 }
 
                 // Update the description with the destroyed message

--- a/Content.Shared/_Starlight/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/_Starlight/Changeling/ChangelingComponent.cs
@@ -174,5 +174,5 @@ public sealed partial class TransformData
     ///     Entity's humanoid appearance component.
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly), NonSerialized]
-    public HumanoidAppearanceComponent Appearance;
+    public Entity<HumanoidAppearanceComponent> Appearance;
 }


### PR DESCRIPTION
# PLEASE ADD "DO NOT USE COMPONENT.OWNER" TO YOUR AI REVIEW BOT SO THAT I DO NOT NEED TO KEEP MAKING THESE PRS

## Short description
<!-- What do you propose to change with your PR? -->
From the creators of https://github.com/ss14Starlight/space-station-14/pull/4242
1 and 2 years after it was added, somehow, it is still not being used
Pray I don't have to keep making these PRs and people do not ignore the giant warning their IDE gives them
<img width="1186" height="219" alt="Ed4WA5W9ky" src="https://github.com/user-attachments/assets/cff021c7-6799-4532-abab-11835e469cb4" />

I removed the pragma warning disable / comment that said it was accessing Component.Owner for performance because that makes no sense
The remaining usage in gas reactions is not changed in this PR since that would make a much bigger diff
StoreSystem changes are in a different commit since that's what I actually care about downstream and because it's upstream files mostly

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Need it to not get an aneurysm using StoreSystem code downstream

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Gets ingame, store opens
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/ed7cd22d-bb78-408f-86b8-8ee71eef2a75" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
