### PR TITLE
Allow selection of multiple roles/departments when configuring access

### DIFF
--- a/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
+++ b/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
@@ -18,6 +18,13 @@ namespace Content.Client.Access.UI
         private readonly AccessLevelControl _accessButtons = new();
         private readonly AccessGroupControl _accessGroups = new();
         private readonly Dictionary<string, Button> _legacyAccessButtons = new();
+
+        /// <summary>
+        /// Every access set on the target, including those outside the selected group.
+        /// Only the selected group has buttons at any one time, so the rest are held here
+        /// and merged back in on submit rather than being dropped.
+        /// </summary>
+        private readonly HashSet<ProtoId<AccessLevelPrototype>> _pressedAccess = new();
         // Starlight-edit: End
 
         public event Action<List<ProtoId<AccessLevelPrototype>>>? OnSubmit;
@@ -57,15 +64,20 @@ namespace Content.Client.Access.UI
             // Wire up level presses -> submit list
             foreach (var (id, button) in _accessButtons.ButtonsList)
             {
-                button.OnPressed += _ =>
-                {
-                    OnSubmit?.Invoke(
-                        _accessButtons.ButtonsList.Where(x => x.Value.Pressed)
-                            .Select(x => new ProtoId<AccessLevelPrototype>(x.Key))
-                            .ToList());
-                    // Starlight-edit: End
-                };
+                button.OnPressed += _ => OnSubmit?.Invoke(BuildAccessList());
             }
+        }
+
+        /// <summary>
+        /// Layers the visible buttons' states over the accesses belonging to the other groups.
+        /// </summary>
+        private List<ProtoId<AccessLevelPrototype>> BuildAccessList()
+        {
+            var accessList = _pressedAccess.Where(x => !_accessButtons.ButtonsList.ContainsKey(x)).ToList();
+            accessList.AddRange(_accessButtons.ButtonsList.Where(x => x.Value.Pressed).Select(x => x.Key));
+
+            return accessList;
+            // Starlight-edit: End
         }
 
         public void UpdateState(IPrototypeManager protoManager, AccessOverriderBoundUserInterfaceState state)
@@ -131,6 +143,9 @@ namespace Content.Client.Access.UI
             var availableAccess = state.AvailableAccessLevels?.ToList() ?? new List<ProtoId<AccessLevelPrototype>>();
             var pressedAccess = state.PressedAccessLevels?.ToList() ?? new List<ProtoId<AccessLevelPrototype>>();
 
+            _pressedAccess.Clear();
+            _pressedAccess.UnionWith(pressedAccess);
+
             var groupsWithCoverage = new List<ProtoId<AccessGroupPrototype>>();
             if (availableAccess.Count > 0 && state.AccessGroups != null)
             {
@@ -190,10 +205,7 @@ namespace Content.Client.Access.UI
 
             foreach (var (id, button) in _accessButtons.ButtonsList)
             {
-                button.OnPressed += _ => OnSubmit?.Invoke(
-                    _accessButtons.ButtonsList.Where(x => x.Value.Pressed)
-                        .Select(x => new ProtoId<AccessLevelPrototype>(x.Key))
-                        .ToList());
+                button.OnPressed += _ => OnSubmit?.Invoke(BuildAccessList());
             // Starlight-edit: End
             }
         }

--- a/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
+++ b/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
@@ -18,14 +18,16 @@ namespace Content.Client.Access.UI
         private readonly AccessLevelControl _accessButtons = new();
         private readonly AccessGroupControl _accessGroups = new();
         private readonly Dictionary<string, Button> _legacyAccessButtons = new();
+        // Starlight-edit: End
 
+        #region Starlight
         /// <summary>
         /// Every access set on the target, including those outside the selected group.
         /// Only the selected group has buttons at any one time, so the rest are held here
         /// and merged back in on submit rather than being dropped.
         /// </summary>
         private readonly HashSet<ProtoId<AccessLevelPrototype>> _pressedAccess = new();
-        // Starlight-edit: End
+        #endregion
 
         public event Action<List<ProtoId<AccessLevelPrototype>>>? OnSubmit;
         public event Action<ProtoId<AccessGroupPrototype>>? OnGroupSelected; // Starlight-edit

--- a/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
+++ b/Content.Client/Access/UI/AccessOverriderWindow.xaml.cs
@@ -67,7 +67,9 @@ namespace Content.Client.Access.UI
                 button.OnPressed += _ => OnSubmit?.Invoke(BuildAccessList());
             }
         }
+        // Starlight-edit: End
 
+        #region Starlight
         /// <summary>
         /// Layers the visible buttons' states over the accesses belonging to the other groups.
         /// </summary>
@@ -77,8 +79,8 @@ namespace Content.Client.Access.UI
             accessList.AddRange(_accessButtons.ButtonsList.Where(x => x.Value.Pressed).Select(x => x.Key));
 
             return accessList;
-            // Starlight-edit: End
         }
+        #endregion
 
         public void UpdateState(IPrototypeManager protoManager, AccessOverriderBoundUserInterfaceState state)
         {

--- a/Content.Client/Doors/Electronics/DoorElectronicsConfigurationMenu.xaml.cs
+++ b/Content.Client/Doors/Electronics/DoorElectronicsConfigurationMenu.xaml.cs
@@ -107,7 +107,9 @@ public sealed partial class DoorElectronicsConfigurationMenu : DefaultWindow
                     _pressedLevels.Add(id);
                 else
                     _pressedLevels.Remove(id);
-                OnAccessChanged?.Invoke(_pressedLevels.Where(level => levels.Contains(level)).ToList());
+                // Submit every pressed access, not just the selected group's, or switching
+                // groups would wipe the accesses set from the previous one.
+                OnAccessChanged?.Invoke(_pressedLevels.ToList());
             };
         }
     // Starlight edit End


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Enables the multiool and access configurator to configure access from any department, no longer limited to one.


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Currently if you select an access level for a device, it is discarded if you select another department to add more roles. This change will remove this limitation.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/992f0d44-fb68-4638-8ed2-35cb2bed0a05


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- fix: Access configurators and multitools can now configure access spanning multiple departments.