### PR TITLE
Avali, Reptillians, and Noctiliae can now eat Phenylpiperidine crystals

### DIFF
--- a/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
+++ b/Resources/Prototypes/_Mono/Entities/Objects/Misc/solids.yml
@@ -41,3 +41,6 @@
           collection: GlassBreak
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
+  - type: Tag # Starlight start
+    tags:
+    - Pill # Starlight end


### PR DESCRIPTION
## Short description
Avali, Reptillians, and Noctiliae can now eat Phenylpiperidine crystals.

## Why we need to add this
They couldn't eat it before, due to their special stomachs.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Avali, Reptillians, and Noctiliae can now eat Phenylpiperidine crystals.

