### PR TITLE
Renames the station beacon "Brig Med" to "Brigmedic"

### DIFF
--- a/Resources/Locale/en-US/_Starlight/navmap-beacons/station-beacons.ftl
+++ b/Resources/Locale/en-US/_Starlight/navmap-beacons/station-beacons.ftl
@@ -20,3 +20,4 @@ station-beacon-musician = Musician
 station-beacon-lawyer = Lawyer
 station-beacon-janitor-cleaning-closet = Cleaning Closet
 station-beacon-washrooms = Washrooms
+station-beacon-brigmedic = Brigmedic

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -183,10 +183,10 @@
 - type: entity
   parent: DefaultStationBeaconSecurity
   id: DefaultStationBeaconBrigMed
-  suffix: Brig Med
+  suffix: Brigmedic # Starlight: "Brig Med" -> "Brigmedic"
   components:
   - type: NavMapBeacon
-    defaultText: station-beacon-brig-med
+    defaultText: station-beacon-brigmedic # Starlight: "Brig Med" -> "Brigmedic"
 
 - type: entity
   parent: DefaultStationBeaconSecurity


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Renames the station beacon text of the brigmedic beacon from "Brig Med" to "Brigmedic".

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The spelling of this station beacon personally annoyed me.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="437" height="266" alt="image" src="https://github.com/user-attachments/assets/aa7edeaa-5546-4b00-8c21-fedbde576546" />

fig. 1 - Updated station beacon.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: "Brig Med" map beacon has been renamed to "Brigmedic".