### PR TITLE
Radio Host Immediate Fixes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -634,7 +634,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (session.AttachedEntity is not { Valid: true } listener) // Starlight-edit: Languages
                 continue;
 
-            if (MessageRangeCheck(session, data, range) != MessageRangeCheckResult.Full)
+            // Moffstation - Start - Radio Host, hide chat messages from station radio
+            var rangeCheck = MessageRangeCheck(session, data, range);
+            if (rangeCheck == MessageRangeCheckResult.Disallowed)
+            // Moffstation - End
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
             // Starlight - Start
@@ -673,7 +676,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 wrappedMessage = WrapWhisperMessage(source, "chat-manager-entity-whisper-unknown-wrap-message", string.Empty, result, language, obfuscated);
             }
 
-            _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, false, session.Channel);
+            _chatManager.ChatMessageToOne(ChatChannel.Whisper, result, wrappedMessage, source, rangeCheck == MessageRangeCheckResult.HideChat, session.Channel); // Moffstation - Radio Host, hide chat messages from station radio
             // Starlight - End
         }
 

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.Chat.Systems;
 using Content.Server.Interaction;
 using Content.Server.Popups;
 using Content.Server.Power.EntitySystems;
+using Content.Shared._Goobstation.StationRadio.Components;
 using Content.Shared.Chat;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -14,6 +15,7 @@ using Content.Shared.Speech;
 using Content.Shared.Speech.Components;
 using Robust.Shared.Prototypes;
 using Content.Shared.Power.EntitySystems; // Goobstation - Radio Host
+using Content.Shared._Goobstation.StationRadio.Components; // Goobstation - Radio Host
 
 #region Starlight
 using Content.Server._Starlight.Language;
@@ -195,7 +197,7 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
 
     private void OnReceiveRadio(EntityUid uid, RadioSpeakerComponent component, ref RadioReceiveEvent args)
     {
-        if (uid == args.RadioSource || component.PowerRequired && !_power.IsPowered(uid)) // Goobstation - Radio Host - Powered required
+        if (uid == args.RadioSource || !_power.IsPowered(uid)) // Goobstation - Radio Host
             return;
 
         var nameEv = new TransformSpeakerNameEvent(args.MessageSource, Name(args.MessageSource));
@@ -205,10 +207,17 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
             ("speaker", Name(uid)),
             ("originalName", nameEv.VoiceName));
 
+        // Starlight - Start - Radio Host
+        var chatType = TryComp<StationRadioReceiverComponent>(uid, out var receiverComp) && receiverComp.LowVolume
+            ? InGameICChatType.Whisper
+            : InGameICChatType.Speak;
+        // Starlight - End
+
         // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
         var message = args.OriginalChatMsg.Message; // Starlight-edit: The chat system will handle the rest and re-obfuscate if needed.
-        _chat.TrySendInGameICMessage(uid, message, InGameICChatType.Whisper, ChatTransmitRange.GhostRangeLimit, nameOverride: name,
-            checkRadioPrefix: component.ParseRadioPrefix, // Starlight - Radio Host, change LouderSpeech to ParseRadioPrefix
+        _chat.TrySendInGameICMessage(uid, message,
+            chatType, // Starlight - Radio Host (ChatTransmitRange.GhostRangeLimit -> chatType)
+            ChatTransmitRange.GhostRangeLimit, nameOverride: name, checkRadioPrefix: false,
             languageOverride: args.Language); // Starlight
     }
 

--- a/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioDeviceSystem.cs
@@ -208,16 +208,21 @@ public sealed partial class RadioDeviceSystem : SharedRadioDeviceSystem
             ("originalName", nameEv.VoiceName));
 
         // Starlight - Start - Radio Host
