### PR TITLE
Port System to check for building big machines (Like Bluespace Harvester)

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Interactions.cs
+++ b/Content.Server/Construction/ConstructionSystem.Interactions.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Construction.Components;
 using Content.Server.Temperature.Components;
+using Content.Shared._Omu.Common.Construction;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Construction.EntitySystems;
@@ -14,8 +15,10 @@ using Content.Shared.Radio.EntitySystems;
 using Content.Shared.Stacks;
 using Content.Shared.Temperature;
 using Content.Shared.Temperature.Components;
+using Content.Shared.Tools;
 using Content.Shared.Tools.Systems;
 using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 #if EXCEPTION_TOLERANCE
 // ReSharper disable once RedundantUsingDirective
@@ -50,6 +53,8 @@ namespace Content.Server.Construction
             SubscribeLocalEvent<ConstructionComponent, OnTemperatureChangeEvent>(EnqueueEvent);
             SubscribeLocalEvent<ConstructionComponent, PartAssemblyPartInsertedEvent>(EnqueueEvent);
         }
+
+        private static readonly ProtoId<ToolQualityPrototype> PryingQuality = "Prying"; // Omu starlight fixes
 
         /// <summary>
         ///     Takes in an entity with <see cref="ConstructionComponent"/> and an object event, and handles any
@@ -385,6 +390,18 @@ namespace Content.Server.Construction
                     // If we're handling an event after its DoAfter finished...
                     if (doAfterState == DoAfterState.Completed)
                         return  HandleResult.True;
+
+                    // Omustation Start
+                    if (HasComp<BigMachineBeingBuiltComponent>(uid)
+                        && !_toolSystem.HasQuality(interactUsing.Used, PryingQuality)) // kinda hardcoded crowbar check in case we are dissasembling
+                    {
+                        var bigBuildEvent = new BigBuildAttemptEvent(uid, user.Value);
+                        RaiseLocalEvent(uid, ref bigBuildEvent, true);
+
+                        if (bigBuildEvent.Cancelled)
+                            return HandleResult.False;
+                    }
+                    // Omustation End
 
                     _interactionSystem.DoContactInteraction(interactUsing.User, uid, interactUsing.Used, false); // Moffstation - Interaction particles
                     var result  = _toolSystem.UseTool(

--- a/Content.Server/Construction/MachineFrameSystem.cs
+++ b/Content.Server/Construction/MachineFrameSystem.cs
@@ -1,6 +1,7 @@
 using Content.Server.Construction.Components;
 using Content.Server.Stack;
 using Content.Shared._Moffstation.BladeServer;
+using Content.Shared._Omu.Common.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Examine;
 using Content.Shared.Interaction;
@@ -146,6 +147,9 @@ public sealed partial class MachineFrameSystem : EntitySystem
     {
         if (!TryComp<MachineBoardComponent>(used, out var machineBoard))
             return false;
+
+        if (HasComp<BigMachineBoardComponent>(used)) // Omu
+            EnsureComp<BigMachineBeingBuiltComponent>(uid); // todo checks to remove this comp. but its an edgecase i cant be bothered with rn
 
         // Moffstation - Begin - Blade Server construction
         // If this is a Blade Server frame, make sure the board is a Blade Server board.

--- a/Content.Server/_Omu/Construction/OmuConstructionBlockerSystem.cs
+++ b/Content.Server/_Omu/Construction/OmuConstructionBlockerSystem.cs
@@ -1,0 +1,60 @@
+using Content.Server.Construction.Components;
+using Content.Shared._Omu.Common.Construction;
+using Content.Shared.Popups;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
+
+namespace Content.Server._Omu.Construction
+{
+    public sealed partial class OmuConstructionBlockerSystem : EntitySystem
+    {
+        [Dependency] private readonly SharedMapSystem _map = default!;
+        [Dependency] private readonly EntityLookupSystem _lookupSystem = default!;
+        [Dependency] private readonly SharedPopupSystem _popup = default!;
+
+        public override void Initialize()
+        {
+            SubscribeLocalEvent<ConstructionComponent, BigBuildAttemptEvent>(CanBigBuild);
+        }
+
+        private void CanBigBuild(EntityUid uid, ConstructionComponent component, ref BigBuildAttemptEvent args)
+        {
+            var xform = Transform(uid);
+
+            if (xform.GridUid is not { } grid || !TryComp<MapGridComponent>(grid, out var gridComp))
+            {
+                args.Cancelled = true;
+                return;
+            }
+            var buildPos = _map.TileIndicesFor(grid, gridComp, xform.Coordinates);
+
+            var positions = new List<EntityCoordinates> // todo this is shit and manually makes a 3x3 square to check. Probably could be smarter.
+            {
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i(-1,  1)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i( 0,  1)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i( 1,  1)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i(-1,  0)),
+                // _map.ToCenterCoordinates(grid, buildPos), // This is the center. Don't actually check the machine to intersect with... itself.
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i( 1,  0)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i(-1, -1)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i( 0, -1)),
+                _map.ToCenterCoordinates(grid, buildPos + new Vector2i( 1, -1)),
+            };
+            var intersecting = false;
+            foreach (var coords in positions)
+            {
+                if (_lookupSystem.AnyEntitiesIntersecting(coords, LookupFlags.Static))
+                    intersecting = true;
+            }
+
+            // if anything intersects in the 3x3 space cancel construction push markup that there's not enough space.
+            if (intersecting && args.User != null)
+            {
+                _popup.PopupEntity(Loc.GetString("big-machine-build-no-room"), uid, args.User.Value);
+                args.Cancelled = true;
+            }
+            // not intersecting
+        }
+
+    }
+}

