### PR TITLE
Fix assistant plushie playtime requirement

### DIFF
--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/jobtrinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/jobtrinkets.yml
@@ -52,7 +52,7 @@
   - !type:JobRequirementLoadoutEffect
     requirement:
       !type:RoleTimeRequirement
-      role: JobAssistant
+      role: JobPassenger
       time: 72000 # 20hr
   storage:
     back:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes the playtime requirement for the assistant's lizard plushie.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For as long as I've been playing, the assistants job trinket plushie has been unobtainable, due to the playtime requirement pointing to "JobAssistant", and not "JobPassenger", which is where assistant playtime is actually tracked. No longer.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="744" height="78" alt="Screenshot 2026-08-11 033440" src="https://github.com/user-attachments/assets/2e330b09-f4a7-43e4-9a29-73e4a4aa4e47" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: XeroTec/Meepmerp
- fix: Fixed assistant lizard plushie playtime requirement.
