### PR TITLE
Increased max link range for analysis console from 9 tiles to 12 tiles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -669,7 +669,7 @@
   - type: DeviceNetwork
     deviceNetId: Wired
   - type: DeviceLinkSource
-    range: 9 # Starlight | Requested by Conflee to have a larger range.
+    range: 12 # Starlight | Requested by Conflee to have a larger range.
     ports:
       - ArtifactAnalyzerSender
   - type: ActivatableUI


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Request by conf. It was bumped up once, but I'm bumping it up again.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
A little more flexibility for mapping artifact chambers in more creative shapes and styles. WizDen's default was a very restrictive 5 for reference.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Increased the maximum linking range of the artifact analysis console from 9 tiles to 12.