-        var chatType = TryComp<StationRadioReceiverComponent>(uid, out var receiverComp) && receiverComp.LowVolume
-            ? InGameICChatType.Whisper
-            : InGameICChatType.Speak;
+        var chatType = InGameICChatType.Whisper; // Default, messages from radios are sent as whispers.
+        var transmitRange = ChatTransmitRange.GhostRangeLimit; // Default, all ghosts can hear whispers from radios.
+        if (TryComp<StationRadioReceiverComponent>(uid, out var receiverComp))
+        {
+            transmitRange = ChatTransmitRange.HideChat; // Message hidden from chat if from a Station Radio.
+            chatType = receiverComp.LowVolume ? InGameICChatType.Whisper : InGameICChatType.Speak; // Radios will talk loudly if at full volume.
+        }
         // Starlight - End
 
         // log to chat so people can identity the speaker/source, but avoid clogging ghost chat if there are many radios
         var message = args.OriginalChatMsg.Message; // Starlight-edit: The chat system will handle the rest and re-obfuscate if needed.
         _chat.TrySendInGameICMessage(uid, message,
-            chatType, // Starlight - Radio Host (ChatTransmitRange.GhostRangeLimit -> chatType)
-            ChatTransmitRange.GhostRangeLimit, nameOverride: name, checkRadioPrefix: false,
+            chatType, // Starlight - Radio Host (InGameICChatType.Whisper -> chatType)
+            transmitRange,// Starlight - Radio Host (ChatTransmitRange.GhostRangeLimit -> transmitRange)
+            nameOverride: name, checkRadioPrefix: false,
             languageOverride: args.Language); // Starlight
     }
 

--- a/Content.Shared/Radio/Components/RadioSpeakerComponent.cs
+++ b/Content.Shared/Radio/Components/RadioSpeakerComponent.cs
@@ -25,20 +25,4 @@ public sealed partial class RadioSpeakerComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool Enabled;
-
-    // Starlight - Radio Host LouderSpeech -> ParseRadioPrefix.
-    /// <summary>
-    /// Whether or not a message is parsed through the radio when when sent in local chat.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public bool ParseRadioPrefix;
-    // Starlight - End
-
-    // Goobstation - Radio Host
-    /// <summary>
-    /// Does the radio need to be on a power grid to work?
-    /// </summary>
-    [DataField]
-    public bool PowerRequired;
-    // Goobstation - End
 }

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -59,6 +59,7 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<StationRadioServerComponent, ExaminedEvent>(OnExamined);
+        SubscribeLocalEvent<IntercomComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
     }
 
     /// <summary>

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -1,5 +1,7 @@
 using Content.Shared.Popups;
 using Content.Shared.Radio.Components;
+using Content.Shared._Goobstation.StationRadio.Components; // Starlight  - Examine the station radio server to see if microphone is active.
+using Content.Shared.Examine; // Starlight  - Examine the station radio server to see if microphone is active.
 
 namespace Content.Shared.Radio.EntitySystems;
 
@@ -47,6 +49,27 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
             EnsureComp<ActiveRadioComponent>(uid).Channels.UnionWith(component.Channels);
         else
             RemCompDeferred<ActiveRadioComponent>(uid);
+    }
+    #endregion
+
+    #region Starlight
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<StationRadioServerComponent, ExaminedEvent>(OnExamined);
+    }
+
+    /// <summary>
+    /// Examining a Radio Station Server will now tell you if it is recording or not.
+    /// </summary>
+    private void OnExamined(EntityUid uid, StationRadioServerComponent comp, ref ExaminedEvent args)
+    {
+        if (!TryComp<RadioMicrophoneComponent>(uid, out var mic))
+            return;
+
+        args.PushMarkup(Loc.GetString(mic.Enabled
+            ? "station-radio-server-examine-recording"
+            : "station-radio-server-examine-not-recording"));
     }
     #endregion
 }

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -53,8 +53,8 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
     #endregion
 
     // Starlight - Start
-    #region Starlight 
-    
+    #region Starlight
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -52,7 +52,9 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
     }
     #endregion
 
-    #region Starlight
+    // Starlight - Start
+    #region Starlight 
+    
     public override void Initialize()
     {
         base.Initialize();
@@ -68,9 +70,10 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
             return;
 
         args.PushMarkup(Loc.GetString(mic.Enabled
-            ? "station-radio-server-examine-recording"
-            : "station-radio-server-examine-not-recording"));
+            ? "station-radio-server-examine-not-recording"
+            : "station-radio-server-examine-recording"));
     }
     #endregion
