### PR TITLE
Slightly Longer News Articles

### DIFF
--- a/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
+++ b/Content.Shared/MassMedia/Systems/SharedNewsSystem.cs
@@ -4,8 +4,8 @@ namespace Content.Shared.MassMedia.Systems;
 
 public abstract class SharedNewsSystem : EntitySystem
 {
-    public const int MaxTitleLength = 25;
-    public const int MaxContentLength = 2048;
+    public const int MaxTitleLength = 35; // Starlight, slight increase
+    public const int MaxContentLength = 3072; // Starlight, +50% increase
 }
 
 [Serializable, NetSerializable]


### PR DESCRIPTION
## Short description
Increased the Max Title Length of News Articles from 25 to 35, and increased the Max Content Length of News Articles from 2048 to 3072 (+50%).

## Why we need to add this
Gives Reporters slightly more room to fit in their articles without needing to split them in two as very often happens.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: increased Max Title Length from 25 to 35, and Max Content Length from 2048 to 3072, for News Articles.

