### PR TITLE
Add Janitorial Maid Dress to Loadout

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/janidrobe.yml
@@ -12,6 +12,5 @@
     ClothingNeckScarfStripedPurple: 3
   contrabandInventory:
     ToyFigurineJanitor: 1
-  emaggedInventory:
     ClothingUniformJumpskirtJanimaid: 2
     ClothingUniformJumpskirtJanimaidmini: 1

--- a/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/LoadoutGroups/loadout_groups.yml
@@ -73,6 +73,8 @@
   - MaidOutfitTactical
   - MaidHeadbandTactical
   - TacticalMaidGloves
+  - JanitorMaidOutfit
+  - JanitorMaidOutfitMini
   - CoderSocks
   - PawBootTrinket
   - CatEars
@@ -609,6 +611,8 @@
   loadouts:
   - JanitorJumpsuit
   - JanitorJumpskirt
+  - JanitorMaidOutfit
+  - JanitorMaidOutfitMini
 
 
 - type: loadoutGroup

--- a/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/Miscellaneous/trinkets.yml
@@ -680,6 +680,37 @@
     head: ClothingHeadHatTacticalMaidHeadband
   groupBy: "maid outfit"
 
+- type: loadout
+  id: JanitorMaidOutfit
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:RoleTimeRequirement
+        role: JobJanitor
+        time: 72000 # 20 hr
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:OverallPlaytimeRequirement
+        time: 144000 # 40 hr
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaid
+  groupBy: "maid outfit"
+
+- type: loadout
+  id: JanitorMaidOutfitMini
+  effects:
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:RoleTimeRequirement
+         role: JobJanitor
+         time: 72000 #20 hr
+    - !type:JobRequirementLoadoutEffect
+      requirement:
+        !type:OverallPlaytimeRequirement
+        time: 144000 # 40 hr
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtJanimaidmini
+  groupBy: "maid outfit"
 
 - type: loadout
   id: TreasureCoinIron

--- a/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
@@ -729,6 +729,8 @@
   - ServiceWorkerChefJumpsuit
   - ServiceWorkerChefJumpskirt
   - MaidOutfit
+  - JanitorMiadOutfit
+  - JanitorMaidOutfitMini
 
 # Performer
 - type: loadoutGroup

--- a/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_Starlight/Loadouts/loadout_groups.yml
@@ -729,8 +729,8 @@
   - ServiceWorkerChefJumpsuit
   - ServiceWorkerChefJumpskirt
   - MaidOutfit
-  - JanitorMiadOutfit
-  - JanitorMaidOutfitMini
+  - JanitorMaidOutfit 
+  - JanitorMaidOutfitMini 
 
 # Performer
 - type: loadoutGroup


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
- Adds janitorial maid dress & mini ver. to janitor jumpsuit loadout
- Adds to service worker jumpsuit loadout
- Adds to trinket section, under maid category
- Unlocking requires: _**20 hours janitor playtime, 40 hours overall playtime**_
- Changes the outfit from being available in the emagged janidrobe inventory, it is now available from the janidrobe after cutting the manager wire.
- _Makes you look super cute, Yay!_

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The janitorial maid dress is super hard to find ingame, and other than set map spawns can only be obtained via emagging the janidrobe, or finding it as random wreck loot. Seeing as we have access to the other maid dresses in the loadout, I see no problem in adding it as a reward for getting those janitor hours in. This is purely a PR of "I like this thing. I want to be able to actually acquire and use it." 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="793" height="808" alt="Screenshot 2026-08-13 121729" src="https://github.com/user-attachments/assets/aad1eefd-d4db-4e13-ab53-845af7a66941" />
<img width="802" height="801" alt="Screenshot 2026-08-13 121849" src="https://github.com/user-attachments/assets/ede65b8c-2fbf-4284-b624-edae804e8179" />



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: briochebear
- add: Added janitorial maid dress to janitor jumpsuit loadout.
- add: Added janitorial maid dress to service worker loadout.
- add: Added janitorial maid dress to trinkets category, under maid dresses.
- tweak: Janidrobe now offers the janitorial maid dress under the contraband catalogue, instead of the emagged catalogue. 