### PR TITLE
Add two (2) combat gloves to the secvend

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/security.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/security.yml
@@ -31,7 +31,7 @@
   - SLSecurity
   conditions:
   - !type:ListingLimitedStockCondition
-    stock: 2
+    stock: 4
   - !type:BuyerAccessCondition
 
 - type: listing


### PR DESCRIPTION
## Short description
As titled

## Why we need to add this
The gloves were added and never increased over one year and a half ago :https://github.com/ss14Starlight/space-station-14/pull/185
Nowadays every sec shift start by a few bolting to an atm and getting the gloves, they are gone in less than a minute into the shift.

Since sec population has definetly increased since then i think its only fair to scale them, its only two more which is like a firth of the sec departement.
Even Medwia agrees, suprisingly.
<img width="707" height="86" alt="image" src="https://github.com/user-attachments/assets/345bf50c-6970-4588-9d97-be70bdf32485" />

## Media (Video/Screenshots)
gloves dot jpg

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Romero/Littlemen
- tweak: Two more combat gloves in secvend.
