### PR TITLE
Remove the DoorLockdown/DoorRuntime event

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -27,7 +27,7 @@
     # Starlight Start
     - id: PsychicScreach
     - id: SecurityDrill
-    - id: DoorRuntime
+    #- id: DoorRuntime
     - id: RadStorm
     - id: AuroraCaelus
     - id: SpaceWhale


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Comments out the ability for the DoorRuntime event to roll, 

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

This event is just plain not fun, it just pauses the round for between 15 seconds and 2 minutes, It hurts newer players who dont know what is going on, it has no greater use than, pause the round, wait.... wait... wait.... okay continue. 

It also has a few rare scenarios spoil an entire round if they happen, mainly, if it rolls and a power outage rolls after, if it ends during the power outage, every door across station will remain bolted. It can roll just before or even _after_ evac arrives, locking every person who cant unbolt shocked doors inside and preventing them from evacing.

There have been proposed solutions, like making it only hit one department, but until those are added, this should stop being an option to roll.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: Musiklie
- remove: Removed the DoorRuntime event, NT finally solved the virus.