+    // Starlight - End
 }
 

--- a/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
+++ b/Content.Shared/Radio/EntitySystems/SharedRadioDeviceSystem.cs
@@ -59,7 +59,6 @@ public abstract partial class SharedRadioDeviceSystem : EntitySystem
     {
         base.Initialize();
         SubscribeLocalEvent<StationRadioServerComponent, ExaminedEvent>(OnExamined);
-        SubscribeLocalEvent<IntercomComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
     }
 
     /// <summary>

--- a/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
@@ -5,7 +5,7 @@ using Content.Shared.Power;
 using Content.Shared.Power.EntitySystems;
 using Robust.Shared.Audio.Systems;
 using Content.Shared.DeviceLinking; // Starlight - Remove Server Check from VinylSummonSystem
-using Content.Shared.Radio.Components; // Starlight - Alt click to lower volume.
+using Content.Shared.Examine; // Starlight - Shift Click to view what volume the radio is at.
 using Content.Shared.Verbs; // Starlight - Alt click to lower volume.
 using Robust.Shared.Network; // Starlight - Add Station Radio Resume Play
 using Robust.Shared.Timing; // Starlight - Add Station Radio Resume Play
@@ -35,6 +35,7 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
         SubscribeLocalEvent<RadioRigComponent, EntityTerminatingEvent>(OnRigTerminating); // Starlight - When Rig is destroyed, it should stop broadcasting.
 
         SubscribeLocalEvent<StationRadioReceiverComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs); // Starlight - Alt click to lower volume.
+        SubscribeLocalEvent<StationRadioReceiverComponent, ExaminedEvent>(OnExamined); // Starlight - Shift Click to view what volume the radio is at.
     }
 
     private void OnRadioToggle(EntityUid uid, StationRadioReceiverComponent comp, ActivateInWorldEvent args)
@@ -234,6 +235,16 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
         {
             RaiseLocalEvent(receiver, new StationRadioMediaStoppedEvent());
         }
+    }
+
+    /// <summary>
+    /// Display whether or not the station radio is at full or low volume when examined.
+    /// </summary>
+    private void OnExamined(EntityUid uid, StationRadioReceiverComponent comp, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString(comp.LowVolume
+            ? "station-radio-receiver-examine-low-volume"
+            : "station-radio-receiver-examine-full-volume"));
     }
     // Starlight - End
 }

--- a/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
@@ -133,6 +133,7 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
         }
     }
 
+    // Starlight - Start
     #region Starlight
     /// <summary>
     /// Method for getting the current volume of the station radio.
@@ -246,4 +247,5 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
             : "station-radio-receiver-examine-full-volume"));
     }
     #endregion
+    // Starlight - End
 }

--- a/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Systems/StationRadioReceiverSystem.cs
@@ -133,8 +133,7 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
         }
     }
 
-    // Starlight - Start - Remove Server Check from VinylSummonSystem
-
+    #region Starlight
     /// <summary>
     /// Method for getting the current volume of the station radio.
     /// </summary>
@@ -246,5 +245,5 @@ public sealed partial class StationRadioReceiverSystem : EntitySystem
             ? "station-radio-receiver-examine-low-volume"
             : "station-radio-receiver-examine-full-volume"));
     }
-    // Starlight - End
+    #endregion
 }

--- a/Content.Shared/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
@@ -4,11 +4,10 @@ using Content.Shared.Destructible;
 using Content.Shared.DeviceLinking;
 using Content.Shared.Power;
 using Content.Shared.Power.EntitySystems;
-using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Network;
-using Content.Shared._Goobstation.StationRadio.Systems; // Starlight - Remove Server Check from VinylSummonSystem
+using Content.Shared.Examine; // Starlight - Shift Click to view what Vinyl is inserted.
 using Robust.Shared.Timing; // Starlight - Add Station Radio Resume Play
 
 namespace Content.Shared._Goobstation.StationRadio.Systems; // Starlight - _Goob -> _Goobstation
