### PR TITLE
You can now take antag ghost roles with none enabled on your characters

### DIFF
--- a/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.API.Assignment.cs
@@ -285,7 +285,7 @@ public sealed partial class AntagSelectionSystem
     [PublicAPI]
     public bool CanTakeAntagGhostRole(ICommonSession session, AntagSpecifierPrototype definition)
     {
-        return !IsAntagBanned(session, definition) && _playTime.IsAllowed(session, definition.PrefRoles);
+        return !IsAntagBanned(session, definition) && _playTime.IsAllowedNonSpawning(session, definition.PrefRoles);
     }
     #endregion
 


### PR DESCRIPTION
## Short description
Not really a bug, I just had it disabled since it had some buggy behavior at one point in the rewrite, but it's actually fine now.

## Why we need to add this
Random fallback's nice, I guess.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: You can now take antag ghost roles with none enabled on your characters again, and it'll create a random character.
