### PR TITLE
Hitbox Roundening

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Singularity/collector.yml
@@ -14,8 +14,12 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
+          #!type:PhysShapeAabb
+          #bounds: "-0.45,-0.45,0.45,0.45"
+          # Starlight Start
+          !type:PhysShapeCircle
+          radius: 0.45
+          # Starlight End
         density: 190
         mask:
         - MachineMask

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -13,8 +13,12 @@
     fixtures:
       fix1:
         shape:
-          !type:PhysShapeAabb
-          bounds: "-0.45,-0.45,0.45,0.45"
+          #!type:PhysShapeAabb
+          #bounds: "-0.45,-0.45,0.45,0.45"
+          # Starlight Start
+          !type:PhysShapeCircle
+          radius: 0.45
+          # Starlight End
         density: 190
         mask:
         - MachineMask

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/generators.yml
@@ -275,6 +275,19 @@
                 max: 1
           - !type:DoActsBehavior
             acts: [ "Destruction" ]
+  # Starlight Start
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  # Starlight End
 
 # TODO: need radioactive fallout when destroyed
 

--- a/Resources/Prototypes/Entities/Structures/Power/chargers.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/chargers.yml
@@ -313,6 +313,19 @@
       machine_board: !type:Container
       machine_parts: !type:Container
   - type: StationAIShuntThrough # Starlight
+  # Starlight Start
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 190
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  # Starlight End
 
 - type: entity
   parent: BorgCharger

--- a/Resources/Prototypes/Entities/Structures/Power/smes.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/smes.yml
@@ -103,6 +103,19 @@
       - VoltageNetworks
       - Power
     - type: StationAiWhitelist #Starlight
+    # Starlight Start
+    - type: Fixtures
+      fixtures:
+        fix1:
+          shape:
+            !type:PhysShapeCircle
+            radius: 0.45
+          density: 200
+          mask:
+          - MachineMask
+          layer:
+          - MachineLayer
+    # Starlight End
 
     # Interface
     - type: BatteryInterface

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -102,6 +102,19 @@
       shader: unshaded
       visible: false
       offset: 0, 1
+  # Starlight Start
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 200
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  # Starlight End
 
 - type: entity
   parent: Thruster
@@ -280,6 +293,19 @@
     damageModifierSet: Electronic
   - type: StaticPrice
     price: 2000
+  # Starlight Start
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.45
+        density: 200
+        mask:
+        - MachineMask
+        layer:
+        - MachineLayer
+  # Starlight End
 
 - type: entity
   id: GyroscopeUnanchored

--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -109,7 +109,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.45
-        density: 200
+        density: 60
         mask:
         - MachineMask
         layer:
@@ -300,7 +300,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.45
-        density: 200
+        density: 60
         mask:
         - MachineMask
         layer:


### PR DESCRIPTION
## Short description
Swaps box shaped hitboxes with round hitboxes on the following;
- Radiation Collector
- Tesla Coil
- RTG
- Cyborg Recharger
- SMES
- Normal Thrusters
- Gyroscope

## Why we need to add this
These are common structures that need to be moved around by players regularly, either for rebuilding areas, setting up engines, setting up new power systems, fixing shuttles, or bringing borg rechargers to work spaces. The issue is, with a box shaped hitbox, they get stuck on literally every single door, forcing you to do a really stupid, clunky, and unintuitive dance of "drag, wrench to realign, drag, wrench to realign, drag" over and over. It sucks. This fixes that.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: Changed the Radiation Collector, Tesla Coil, RTG, Cyborg Recharger, SMES, normal Thrusters, and Gyroscope to use a round hitbox instead of a box shaped one. This should make dragging them through doors easier without needing to wrench and unwrench 100 times to realign them.

