### PR TITLE
Gave ERT-Engineer's a t-ray scanner

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -240,6 +240,7 @@
   storage:
     back:
     - RPD # Starlight: RPD
+    - trayScanner #Starlight: T-ray Scanner
     - WelderIndustrialAdvanced
     - CableApcStack
     - CableMVStack
@@ -269,7 +270,6 @@
   storage:
     back:
     - RPD # Starlight: RPD
-    - trayScanner #Starlight: T-ray Scanner
     - WelderIndustrialAdvanced
     - WeaponLaserCarbine
     - MetalFoamGrenade

--- a/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -269,6 +269,7 @@
   storage:
     back:
     - RPD # Starlight: RPD
+    - trayScanner #Starlight: T-ray Scanner
     - WelderIndustrialAdvanced
     - WeaponLaserCarbine
     - MetalFoamGrenade


### PR DESCRIPTION
commit

## Short description
<!-- What do you propose to change with your PR? -->
Added a t-ray scanner to ERT engineer's loadout
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Why does an Emergency Response Team Engineer NOT have a t-ray scanner but has 3 stacks of cables?
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/a
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: Forrestgod
- tweak: ERT Engineers now spawn with a T-ray Scanner.


