### PR TITLE
Partial revert of #5186 "Improved shuttle security"

### DIFF
--- a/Resources/Maps/Shuttles/cargo.yml
+++ b/Resources/Maps/Shuttles/cargo.yml
@@ -645,7 +645,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -2.5,7.5
       parent: 173
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 78
     components:

--- a/Resources/Maps/Shuttles/cargo_exo.yml
+++ b/Resources/Maps/Shuttles/cargo_exo.yml
@@ -762,7 +762,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: -3.5,8.5
       parent: 173
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 36
     components:

--- a/Resources/Maps/Shuttles/cargo_plasma.yml
+++ b/Resources/Maps/Shuttles/cargo_plasma.yml
@@ -571,7 +571,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 52
     components:

--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -902,7 +902,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -3.5,5.5
       parent: 181
-- proto: ComputerShuttleMining
+- proto: ComputerShuttle
   entities:
   - uid: 156
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Mining/asteroidcracker.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Mining/asteroidcracker.yml
@@ -1138,7 +1138,7 @@ entities:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-- proto: ComputerShuttleMining
+- proto: ComputerShuttle
   entities:
   - uid: 170
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Mining/breaker.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Mining/breaker.yml
@@ -826,7 +826,7 @@ entities:
     - type: Transform
       pos: 7.5,9.5
       parent: 1
-- proto: ComputerShuttleMining
+- proto: ComputerShuttle
   entities:
   - uid: 96
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Salvage/expeditioneer.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Salvage/expeditioneer.yml
@@ -1492,7 +1492,7 @@ entities:
     - type: AccessReader
       accessListsOriginal:
       - - Salvage
-- proto: CompuerShuttleSalvage
+- proto: ComputerShuttle
   entities:
   - uid: 200
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Salvage/pioneer.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Salvage/pioneer.yml
@@ -1437,7 +1437,7 @@ entities:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-- proto: CompuerShuttleSalvage
+- proto: ComputerShuttle
   entities:
   - uid: 191
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Security/oasis_briggle.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Security/oasis_briggle.yml
@@ -455,7 +455,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,0.5
       parent: 1
-- proto: ComputerShuttleSecurity
+- proto: ComputerShuttle
   entities:
   - uid: 57
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Security/pursuit.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Security/pursuit.yml
@@ -1813,7 +1813,7 @@ entities:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-- proto: ComputerShuttleSecurity
+- proto: ComputerShuttle
   entities:
   - uid: 237
     components:

--- a/Resources/Maps/_Starlight/Shuttles/Security/security_prism.yml
+++ b/Resources/Maps/_Starlight/Shuttles/Security/security_prism.yml
@@ -646,7 +646,7 @@ entities:
     - type: Transform
       pos: 0.5,20.5
       parent: 1
-- proto: ComputerShuttleSecurity
+- proto: ComputerShuttle
   entities:
   - uid: 81
     components:

--- a/Resources/Maps/_Starlight/Shuttles/barge.yml
+++ b/Resources/Maps/_Starlight/Shuttles/barge.yml
@@ -2012,7 +2012,7 @@ entities:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-- proto: ComputerShuttleMining
+- proto: ComputerShuttle
   entities:
   - uid: 182
     components:

--- a/Resources/Maps/_Starlight/Shuttles/cargo_plasma.yml
+++ b/Resources/Maps/_Starlight/Shuttles/cargo_plasma.yml
@@ -548,7 +548,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 69
     components:

--- a/Resources/Maps/_Starlight/Shuttles/cargo_prism.yml
+++ b/Resources/Maps/_Starlight/Shuttles/cargo_prism.yml
@@ -859,7 +859,7 @@ entities:
       parent: 1
     - type: Fixtures
       fixtures: {}
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 118
     components:

--- a/Resources/Maps/_Starlight/Shuttles/cargo_silica.yml
+++ b/Resources/Maps/_Starlight/Shuttles/cargo_silica.yml
@@ -735,7 +735,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 4.5,7.5
       parent: 1
-- proto: ComputerShuttleCargo
+- proto: ComputerShuttle
   entities:
   - uid: 94
     components:

--- a/Resources/Maps/_Starlight/Shuttles/prospector.yml
+++ b/Resources/Maps/_Starlight/Shuttles/prospector.yml
@@ -643,7 +643,7 @@ entities:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-- proto: CompuerShuttleSalvage
+- proto: ComputerShuttle
   entities:
   - uid: 6
     components:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reverts mapping changes made in #5186 that weren't mapping approved.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
1. The mapping changes were not approved.
2. The PR modified `.yml` files of upstream shuttles, which isn't proper - new copies of those shuttles should have been made and put in a `_Starlight` subfolder.
3. Using remote consoles on a shuttle makes them annoying for mapping to test - you can't `loadgrid` them and fly them around immediately, you have to stop and replace the remote console with a regular console to test pilot them (unless you boot up in Release mode on local, then `setgamemap` to the map that uses it, etc.)
4. The security shuttles are entirely broken by #5186 as the PR put the "remote security shuttle console" at the helm of these shuttles, but we don't have a universal roundstart security shuttle with the correct grid component, so the computer has no idea what to remote control and just gives you a blank interface.
5. The computer mapped to the helms is the _remote_ shuttle console. It's meant to remotely control shuttles, not be on the shuttle in question.

I don't oppose the concept of #5186 (adding access requirements to shuttle computers), but the implementation is not proper and new prototypes should have been made instead of using the remote consoles on the shuttles themselves.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: The security shuttles no longer give you a blank 'no shuttle found' pilot interface when attempting to pilot them.
