### PR TITLE
Refine C# diagnostics SARIF report generation

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -83,7 +83,10 @@ jobs:
             exit 1
           fi
 
-          jq -s '{version: "2.1.0", runs: [.[].runs[]]}' "${reports[@]}" > /tmp/csharp-diagnostics.sarif
+          jq -s '{version: "2.1.0", runs: [.[].runs[]
+            | .results = ((.results // [])
+              | map(select((.level // "warning") == "warning" or (.level // "warning") == "error")))]}' \
+            "${reports[@]}" > /tmp/csharp-diagnostics.sarif
           reviewdog \
             -f=sarif \
             -name="C# diagnostics" \


### PR DESCRIPTION
## Short description
Update SARIF report generation to filter results by level.

## Why we need to add this
Currently it creates warnings on None and Info levels, when really we should be doing warn and amove

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
