### PR TITLE
Add plasteel knuckle dusters crafting

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
+++ b/Resources/Prototypes/Entities/Clothing/Hands/gloves.yml
@@ -504,7 +504,10 @@
       params:
         variation: 0.125
     animation: WeaponArcFist
-    mustBeEquippedToUse: true
+    mustBeEquippedToUse: true # SL start
+  - type: Construction
+    graph: ClothingHandsKnuckleDusters
+    node: knuckleDusters # SL end
   - type: Tag
     tags:
     - WhitelistChameleon

--- a/Resources/Prototypes/_Starlight/Recipes/Construction/Graphs/weapons/knuckle_dusters.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Construction/Graphs/weapons/knuckle_dusters.yml
@@ -1,0 +1,13 @@
+- type: constructionGraph
+  id: ClothingHandsKnuckleDusters
+  start: start
+  graph:
+  - node: start
+    edges:
+      - to: knuckleDusters
+        steps:
+          - material: Plasteel
+            amount: 12
+            doAfter: 10
+  - node: knuckleDusters
+    entity: ClothingHandsKnuckleDusters

--- a/Resources/Prototypes/_Starlight/Recipes/Construction/weapons.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Construction/weapons.yml
@@ -1,0 +1,7 @@
+- type: construction
+  id: ClothingHandsKnuckleDusters
+  graph: ClothingHandsKnuckleDusters
+  startNode: start
+  targetNode: knuckleDusters
+  category: construction-category-weapons
+  objectType: Item

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/tider_anvil.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/tider_anvil.yml
@@ -30,3 +30,4 @@
   - BorgModuleMakeshiftKnifeTA
   - SpearSteelTA
   - MakeshiftIDTA
+  - KnuckleDustersTA

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
@@ -84,6 +84,13 @@
   materials:
     Cloth: 600
     Plasteel: 1900
+    
+- type: latheRecipe
+  id: KnuckleDustersTA
+  result: ClothingHandsKnuckleDusters
+  completetime: 60
+  materials:
+    Plasteel: 600
 
 # ARMOR
 - type: latheRecipe

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/tider_anvil.yml
@@ -84,7 +84,6 @@
   materials:
     Cloth: 600
     Plasteel: 1900
-    
 - type: latheRecipe
   id: KnuckleDustersTA
   result: ClothingHandsKnuckleDusters


### PR DESCRIPTION
## Short description
Add crafting recipes to both the construction menu and the makeshift anvil for the plasteel knuckle dusters.

## Why we need to add this
Currently, the plasteel knuckle dusters are unobtainable outside of maintenance locker spawns, and the occasional mapped spawn. They are functionally equivalent to the brass knuckle dusters, which can be crafted with brass (ordered from cargo), so it seems fitting that the plasteel dusters would also be craftable.
They are craftable both in the construction menu (12 plasteel), and from the makeshift anvil for half the cost (6 plasteel).

## Media (Video/Screenshots)
<img width="1088" height="693" alt="Screenshot 2026-08-10 203004" src="https://github.com/user-attachments/assets/be27387e-1563-4e71-aff6-ff86e421f296" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: XeroTec/Meepmerp
- add: Plasteel knuckle dusters crafting recipe.
- add: Plasteel knuckle dusters makeshift anvil recipe.
