### PR TITLE
Give Reporters Journalism Access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -12,6 +12,7 @@
   access:
   - Service
   - Maintenance
+  - Journalism
 
 - type: startingGear
   id: ReporterGear

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -12,7 +12,7 @@
   access:
   - Service
   - Maintenance
-  - Journalism
+  - Journalism # Starlight
 
 - type: startingGear
   id: ReporterGear


### PR DESCRIPTION
## Short description
Gives reporters Journalism access.

## Why we need to add this
Reporters are journalists, their doors are gonna have this access type so... gotta give it to em, yknow?

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Orhu
- fix: Reporters now have Journalism access.
