### PR TITLE
Moved SpawnOnDespawnSystem to SharedSpawnOnDespawnSystem

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -1,7 +1,7 @@
 ﻿using System.Numerics;
 using Content.Server.Spawners.Components;
 using Content.Server.Spawners.EntitySystems;
-using Content.Shared._Starlight.Spawners.EntitySystems; //Starlight
+using Content.Shared._Starlight.Spawners.EntitySystems;
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Robust.Server.GameObjects;
@@ -78,7 +78,7 @@ public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
                 system.EntityManager.EnsureComponent<TimedDespawnComponent>(spawner, out var timedDespawnComponent);
                 timedDespawnComponent.Lifetime = SpawnAfter;
                 system.EntityManager.EnsureComponent<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);
-                system.EntityManager.System<SharedSpawnOnDespawnSystem>().SetPrototype((spawner, spawnOnDespawnComponent), entity);
+                system.EntityManager.System<SharedSpawnOnDespawnSystem>().SetPrototype((spawner, spawnOnDespawnComponent), entity); // Starlight-edit
             }
         }
         else

--- a/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/WeightedSpawnEntityBehavior.cs
@@ -1,12 +1,14 @@
 ﻿using System.Numerics;
 using Content.Server.Spawners.Components;
 using Content.Server.Spawners.EntitySystems;
+using Content.Shared._Starlight.Spawners.EntitySystems; //Starlight
 using Content.Shared.Random;
 using Content.Shared.Random.Helpers;
 using Robust.Server.GameObjects;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Spawners;
+using SpawnOnDespawnComponent = Content.Shared._Starlight.Spawners.Components.SpawnOnDespawnComponent;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors;
 
@@ -76,7 +78,7 @@ public sealed partial class WeightedSpawnEntityBehavior : IThresholdBehavior
                 system.EntityManager.EnsureComponent<TimedDespawnComponent>(spawner, out var timedDespawnComponent);
                 timedDespawnComponent.Lifetime = SpawnAfter;
                 system.EntityManager.EnsureComponent<SpawnOnDespawnComponent>(spawner, out var spawnOnDespawnComponent);
-                system.EntityManager.System<SpawnOnDespawnSystem>().SetPrototype((spawner, spawnOnDespawnComponent), entity);
+                system.EntityManager.System<SharedSpawnOnDespawnSystem>().SetPrototype((spawner, spawnOnDespawnComponent), entity);
             }
         }
         else

--- a/Content.Server/_Starlight/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/MonumentSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared._Starlight.CosmicCult;
 using Content.Shared._Starlight.CosmicCult.Components;
 using Content.Shared._Starlight.CosmicCult.Components.Examine;
 using Content.Shared._Starlight.CosmicCult.Prototypes;
+using Content.Shared._Starlight.Spawners.EntitySystems;
 using Content.Shared.Audio;
 using Content.Shared.Interaction;
 using Content.Shared.Popups;
@@ -25,6 +26,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Content.Shared.Damage.Systems;
 using Robust.Shared.Serialization.Markdown.Mapping;
+using SpawnOnDespawnComponent = Content.Shared._Starlight.Spawners.Components.SpawnOnDespawnComponent;
 
 namespace Content.Server._Starlight.CosmicCult;
 
@@ -46,7 +48,7 @@ public sealed partial class MonumentSystem : SharedMonumentSystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedUserInterfaceSystem _ui = default!;
-    [Dependency] private SpawnOnDespawnSystem _sod = default!;
+    [Dependency] private SharedSpawnOnDespawnSystem _sod = default!;
 
     private static readonly EntProtoId _cosmicGod = "MobCosmicGodSpawn";
     private static readonly EntProtoId _monumentCollider = "MonumentCollider";

--- a/Content.Shared/_Starlight/Spawners/Components/SpawnOnDespawnComponent.cs
+++ b/Content.Shared/_Starlight/Spawners/Components/SpawnOnDespawnComponent.cs
@@ -4,7 +4,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._Starlight.Spawners.Components;
 
 /// <summary>
-/// When a <c>TimedDespawnComponent"</c> despawns, another one will be spawned in its place.
+/// When a <c>TimedDespawnComponent</c> despawns, another one will be spawned in its place.
 /// </summary>
 [RegisterComponent, Access(typeof(SharedSpawnOnDespawnSystem))]
 public sealed partial class SpawnOnDespawnComponent : Component

--- a/Content.Shared/_Starlight/Spawners/Components/SpawnOnDespawnComponent.cs
+++ b/Content.Shared/_Starlight/Spawners/Components/SpawnOnDespawnComponent.cs
@@ -1,13 +1,12 @@
-using Content.Server.Spawners.EntitySystems;
+using Content.Shared._Starlight.Spawners.EntitySystems;
 using Robust.Shared.Prototypes;
