### PR TITLE
Adds a maintenance door variant for Journalism access

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -16,3 +16,12 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsJournalism ]
+
+#region Starlight
+- type: entity
+  parent: AirlockJournalismLocked # Starlight
+  id: AirlockMaintJournalismLocked # Starlight
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+#endregion Starlight

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Doors/Airlocks/access.yml
@@ -16,12 +16,3 @@
   - type: ContainerFill
     containers:
       board: [ DoorElectronicsJournalism ]
-
-#region Starlight
-- type: entity
-  parent: AirlockJournalismLocked # Starlight
-  id: AirlockMaintJournalismLocked # Starlight
-  components:
-  - type: Sprite
-    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
-#endregion Starlight

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Airlocks/access.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Doors/Airlocks/access.yml
@@ -362,6 +362,13 @@
   - type: Sprite
     sprite: Structures/Doors/Airlocks/Standard/maint.rsi
 
+- type: entity
+  parent: AirlockJournalismLocked
+  id: AirlockMaintJournalismLocked
+  components:
+  - type: Sprite
+    sprite: Structures/Doors/Airlocks/Standard/maint.rsi
+
 # Courtroom
 - type: entity
   parent: AirlockSecurityLocked


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds `AirlockMaintJournalismLocked`, a maints door version of `AirlockJournalismLocked`

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
**Required for mapping!** 

This is a blocker for Radio Host getting mapped (and for Reporters getting their doors swapped to Journalism access, too!).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="621" height="468" alt="image" src="https://github.com/user-attachments/assets/57a7d91f-4c14-4d42-a525-ae47e873572e" />
<img width="478" height="185" alt="image" src="https://github.com/user-attachments/assets/579e2f8d-7c65-4467-9c1d-7c701f6e4228" />

fig. 1 - Maints door.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
