### PR TITLE
Scents: Fix potential memory leak concern

### DIFF
--- a/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
@@ -27,6 +27,12 @@ public sealed class ClientScentSystem : SharedScentSystem
         SubscribeLocalEvent<SmellerComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
     }
 
+    /// <summary>
+    /// ComponentShutdown/LocalPlayerDetachedEvent only fire on ordinary gameplay transitions, not
+    /// when this system itself gets torn down (e.g. disconnecting mid-round). IOverlayManager is a
+    /// process-lifetime singleton that outlives this system, so without this, _overlay stays
+    /// registered forever, holding a live reference to this connection's entire entity graph.
+    /// </summary>
     public override void Shutdown()
     {
         base.Shutdown();

--- a/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
+++ b/Content.Client/_Starlight/Scent/Systems/ClientScentSystem.cs
@@ -27,6 +27,13 @@ public sealed class ClientScentSystem : SharedScentSystem
         SubscribeLocalEvent<SmellerComponent, LocalPlayerDetachedEvent>(OnPlayerDetached);
     }
 
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _overlayMan.RemoveOverlay(_overlay);
+    }
+
     private void OnSmellerInit(EntityUid uid, SmellerComponent component, ComponentInit args)
     {
         if (_player.LocalEntity == uid && !_overlayMan.HasOverlay<ScentPerceptionOverlay>())


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fix a potential memory leak concern.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
After scents were released, there were concerns that a memory leak may have been introduced with the  drunkenness overlay.
I haven't really seen where the issue may be, but I was able to locate a potential issue with the scent overlay's behavior.  So now we drop it from the overlay manager when someone disconnects.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