-using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 
-namespace Content.Server.Spawners.Components;
+namespace Content.Shared._Starlight.Spawners.Components;
 
 /// <summary>
 /// When a <c>TimedDespawnComponent"</c> despawns, another one will be spawned in its place.
 /// </summary>
-[RegisterComponent, Access(typeof(SpawnOnDespawnSystem))]
+[RegisterComponent, Access(typeof(SharedSpawnOnDespawnSystem))]
 public sealed partial class SpawnOnDespawnComponent : Component
 {
     /// <summary>

--- a/Content.Shared/_Starlight/Spawners/EntitySystems/SharedSpawnOnDespawnSystem.cs
+++ b/Content.Shared/_Starlight/Spawners/EntitySystems/SharedSpawnOnDespawnSystem.cs
@@ -1,14 +1,13 @@
-using Content.Server.Spawners.Components;
-using Robust.Server.GameObjects;
+using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Spawners;
-using Robust.Shared.Map; // Starlight
+using SpawnOnDespawnComponent = Content.Shared._Starlight.Spawners.Components.SpawnOnDespawnComponent;
 
-namespace Content.Server.Spawners.EntitySystems;
+namespace Content.Shared._Starlight.Spawners.EntitySystems;
 
-public sealed partial class SpawnOnDespawnSystem : EntitySystem // Starlight edit
+public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem // Starlight edit
 {
-    [Dependency] private TransformSystem _xform = default!; // Starlight
+    [Dependency] private SharedTransformSystem _xform = default!; // Starlight
     private readonly Queue<(EntProtoId Prototype, EntityCoordinates Coordinates, ComponentRegistry? overrides)> _queuedSpawns = new(); // Starlight
 
     public override void Initialize()
@@ -27,8 +26,7 @@ public sealed partial class SpawnOnDespawnSystem : EntitySystem // Starlight edi
         while (_queuedSpawns.Count > 0)
         {
             var (prototype, coordinates, overrides) = _queuedSpawns.Dequeue();
-            var uid = Spawn(prototype, overrides);
-            _xform.SetCoordinates(uid, coordinates);
+            PredictedSpawnAtPosition(prototype, coordinates, overrides);
         }
     }
     // Starlight End

--- a/Content.Shared/_Starlight/Spawners/EntitySystems/SharedSpawnOnDespawnSystem.cs
+++ b/Content.Shared/_Starlight/Spawners/EntitySystems/SharedSpawnOnDespawnSystem.cs
@@ -5,10 +5,10 @@ using SpawnOnDespawnComponent = Content.Shared._Starlight.Spawners.Components.Sp
 
 namespace Content.Shared._Starlight.Spawners.EntitySystems;
 
-public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem // Starlight edit
+public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem
 {
-    [Dependency] private SharedTransformSystem _xform = default!; // Starlight
-    private readonly Queue<(EntProtoId Prototype, EntityCoordinates Coordinates, ComponentRegistry? overrides)> _queuedSpawns = new(); // Starlight
+    [Dependency] private SharedTransformSystem _xform = default!;
+    private readonly Queue<(EntProtoId Prototype, EntityCoordinates Coordinates, ComponentRegistry? overrides)> _queuedSpawns = new();
 
     public override void Initialize()
     {
@@ -17,7 +17,6 @@ public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem // Starlig
         SubscribeLocalEvent<SpawnOnDespawnComponent, TimedDespawnEvent>(OnDespawn);
     }
 
-    // Starlight Start
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
@@ -29,14 +28,13 @@ public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem // Starlig
             PredictedSpawnAtPosition(prototype, coordinates, overrides);
         }
     }
-    // Starlight End
 
     private void OnDespawn(EntityUid uid, SpawnOnDespawnComponent comp, ref TimedDespawnEvent args)
     {
         if (!TryComp(uid, out TransformComponent? xform))
             return;
 
-        _queuedSpawns.Enqueue((comp.Prototype, xform.Coordinates, comp.Overrides)); // Starlight Edit: Queue the spawn to occur after the entity is fully deleted
+        _queuedSpawns.Enqueue((comp.Prototype, xform.Coordinates, comp.Overrides));
     }
 
     public void SetPrototype(Entity<SpawnOnDespawnComponent> entity, EntProtoId prototype)
@@ -44,10 +42,7 @@ public sealed partial class SharedSpawnOnDespawnSystem : EntitySystem // Starlig
         entity.Comp.Prototype = prototype;
     }
 
-    #region Starlight
-
     public void SetOverrides(Entity<SpawnOnDespawnComponent> entity, ComponentRegistry? overrides) =>
         entity.Comp.Overrides = overrides;
 
-    #endregion
 }


### PR DESCRIPTION
## Short description
This aims to fix a bug where asteroid tiles where lacking collisions

## Why we need to add this
Unfortunately due to having to use prediction it was best to move the whole class and component over to shared to prevent clients having to wait for server responses

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: RedSpeeds
- fix: Fixed asteroids lacking collision.