@@ -22,6 +21,8 @@ public sealed partial class VinylPlayerSystem : EntitySystem
     [Dependency] private StationRadioReceiverSystem _stationRadio = default!; // Starlight - Remove Server Check from VinylSummonSystem
     [Dependency] private IGameTiming _timing = default!; // Starlight - Add Station Radio Resume Play
 
+    [Dependency] private readonly SharedContainerSystem _container = default!; // Starlight - Shift Click to view what Vinyl is inserted.
+
     public override void Initialize()
     {
         base.Initialize();
@@ -29,6 +30,8 @@ public sealed partial class VinylPlayerSystem : EntitySystem
         SubscribeLocalEvent<VinylPlayerComponent, EntRemovedFromContainerMessage>(OnVinylRemove);
         SubscribeLocalEvent<VinylPlayerComponent, DestructionEventArgs>(OnDestruction);
         SubscribeLocalEvent<VinylPlayerComponent, PowerChangedEvent>(OnPowerChanged);
+
+        SubscribeLocalEvent<VinylPlayerComponent, ExaminedEvent>(OnExamined); // Starlight - Shift Click to view what Vinyl is inserted.
     }
 
     private void OnPowerChanged(EntityUid uid, VinylPlayerComponent comp, PowerChangedEvent args)
@@ -154,4 +157,21 @@ public sealed partial class VinylPlayerSystem : EntitySystem
         }
         return false;
     }
+    // Starlight - Start - Shift Click to view what Vinyl is inserted.
+
+    /// <summary>
+    /// Show what vinyl is currently inserted when examined.
+    /// </summary>
+    private void OnExamined(EntityUid uid, VinylPlayerComponent comp, ref ExaminedEvent args)
+    {
+        if (!_container.TryGetContainer(uid, "vinyl", out var container) || container.ContainedEntities.Count == 0) // confirm actual container ID
+        {
+            args.PushMarkup(Loc.GetString("vinyl-player-examine-empty"));
+            return;
+        }
+
+        var vinyl = container.ContainedEntities[0];
+        args.PushMarkup(Loc.GetString("vinyl-player-examine-loaded", ("vinyl", Name(vinyl))));
+    }
+    // Starlight - End
 }

--- a/Content.Shared/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
+++ b/Content.Shared/_Goobstation/StationRadio/Systems/VinylPlayerSystem.cs
@@ -157,8 +157,8 @@ public sealed partial class VinylPlayerSystem : EntitySystem
         }
         return false;
     }
-    // Starlight - Start - Shift Click to view what Vinyl is inserted.
 
+    #region Starlight
     /// <summary>
     /// Show what vinyl is currently inserted when examined.
     /// </summary>
@@ -173,5 +173,5 @@ public sealed partial class VinylPlayerSystem : EntitySystem
         var vinyl = container.ContainedEntities[0];
         args.PushMarkup(Loc.GetString("vinyl-player-examine-loaded", ("vinyl", Name(vinyl))));
     }
-    // Starlight - End
+    #endregion
 }

--- a/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
@@ -10,3 +10,9 @@ signal-port-description-radio-server = The input of the radio server, connect a 
 vinyl-popout-no-station = The vinyl ejects itself, you're not on a station!
 vinyl-popout-no-power = The vinyl ejects itself, the player isn't powered!
 vinyl-popout-no-radio-connection = The vinyl ejects itself, the player isn't connected to the radio system!
+
+vinyl-player-examine-empty = It's empty.
+vinyl-player-examine-loaded = There's a copy of { $vinyl } inside.
+
+station-radio-receiver-examine-full-volume = It's playing at full volume.
+station-radio-receiver-examine-low-volume = It's playing at low volume.

--- a/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
@@ -11,6 +11,7 @@ vinyl-popout-no-station = The vinyl ejects itself, you're not on a station!
 vinyl-popout-no-power = The vinyl ejects itself, the player isn't powered!
 vinyl-popout-no-radio-connection = The vinyl ejects itself, the player isn't connected to the radio system!
 
