### PR TITLE
Allow partial smellers to detect bodies in closed containers

### DIFF
--- a/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ScentTrackingSystem.cs
@@ -123,7 +123,7 @@ public sealed class ScentTrackingSystem : EntitySystem
             return;
 
         var visible = !IsPerceptionBlocked(smeller) &&
-                      !(smeller.Perception == ScentPerception.Partial && ent.Comp.ContainedIn != null) &&
+                      !(smeller.Perception == ScentPerception.Partial && ent.Comp.ContainedIn != null && !ent.Comp.WasDead) &&
                       !(smeller.Perception == ScentPerception.Partial && IsOutsideOwnEnclosure(ent, enclosure)) &&
                       (smeller.TrackedScentId == null || ent.Comp.ScentId == smeller.TrackedScentId);
         _sprite.SetVisible((ent.Owner, sprite), visible);

--- a/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
+++ b/Content.Server/_Starlight/Scent/Systems/ScentSystem.cs
@@ -456,6 +456,7 @@ public sealed class ScentSystem : SharedScentSystem
         markerComp.ExpiresAt = _timing.CurTime + decayTime;
         markerComp.TotalDuration = decayTime;
         markerComp.ContainedIn = GetAirtightContainer(xform);
+        markerComp.WasDead = MobState.IsDead(uid);
         Dirty(marker, markerComp);
 
         var despawn = Comp<TimedDespawnComponent>(marker);
@@ -530,6 +531,7 @@ public sealed class ScentSystem : SharedScentSystem
         marker.ExpiresAt = _timing.CurTime + decayTime;
         marker.TotalDuration = decayTime;
         marker.ContainedIn = GetAirtightContainer(xform);
+        marker.WasDead = MobState.IsDead(uid);
         Dirty(tail, marker);
 
         if (TryComp<TimedDespawnComponent>(tail, out var despawn))

--- a/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
+++ b/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
@@ -3,29 +3,39 @@ using Robust.Shared.GameStates;
 
 namespace Content.Shared._Starlight.Scent.Components;
 
-// A short-lived, invisible-to-normal-vision object left behind by a ScentComponent entity.
-// TimedDespawnComponent handles despawn. See scent_marker.yml.
+/// <summary>
+/// A short-lived, invisible-to-normal-vision object left behind by a ScentComponent entity.
+/// TimedDespawnComponent handles despawn. See scent_marker.yml.
+/// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(SharedScentSystem))]
 public sealed partial class ScentMarkerComponent : Component
 {
     [DataField, AutoNetworkedField]
     public string ScentId = string.Empty;
 
-    // Absolute despawn timestamp. Lets the fade animation recompute remaining time correctly
-    // whenever it restarts.
+    /// <summary>
+    /// Absolute despawn timestamp. Lets the fade animation recompute remaining time correctly
+    /// whenever it restarts.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan ExpiresAt;
 
+    /// <summary>
     // How pooled this marker is, 0-1. Maps to alpha/scale client-side.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public float Strength;
 
-    // The decay time actually used for this marker's current life. ExpiresAt - TotalDuration
-    // gives the moment this life cycle started, used to compute elapsed fraction client-side.
+    /// <summary>
+    /// The decay time actually used for this marker's current life. ExpiresAt - TotalDuration
+    /// gives the moment this life cycle started, used to compute elapsed fraction client-side.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public TimeSpan TotalDuration;
 
-    // The airtight container the emitter was inside at the moment of this emission, if any.
+    /// <summary>
+    /// The airtight container the emitter was inside at the moment of this emission, if any.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public EntityUid? ContainedIn;
 

--- a/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
+++ b/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
@@ -29,7 +29,9 @@ public sealed partial class ScentMarkerComponent : Component
     [DataField, AutoNetworkedField]
     public EntityUid? ContainedIn;
 
-    // Whether the emitter was dead at the moment of this emission.
+    /// <summary>
+    /// Whether the emitter was dead when this marker was emitted or last refreshed.
+    /// </summary>
     [DataField, AutoNetworkedField]
     public bool WasDead;
 }

--- a/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
+++ b/Content.Shared/_Starlight/Scent/Components/ScentMarkerComponent.cs
@@ -28,4 +28,8 @@ public sealed partial class ScentMarkerComponent : Component
     // The airtight container the emitter was inside at the moment of this emission, if any.
     [DataField, AutoNetworkedField]
     public EntityUid? ContainedIn;
+
+    // Whether the emitter was dead at the moment of this emission.
+    [DataField, AutoNetworkedField]
+    public bool WasDead;
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Based on a request from SnakeNuke.  Seemed reasonable.
Partial smellers (vulpkanins) can now detect bodies inside closed containers, with a faint scent emission.
This primarily is intended to help with paramedic work, and aid in discoverability of corpses hidden in maints.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Putting a corpse in a locker is basically round removal.  Bodies in closets can be detected by full smellers already; but we're doing a carve-out for corpses being detected in closets by partial smellers.  Makes sense for a corpse to smell bad anyway.

<img width="1119" height="50" alt="image" src="https://github.com/user-attachments/assets/b33aa26e-5467-48b1-9a5e-34450fb6eee7" />
<img width="1405" height="78" alt="image" src="https://github.com/user-attachments/assets/65fd0a29-1669-45c2-8e91-9378f6bed08c" />
<img width="1396" height="74" alt="image" src="https://github.com/user-attachments/assets/b687be37-3e20-4c47-bf51-c7e94bc7d5ee" />
<img width="1287" height="186" alt="image" src="https://github.com/user-attachments/assets/bfd30fb9-4986-4307-bb85-5a4795c8fd57" />
<img width="1150" height="124" alt="image" src="https://github.com/user-attachments/assets/bdd970cc-4ac8-4dbf-b95d-9c9090f642a0" />
<img width="1317" height="124" alt="image" src="https://github.com/user-attachments/assets/a3e25c7b-d7e2-4b03-9785-df76e03b5ea9" />


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/23e2249b-557e-4fdb-be6c-7ad7bb2826b1

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- add: Partial smellers can now faintly perceive the scent emissions of corpses inside closed containers.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
