### PR TITLE
Cultist metrics

### DIFF
--- a/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
@@ -64,6 +64,7 @@ using Content.Shared.Shuttles.Components;
 using Content.Shared.Radio.Components;
 using Content.Shared.Mind.Components;
 using Content.Shared._Starlight.Shadekin.Components;
+using Prometheus;
 
 namespace Content.Server._Starlight.CosmicCult;
 
@@ -131,6 +132,9 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
     /// Mind role to add to cultists.
     /// </summary>
     public static readonly EntProtoId MindRole = "MindRoleCosmicCult";
+
+    private static readonly Counter _cultistCounter = Metrics.CreateCounter("cultist_counter",
+        "Keeps a track of the amount of times cultist win or loose", ["results"]);
 
     public override void Initialize()
     {
@@ -444,6 +448,8 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
 
         if (type is WinType.CultComplete or WinType.CrewComplete) //Let's lock in our WinType to prevent us from setting a worse win if a better win's been achieved.
             ent.Comp.WinLocked = true;
+
+        _cultistCounter.WithLabels(type.ToString()).Inc();
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
@@ -552,6 +558,7 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
         GameRuleComponent gameRule,
         ref RoundEndTextAppendEvent args)
     {
+
         var ftlKey = component.WinType.ToString().ToLower();
         var winType = Loc.GetString($"cosmiccult-roundend-{ftlKey}");
         var summaryText = Loc.GetString($"cosmiccult-summary-{ftlKey}");

--- a/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
@@ -136,6 +136,10 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
     private static readonly Counter _cultistCounter = Metrics.CreateCounter("cultist_counter",
         "Keeps a track of the amount of times cultist win or loose", ["results"]);
 
+    private static readonly Counter _convertsCounter = Metrics.CreateCounter("cultist_converts",
+        "Keeps track of the amount of players converted this round",
+        new CounterConfiguration { LabelNames = new[] { "round_id" } });
+
     public override void Initialize()
     {
         base.Initialize();
@@ -450,6 +454,8 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
             ent.Comp.WinLocked = true;
 
         _cultistCounter.WithLabels(type.ToString()).Inc();
+        var ticker = IoCManager.Resolve<GameTicker>();
+        _convertsCounter.WithLabels(ticker.RoundId.ToString()).Inc(ent.Comp.TotalCult);
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)

--- a/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
@@ -136,9 +136,8 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
     private static readonly Counter _cultistCounter = Metrics.CreateCounter("cultist_counter",
         "Keeps a track of the amount of times cultist win or loose", ["results"]);
 
-    private static readonly Counter _convertsCounter = Metrics.CreateCounter("cultist_converts",
-        "Keeps track of the amount of players converted this round",
-        new CounterConfiguration { LabelNames = new[] { "round_id" } });
+    private static readonly Gauge _convertsGauage = Metrics.CreateGauge("cultist_converts",
+        "Keeps track of the amount of players converted this round");
 
     public override void Initialize()
     {
@@ -452,10 +451,6 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
 
         if (type is WinType.CultComplete or WinType.CrewComplete) //Let's lock in our WinType to prevent us from setting a worse win if a better win's been achieved.
             ent.Comp.WinLocked = true;
-
-        _cultistCounter.WithLabels(type.ToString()).Inc();
-        var ticker = IoCManager.Resolve<GameTicker>();
-        _convertsCounter.WithLabels(ticker.RoundId.ToString()).Inc(ent.Comp.TotalCult);
     }
 
     private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
@@ -574,6 +569,8 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
         args.AddLine(Loc.GetString("cosmiccult-roundend-cultpop-count", ("count", component.PercentConverted)));
         args.AddLine(Loc.GetString("cosmiccult-roundend-entropy-count", ("count", component.EntropySiphoned)));
         args.AddLine(Loc.GetString("cosmiccult-roundend-monument-stage", ("stage", component.CurrentTier)));
+
+        _cultistCounter.WithLabels(component.WinType.ToString()).Inc();
     }
 
     public void IncrementCultObjectiveEntropy(Entity<CosmicCultComponent> ent)
@@ -591,6 +588,7 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
 
     public void AdjustCultObjectiveConversion(int value)
     {
+        _convertsGauage.Inc(value); // I know, I know using an Inc function with potential negative values is bad. Blame Prometheus for not having an .Adjust function...
         var query = EntityQueryEnumerator<CosmicConversionConditionComponent>();
         while (query.MoveNext(out _, out var conversionComp))
         {


### PR DESCRIPTION
## Short description
Added metrics to cultists so we can see their win rates as well as the amount of converts they had.

## Why we need to add this
So we can actually make changes to coscult based on data instead of vibes.

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

