### PR TITLE
Only Render Health Bar if Damaged

### DIFF
--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -89,9 +89,9 @@ public sealed class EntityHealthBarOverlay : Overlay
                 continue;
 
             // Starlight Start: Do not render the health bar is the entity is full health
-			if (deathProgress is (1, false))
-				continue;
-			// Starlight End
+            if (deathProgress is (1, false))
+            continue;
+            // Starlight End
 
             var worldPosition = _transform.GetWorldPosition(xform);
             var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -90,7 +90,7 @@ public sealed class EntityHealthBarOverlay : Overlay
 
             // Starlight Start: Do not render the health bar is the entity is full health
             if (deathProgress is (1, false))
-            continue;
+                continue;
             // Starlight End
 
             var worldPosition = _transform.GetWorldPosition(xform);

--- a/Content.Client/Overlays/EntityHealthBarOverlay.cs
+++ b/Content.Client/Overlays/EntityHealthBarOverlay.cs
@@ -88,6 +88,11 @@ public sealed class EntityHealthBarOverlay : Overlay
             if (CalcProgress(uid, mobStateComponent, damageableComponent, mobThresholdsComponent) is not { } deathProgress)
                 continue;
 
+            // Starlight Start: Do not render the health bar is the entity is full health
+			if (deathProgress is (1, false))
+				continue;
+			// Starlight End
+
             var worldPosition = _transform.GetWorldPosition(xform);
             var worldMatrix = Matrix3Helpers.CreateTranslation(worldPosition);
 


### PR DESCRIPTION
## Short description
A small edit to the EntityHealthBarOverlay that makes the bar not render if the entity is full health. The Med Status Icon to the left of their job icon still renders normally.

## Why we need to add this
Removes some visual clutter from the Med HUD to make seeing easier for Medical staff. The bar only matters if someone is damaged, seeing it on top of all med staff's heads just blocks more of the screen and makes it harder to see who is hurt.

## Media (Video/Screenshots)
<img width="591" height="435" alt="image" src="https://github.com/user-attachments/assets/19e4f56e-2bf5-4892-878b-df19d666d57c" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed the EntityHealthBarOverlay (Med HUD health bar) to not render if the entity is full health. This removes some visual clutter and should make parsing who is hurt in medbay easier for med staff.