+# Starlight - Station Radio Examination Text.
 vinyl-player-examine-empty = It's empty.
 vinyl-player-examine-loaded = There's a copy of { $vinyl } inside.
 
@@ -19,3 +20,4 @@ station-radio-receiver-examine-low-volume = It's playing at low volume.
 
 station-radio-server-examine-recording = The station server is not recording.
 station-radio-server-examine-not-recording = The station server is currently recording.
+# Starlight - End

--- a/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
+++ b/Resources/Locale/en-US/_Goobstation/machines/stationradio.ftl
@@ -16,3 +16,6 @@ vinyl-player-examine-loaded = There's a copy of { $vinyl } inside.
 
 station-radio-receiver-examine-full-volume = It's playing at full volume.
 station-radio-receiver-examine-low-volume = It's playing at low volume.
+
+station-radio-server-examine-recording = The station server is not recording.
+station-radio-server-examine-not-recording = The station server is currently recording.

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -18,6 +18,7 @@
   - Hydroponics # Starlight
   extendedAccess:
   - Theatre # Starlight
+  - Journalism # Starlight
 #  - Hydroponics # Starlight
 
 - type: startingGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -12,6 +12,7 @@
   access:
   - Service
   - Maintenance
+  - Journalism # Starlight
 
 - type: startingGear
   id: ReporterGear

--- a/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/StationRadio/radio_recievers.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Structures/Machines/StationRadio/radio_recievers.yml
@@ -46,8 +46,6 @@
   - type: Machine
     board: StationRadioCircuitboard
   - type: RadioSpeaker
-    powerRequired: true
-    parseRadioPrefix: false
     enabled: true
     channels:
     - RadioShow

--- a/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/loadout_groups.yml
@@ -1,7 +1,7 @@
 - type: loadoutGroup
   id: RadioHostJumpsuit
   name: loadout-group-radiohost-jumpsuit
-  minLimit: 0
+  minLimit: 1
   loadouts:
   - JumpsuitHawaiBlack
   - JumpsuitHawaiBlue

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
@@ -9,6 +9,7 @@
   access:
   - Maintenance
   - Journalism
+  - Service
 
 - type: startingGear
   id: RadioHostGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
@@ -13,6 +13,7 @@
 - type: startingGear
   id: RadioHostGear
   equipment:
+    id: RadioHostPDA
     ears: ClothingHeadsetAltRadioHost
     belt: ClothingBeltStorageWaistbag
 

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
@@ -56,6 +56,7 @@
     - Mining
     - SalvageLead
     - Debrief
+    - Journalism
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
@@ -52,6 +52,7 @@
     - Surgery
     - Paramedic
     - Debrief
+    - Journalism
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
So the chat range was not working on the first PR. I think in the demonstration video its also not working, I just accidentally gaslit myself into thinking it was working in testing cause the aghost has infinite whisper range.

Now it actually functions. By default...
Station Radios will relay messages normally.
If low volume mode is enabled, then it will whisper the message instead.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
🐛 🔫 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="356" height="185" alt="image" src="https://github.com/user-attachments/assets/b9b950f8-142d-49cd-873a-b7c5865e3d9e" />
<img width="350" height="151" alt="image" src="https://github.com/user-attachments/assets/fc64dc3d-d8a1-4d08-8117-ee7c1a0b36b4" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Huaqas
- fix: Radio Hosts will now spawn with their PDAs.
- fix: Radio Hosts can no longer spawn with no jumpsuit.
- fix: Station Radios should be easier to hear and will whisper when set to Low Volume mode.
- fix: Ghosts will no longer get spammed with messages from every station radio.
- add: Radio Hosts now have Service access.
- add: BSO, NTR and the Reporter now have Journalism access. Service Workers will receive Journalism access with their extended access.
- add: You can now examine a Vinyl Player to tell you what is currently inserted.
- add: You can now examine a Station Radio to tell what volume it is playing at.
- add: You can now examine a Station Radio Server to tell if it is recording or not.