### PR TITLE
Use "Holy Book" instead of "Bible" in Cosmic Cult guidebook entries

### DIFF
--- a/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCultDeconversion.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCultDeconversion.xml
@@ -9,7 +9,7 @@
   When mounting an effort to thwart the [color=#4cabb3]Cosmic Cult[/color], there are several methods the crew might employ to ensure their survival and safety. One of these methods is [color=Yellow]Deconversion[/color].
 
   To [color=Yellow]Deconvert[/color] a cosmic cultist, an [bold]Ardent Censer[/bold] must be used. Censers are fueled with Holy Water, which can be procured from:
-  - Usage of a Bible by a Chaplain on most containers of water will bless the water, turning it into Holy Water.
+  - Usage of a Holy Book by a Chaplain on most containers of water will bless the water, turning it into Holy Water.
 
   ## Suppression Methods
   <Box>

--- a/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCultMalignRifts.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCultMalignRifts.xml
@@ -7,7 +7,7 @@
   As your cult progresses, [color=#4cabb3]Malign Rifts[/color] will begin to spawn throughout the surrounding environment.
   These rifts in realspace bleed unstable astral power, and should be located as soon as possible!
 
-  Malign Rifts can be expunged by an [color=Yellow]A.P.E[/color] set to [bold]Nullspace stabilizer particles[/bold] or by a bible.
+  Malign Rifts can be expunged by an [color=Yellow]A.P.E[/color] set to [bold]Nullspace stabilizer particles[/bold] or by a Holy Book.
 
   Cultists may stealthily [color=#4cabb3]absorb[/color] a Malign Rift by interacting with it.
 


### PR DESCRIPTION
## Short description
In the Cosmic Cult guidebook sections, change "Bible" text to "Holy Book" instead

## Why we need to add this
The bible is just one of many selectable Holy Book types in the Chaplain's loadout. The guidebook shouldn't presume every Chaplain is playing a Christian.

I tested that the guidebook entries display as I expected with these changes.

**I also tested every loadout-selectable holy book** to ensure that they all produce holy water when used on water.

## Media (Video/Screenshots)

<img width="694" height="602" alt="Screenshot_20260810_145302" src="https://github.com/user-attachments/assets/79b50a4c-5585-40a1-ab41-ecf7c2c6efa1" />

<img width="694" height="602" alt="Screenshot_20260810_145316" src="https://github.com/user-attachments/assets/5689eaa1-fa96-41a4-931b-194bac7fb49e" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: noxypaws
- tweak: use "Holy Book" instead of "Bible" in Cosmic Cult guidebook entries.