--- a/Content.Server/_Omu/Readme.txt
+++ b/Content.Server/_Omu/Readme.txt
@@ -1,0 +1,2 @@
+Anything in this directory is in Content.Omu.Server on Omu (infomally OmuMod) I just can't be asked porting our codebase larp here. Caveat Emptor.
+

--- a/Content.Shared/_Omu/Common/Construction/BigMachineBeingBuiltComponent.cs
+++ b/Content.Shared/_Omu/Common/Construction/BigMachineBeingBuiltComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Omu.Common.Construction;
+
+/// <summary>
+/// Used to mark that a machine that is big i.e. 3x3 is being built
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class BigMachineBeingBuiltComponent : Component
+{
+
+}
+

--- a/Content.Shared/_Omu/Common/Construction/BigMachineBoardComponent.cs
+++ b/Content.Shared/_Omu/Common/Construction/BigMachineBoardComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._Omu.Common.Construction;
+
+/// <summary>
+/// Used to mark that a machine board will build into a big machine i.e. a 3x3 instead of a 1x1
+/// </summary>
+[RegisterComponent, AutoGenerateComponentPause]
+public sealed partial class BigMachineBoardComponent : Component
+{
+
+}
+

--- a/Content.Shared/_Omu/Common/Construction/OmuConstructionBlockerEvent.cs
+++ b/Content.Shared/_Omu/Common/Construction/OmuConstructionBlockerEvent.cs
@@ -1,0 +1,5 @@
+namespace Content.Shared._Omu.Common.Construction
+{
+    [ByRefEvent]
+    public record struct BigBuildAttemptEvent(EntityUid Machine, EntityUid? User, bool Cancelled = false);
+}

--- a/Content.Shared/_Omu/Readme.txt
+++ b/Content.Shared/_Omu/Readme.txt
@@ -1,0 +1,2 @@
+Anything in this directory is in Content.Omu.Shared on Omu (infomally OmuMod) I just can't be asked porting our codebase larp here. Caveat Emptor.
+Anything in `Common` is under Content.Omu.Common in the original codebase.

--- a/Resources/Locale/en-US/_Omu/Construction/bigmachinebuild.ftl
+++ b/Resources/Locale/en-US/_Omu/Construction/bigmachinebuild.ftl
@@ -1,0 +1,1 @@
+big-machine-build-no-room = There's no room to finish building this!

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/power.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/power.yml
@@ -7,6 +7,7 @@
   - type: Sprite
     sprite: Objects/Misc/module.rsi
     state: engineering
+  - type: BigMachineBoard # to check for big machine bounds since its a 3x3
   - type: MachineBoard
     prototype: BluespaceHarvester
     stackRequirements:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Building big bluespace machine next to walls builds the machine inside wall since its a 3x3.

<img width="426" height="484" alt="image" src="https://github.com/user-attachments/assets/450e42d8-14ac-4c21-bbb5-485a839be403" />


## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Multiple fixtures inside one another prevent  hitting them. This can be abused.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/ae4bd4cd-40c5-462c-81ab-6210d6ece94d

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

sidenote my shit is like public domain just like, yoink it i dont give a fuck.

Adding this because its getting ported to our side and seemed like a pretty damn bad bug.

see:
https://github.com/ProjectOmu/OmuStation/pull/1345

If you ask me to comment usings i'm immediately closing the PR. Nobody cares when upstreaming if the usings aren't commented and its actually fucking annoying to have them commented.
source: I upstream wizden to goob.

Using an event here instead of calling the system directly because its easier in our omumod larp and if you keep it the same way here it makes my life easier next time someone ports something from here since i don't need to like make the systems different.

I threw this up in like an hour, do doublecheck the code.

**Changelog**

:cl: 
- fix: Bluespace harvester can no longer be built if there isn't enough space to build it.
