### PR TITLE
Pacifies space koi so they don't bite windows

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/carp.yml
@@ -40,6 +40,8 @@
         - id: MaterialToothSpaceCarp1
           amount: 1
           maxAmount: 4
+    - type: Pacified # prevent them from biting windows when they see people
+      disallowAllCombat: true
 
 - type: entity
   parent: BaseMobKoi


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Applies pacifism to space koi. They're friendly, after all.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Mappers like making fish tanks with space koi in them, but koi will bite the windows angrily. This PR resolves that.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/455f360a-c81a-47a5-b87c-6b64f0fba2a5

fig. 1 Left - Unpacified (before). Right - Pacified (after).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Space koi are now pacified and should no longer angrily bite the windows of their fish tanks.
