### PR TITLE
Virology part 1: pathogens, symptoms and contamination

### DIFF
--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenAmbientSymptomTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenAmbientSymptomTests.cs
@@ -1,0 +1,112 @@
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.EntityEffects.Effects;
+using Content.Shared.EntityEffects.Effects.Transform;
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class PathogenAmbientSymptomTests : GameTest
+{
+    private static readonly (ProtoId<PathogenArchetypePrototype> Archetype, string Signature)[] AmbientArchetypes =
+    {
+        ("SpaceCold", "AmbientViralShivering"),
+        ("ThroatRot", "AmbientBacterialCoughingFit"),
+        ("SporeBloom", "AmbientFungalEyeBlur"),
+    };
+
+    [Test]
+    public async Task AmbientStrainsRollOneCoreTwoFlavoursAndOneSignature()
+    {
+        var server = Pair.Server;
+        var prototypes = server.ResolveDependency<IPrototypeManager>();
+        var registry = server.System<PathogenRegistrySystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var (archetypeId, signature) in AmbientArchetypes)
+            {
+                var archetype = prototypes.Index(archetypeId);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(archetype.StageOneSymptoms, Has.Count.EqualTo(3));
+                    Assert.That(archetype.StageTwoSymptomPool, Has.Count.EqualTo(6));
+                    Assert.That(archetype.MinStages, Is.EqualTo(3));
+                    Assert.That(archetype.MaxStages, Is.EqualTo(3));
+                    Assert.That(archetype.StageThreeSymptoms.Select(id => id.Id), Is.EqualTo(new[] { signature }));
+                });
+
+                foreach (var stageOneId in archetype.StageOneSymptoms)
+                {
+                    var stageOne = prototypes.Index(stageOneId);
+                    Assert.That(stageOne.MinStage, Is.EqualTo(1));
+                    Assert.That(
+                        stageOne.Effects.Any(effect =>
+                            effect is Emote { ShowInChat: true } ||
+                            effect is PopupMessage { Type: PopupRecipients.Pvs }),
+                        Is.True,
+                        $"{stageOneId} must be visible to nearby crew.");
+                }
+
+                for (var i = 0; i < 12; i++)
+                {
+                    var strain = registry.Generate(archetype);
+                    var symptoms = strain.Symptoms
+                        .Select(id => prototypes.Index(id))
+                        .ToList();
+
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 1), Is.EqualTo(1));
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 2), Is.EqualTo(2));
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 3), Is.EqualTo(1));
+                        Assert.That(strain.Symptoms.Select(id => id.Id), Does.Contain(signature));
+                    });
+                }
+            }
+        });
+    }
+
+    [Test]
+    public async Task FungalSignatureAddsAndRemovesMildBlur()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var statusEffects = server.System<StatusEffectsSystem>();
+
+        EntityUid patient = default;
+        await server.WaitPost(() =>
+        {
+            patient = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+            Assert.That(
+                statusEffects.TryAddStatusEffectDuration(
+                    patient,
+                    "PathogenMildBlurStatusEffect",
+                    TimeSpan.FromSeconds(2)),
+                Is.True);
+        });
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var blur = entities.GetComponent<BlurryVisionComponent>(patient);
+            Assert.That(blur.Magnitude, Is.EqualTo(1.5f).Within(0.001f));
+        });
+
+        await server.WaitPost(() =>
+            Assert.That(
+                statusEffects.TryRemoveStatusEffect(patient, "PathogenMildBlurStatusEffect"),
+                Is.True));
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+            Assert.That(entities.HasComponent<BlurryVisionComponent>(patient), Is.False));
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenContaminationTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenContaminationTests.cs
@@ -1,0 +1,416 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Server.Fluids.EntitySystems;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Disposal.Unit;
+using Content.Shared.FixedPoint;
+using Content.Shared.Tag;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class PathogenContaminationTests : GameTest
+{
+    private static readonly EntProtoId BananaPeel = "TrashBananaPeel";
+    private static readonly EntProtoId FoodMeatRotten = "FoodMeatRotten";
+    private static readonly EntProtoId RawMeat = "FoodMeat";
+    private static readonly EntProtoId StorageCrate = "CrateGenericSteel";
+    private static readonly ProtoId<TagPrototype> OrganicTrashTag = "OrganicTrash";
+    private static readonly ProtoId<TagPrototype> RottenFoodTag = "PathogenRottenFood";
+    private static readonly EntProtoId[] OrganicTrashPrototypes =
+    [
+        "FoodPacketBoritosTrash",
+        "FoodTinPeachesTrash",
+        "FoodPlateTrash",
+        "FoodBowlBigTrash",
+        BananaPeel,
+        "FoodCornTrash",
+        "FoodBungoPit",
+        "TrashCherryPit",
+    ];
+
+    [TestCase(0f, 0.06f, 2.4f, 0f)]
+    [TestCase(20f, 0.06f, 2.4f, 1.2f)]
+    [TestCase(100f, 0.06f, 2.4f, 2.4f)]
+    [TestCase(20f, 0.03f, 1.2f, 0.6f)]
+    [TestCase(100f, 0.03f, 1.2f, 1.2f)]
+    [TestCase(100f, 0.06f, 1.8f, 1.8f)]
+    [TestCase(-10f, 0.06f, 2.4f, 0f)]
+    public void PuddleContaminationIsBounded(
+        float volume,
+        float perUnit,
+        float maximum,
+        float expected)
+    {
+        Assert.That(
+            PathogenContaminationMath.PuddleContamination(volume, perUnit, maximum),
+            Is.EqualTo(expected).Within(0.0001f));
+    }
+
+    [Test]
+    public async Task OrganicWastePrototypesCarryContaminationTag()
+    {
+        var server = Pair.Server;
+        var proto = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var prototypeId in OrganicTrashPrototypes)
+            {
+                var prototype = proto.Index<EntityPrototype>(prototypeId);
+                Assert.That(
+                    prototype.TryGetComponent<TagComponent>(
+                        out var tags,
+                        server.EntMan.ComponentFactory),
+                    Is.True,
+                    $"{prototypeId} should have a Tag component");
+                Assert.That(
+                    tags!.Tags,
+                    Does.Contain(OrganicTrashTag),
+                    $"{prototypeId} should be sampled as organic trash");
+            }
+        });
+    }
+
+    [Test]
+    public async Task RottenFoodPrototypeCarriesContaminationTag()
+    {
+        var server = Pair.Server;
+        var proto = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var prototype = proto.Index<EntityPrototype>(FoodMeatRotten);
+            Assert.That(
+                prototype.TryGetComponent<TagComponent>(
+                    out var tags,
+                    server.EntMan.ComponentFactory),
+                Is.True,
+                $"{FoodMeatRotten} should have a Tag component");
+            Assert.That(
+                tags!.Tags,
+                Does.Contain(RottenFoodTag),
+                $"{FoodMeatRotten} should be sampled as rotten food");
+        });
+    }
+
+    /// <summary>
+    /// Rubbish is found by tag and rot is found by component, so disposal has to silence
+    /// both. It marks instead of clearing tags for exactly that reason - a rotting steak
+    /// carries no tag to clear, and used to start counting again the moment the pipes
+    /// dumped it onto the disposal room floor.
+    /// </summary>
+    [Test]
+    public async Task DisposalSilencesTaggedAndRottingSourcesAlike()
+    {
+        var testMap = await Pair.CreateTestMap();
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var sources = server.System<PathogenContaminationSourceSystem>();
+
+        EntityUid trash = default;
+        EntityUid rotten = default;
+        EntityUid rotting = default;
+
+        await server.WaitPost(() =>
+        {
+            sources.ResetSourceStateForTest();
+            sources.SampleSourcesForTest();
+
+            trash = entities.SpawnEntity(BananaPeel, testMap.GridCoords);
+            rotten = entities.SpawnEntity(FoodMeatRotten, testMap.GridCoords);
+            rotting = entities.SpawnEntity(RawMeat, testMap.GridCoords);
+            entities.EnsureComponent<RottingComponent>(rotting);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                sources.ActiveSourceCount,
+                Is.GreaterThanOrEqualTo(3),
+                "All three have to count before disposal means anything."));
+
+        // Disposal ejects things back onto the floor, so being uncontained afterwards must
+        // not be enough to bring them back.
+        await server.WaitPost(() =>
+        {
+            entities.EnsureComponent<BeingDisposedComponent>(trash);
+            entities.EnsureComponent<BeingDisposedComponent>(rotten);
+            entities.EnsureComponent<BeingDisposedComponent>(rotting);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(entities.HasComponent<PathogenDisposedComponent>(trash), Is.True);
+                Assert.That(entities.HasComponent<PathogenDisposedComponent>(rotten), Is.True);
+                Assert.That(entities.HasComponent<PathogenDisposedComponent>(rotting), Is.True);
+                Assert.That(sources.ActiveSourceCount, Is.Zero);
+            });
+        });
+
+        await server.WaitPost(() =>
+        {
+            entities.DeleteEntity(trash);
+            entities.DeleteEntity(rotten);
+            entities.DeleteEntity(rotting);
+        });
+    }
+
+    /// <summary>
+    /// Rot is the only collector that used to skip these guards, so a rotting steak kept
+    /// contaminating the station from inside a bag, a crate or a disposal unit.
+    /// </summary>
+    [Test]
+    public async Task RotSourcesIgnoreContainedAndUngriddedEntities()
+    {
+        var testMap = await Pair.CreateTestMap();
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var containers = server.System<SharedContainerSystem>();
+        var sources = server.System<PathogenContaminationSourceSystem>();
+
+        EntityUid meat = default;
+        EntityUid crate = default;
+
+        await server.WaitPost(() =>
+        {
+            sources.ResetSourceStateForTest();
+            sources.SampleSourcesForTest();
+
+            meat = entities.SpawnEntity(RawMeat, testMap.GridCoords);
+            crate = entities.SpawnEntity(StorageCrate, testMap.GridCoords);
+            entities.EnsureComponent<RottingComponent>(meat);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                sources.SourceReport.Any(report =>
+                    report.Kind == PathogenContaminationSourceKind.RottingEdible),
+                Is.True,
+                "Rotting meat on the floor has to count in the first place."));
+
+        await server.WaitPost(() =>
+        {
+            var container = containers.EnsureContainer<Container>(crate, "test_storage");
+            Assert.That(containers.Insert(meat, container), Is.True);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                sources.SourceReport.Any(report =>
+                    report.Kind == PathogenContaminationSourceKind.RottingEdible),
+                Is.False,
+                "Stowing it in a crate is the crew dealing with it."));
+
+        await server.WaitPost(() =>
+        {
+            entities.DeleteEntity(meat);
+            entities.DeleteEntity(crate);
+        });
+    }
+
+    [Test]
+    public async Task FirstSampleBaselinesExistingPhysicalSources()
+    {
+        var testMap = await Pair.CreateTestMap();
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var contamination = server.System<PathogenContaminationSystem>();
+        var sources = server.System<PathogenContaminationSourceSystem>();
+        EntityUid baselineTrash = default;
+        EntityUid newTrash = default;
+
+        await server.WaitPost(() =>
+        {
+            sources.ResetSourceStateForTest();
+            baselineTrash = entities.SpawnEntity(BananaPeel, testMap.GridCoords);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sources.HasBaseline, Is.True);
+            Assert.That(sources.ActiveSourceCount, Is.Zero);
+            Assert.That(sources.BaselineSourceCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(sources.IgnoredBaselineSourceCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(contamination.GetContamination(PathogenType.Bacteria), Is.Zero);
+            Assert.That(
+                sources.IgnoredBaselineReport.Any(report =>
+                    report.Kind == PathogenContaminationSourceKind.OrganicTrash),
+                Is.True);
+        });
+
+        await server.WaitPost(() =>
+        {
+            newTrash = entities.SpawnEntity(BananaPeel, testMap.GridCoords);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sources.ActiveSourceCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(sources.IgnoredBaselineSourceCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(contamination.GetContamination(PathogenType.Bacteria), Is.GreaterThan(0f));
+            Assert.That(
+                sources.SourceReport.Any(report =>
+                    report.Kind == PathogenContaminationSourceKind.OrganicTrash),
+                Is.True);
+        });
+
+        await server.WaitPost(() =>
+        {
+            entities.DeleteEntity(baselineTrash);
+            entities.DeleteEntity(newTrash);
+        });
+    }
+
+    [Test]
+    public async Task RottenFoodSourcesContributeAfterBaseline()
+    {
+        var testMap = await Pair.CreateTestMap();
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var contamination = server.System<PathogenContaminationSystem>();
+        var sources = server.System<PathogenContaminationSourceSystem>();
+        EntityUid rottenFood = default;
+
+        await server.WaitPost(() =>
+        {
+            sources.ResetSourceStateForTest();
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitPost(() =>
+        {
+            rottenFood = entities.SpawnEntity(FoodMeatRotten, testMap.GridCoords);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(sources.ActiveSourceCount, Is.GreaterThanOrEqualTo(1));
+            Assert.That(contamination.GetContamination(PathogenType.Bacteria), Is.GreaterThan(0f));
+            Assert.That(contamination.GetContamination(PathogenType.Fungus), Is.GreaterThan(0f));
+            Assert.That(
+                sources.SourceReport.Any(report =>
+                    report.Kind == PathogenContaminationSourceKind.SpoiledFood),
+                Is.True);
+        });
+
+        await server.WaitPost(() => entities.DeleteEntity(rottenFood));
+    }
+
+    [Test]
+    public async Task MoldPuddlesContributeBacteriaAndFungus()
+    {
+        var testMap = await Pair.CreateTestMap();
+        var server = Pair.Server;
+        var contamination = server.System<PathogenContaminationSystem>();
+        var puddles = server.System<PuddleSystem>();
+        var sources = server.System<PathogenContaminationSourceSystem>();
+
+        await server.WaitPost(() =>
+        {
+            sources.ResetSourceStateForTest();
+            sources.SampleSourcesForTest();
+
+            var solution = new Solution("Mold", FixedPoint2.New(100));
+            Assert.That(puddles.TrySpillAt(testMap.Tile, solution, out _), Is.True);
+            sources.SampleSourcesForTest();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    contamination.GetContamination(PathogenType.Bacteria),
+                    Is.EqualTo(1.8f).Within(0.0001f));
+                Assert.That(
+                    contamination.GetContamination(PathogenType.Fungus),
+                    Is.EqualTo(1.8f).Within(0.0001f));
+            });
+        });
+    }
+
+    [Test]
+    public void ContaminationPoolTracksTypedContributions()
+    {
+        var pool = new PathogenContaminationPool();
+
+        pool.Set(new Dictionary<PathogenType, float>
+        {
+            [PathogenType.Virus] = 10f,
+            [PathogenType.Bacteria] = 30f,
+            [PathogenType.Fungus] = 20f,
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pool.Total, Is.EqualTo(60f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Virus), Is.EqualTo(10f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Bacteria), Is.EqualTo(30f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Fungus), Is.EqualTo(20f).Within(0.0001f));
+            Assert.That(
+                pool.GetDominantTypes(),
+                Is.EqualTo(new[] { PathogenType.Bacteria }));
+        });
+    }
+
+    [Test]
+    public void NewSourceSnapshotReplacesPreviousContamination()
+    {
+        var pool = new PathogenContaminationPool();
+        pool.Set(new Dictionary<PathogenType, float>
+        {
+            [PathogenType.Virus] = 20f,
+            [PathogenType.Bacteria] = 30f,
+        });
+
+        pool.Set(new Dictionary<PathogenType, float>
+        {
+            [PathogenType.Fungus] = 9f,
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pool.Total, Is.EqualTo(9f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Virus), Is.Zero);
+            Assert.That(pool.Get(PathogenType.Bacteria), Is.Zero);
+            Assert.That(pool.Get(PathogenType.Fungus), Is.EqualTo(9f).Within(0.0001f));
+        });
+    }
+
+    [Test]
+    public void BatchedContributionsPreserveCompositionAtCap()
+    {
+        var pool = new PathogenContaminationPool();
+        pool.Set(new Dictionary<PathogenType, float>
+        {
+            [PathogenType.Virus] = 90f,
+            [PathogenType.Bacteria] = 20f,
+            [PathogenType.Fungus] = 20f,
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(pool.Total, Is.EqualTo(100f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Virus), Is.EqualTo(69.23077f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Bacteria), Is.EqualTo(15.38462f).Within(0.0001f));
+            Assert.That(pool.Get(PathogenType.Fungus), Is.EqualTo(15.38462f).Within(0.0001f));
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenContaminationTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenContaminationTests.cs
@@ -321,6 +321,7 @@ public sealed class PathogenContaminationTests : GameTest
         var contamination = server.System<PathogenContaminationSystem>();
         var puddles = server.System<PuddleSystem>();
         var sources = server.System<PathogenContaminationSourceSystem>();
+        EntityUid puddle = default;
 
         await server.WaitPost(() =>
         {
@@ -328,7 +329,7 @@ public sealed class PathogenContaminationTests : GameTest
             sources.SampleSourcesForTest();
 
             var solution = new Solution("Mold", FixedPoint2.New(100));
-            Assert.That(puddles.TrySpillAt(testMap.Tile, solution, out _), Is.True);
+            Assert.That(puddles.TrySpillAt(testMap.Tile, solution, out puddle), Is.True);
             sources.SampleSourcesForTest();
         });
 
@@ -344,6 +345,8 @@ public sealed class PathogenContaminationTests : GameTest
                     Is.EqualTo(1.8f).Within(0.0001f));
             });
         });
+
+        await server.WaitPost(() => server.EntMan.DeleteEntity(puddle));
     }
 
     [Test]

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenEmergentSymptomTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenEmergentSymptomTests.cs
@@ -3,8 +3,10 @@ using System.Numerics;
 using Content.IntegrationTests.Fixtures;
 using Content.Server._Starlight.Medical.Virology;
 using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Systems;
 using Content.Shared.EntityEffects;
 using Content.Shared.EntityEffects.Effects.StatusEffects;
 using Content.Shared.FixedPoint;
@@ -137,6 +139,44 @@ public sealed class PathogenEmergentSymptomTests : GameTest
     }
 
     [Test]
+    public async Task EmergentDamageCapIgnoresPreExistingDamage()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var damageable = server.System<DamageableSystem>();
+        var effects = server.System<SharedEntityEffectsSystem>();
+
+        EntityUid patient = default;
+        await server.WaitPost(() =>
+        {
+            patient = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+
+            var preexisting = new DamageSpecifier();
+            preexisting.DamageDict["Heat"] = FixedPoint2.New(10);
+            Assert.That(damageable.TryChangeDamage(patient, preexisting, true), Is.True);
+
+            var infections = entities.EnsureComponent<PathogenInfectionComponent>(patient);
+            infections.Infections.Add(new PathogenInfection { Pathogen = 1 });
+
+            var effect = new PathogenCappedDamage
+            {
+                DamageType = new ProtoId<DamageTypePrototype>("Heat"),
+                Amount = 3,
+                Maximum = 6,
+            };
+
+            for (var i = 0; i < 3; i++)
+                effects.ApplyEffect(patient, effect);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var damage = entities.GetComponent<DamageableComponent>(patient);
+            Assert.That(damage.Damage.DamageDict["Heat"], Is.EqualTo(FixedPoint2.New(16)));
+        });
+    }
+
+    [Test]
     public async Task NumbFingersDropsOnlyTheActiveHandItem()
     {
         var server = Pair.Server;
@@ -146,22 +186,43 @@ public sealed class PathogenEmergentSymptomTests : GameTest
         var map = await Pair.CreateTestMap();
 
         EntityUid patient = default;
-        EntityUid item = default;
+        EntityUid active = default;
+        EntityUid offHand = default;
+        var pickedUpActive = false;
+        var pickedUpOffHand = false;
+        EntityUid? activeBefore = null;
         await server.WaitPost(() =>
         {
             var coordinates = new MapCoordinates(Vector2.Zero, map.MapId);
             patient = entities.SpawnEntity("MobHuman", coordinates);
-            item = entities.SpawnEntity("Crowbar", coordinates);
-            Assert.That(hands.TryPickupAnyHand(patient, item), Is.True);
-            Assert.That(hands.GetActiveItem(patient), Is.EqualTo(item));
+            active = entities.SpawnEntity("Crowbar", coordinates);
+            offHand = entities.SpawnEntity("Crowbar", coordinates);
 
-            effects.ApplyEffect(patient, new PathogenDropActiveItem());
+            pickedUpActive = hands.TryPickupAnyHand(patient, active);
+            pickedUpOffHand = hands.TryPickupAnyHand(patient, offHand);
+            activeBefore = hands.GetActiveItem(patient);
         });
+
+        // The second pickup has to land in a free hand, leaving the first one active.
+        Assert.Multiple(() =>
+        {
+            Assert.That(pickedUpActive, Is.True, "first item was not picked up");
+            Assert.That(pickedUpOffHand, Is.True, "second item was not picked up");
+            Assert.That(activeBefore, Is.EqualTo(active), "the first item should still be the active one");
+        });
+
+        await server.WaitPost(() => effects.ApplyEffect(patient, new PathogenDropActiveItem()));
 
         await server.WaitAssertion(() =>
         {
-            Assert.That(hands.GetActiveItem(patient), Is.Null);
-            Assert.That(entities.Deleted(item), Is.False);
+            Assert.Multiple(() =>
+            {
+                Assert.That(hands.GetActiveItem(patient), Is.Null);
+                Assert.That(hands.IsHolding(patient, active), Is.False);
+                Assert.That(hands.IsHolding(patient, offHand), Is.True);
+                Assert.That(entities.Deleted(active), Is.False);
+                Assert.That(entities.Deleted(offHand), Is.False);
+            });
         });
     }
 

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenEmergentSymptomTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenEmergentSymptomTests.cs
@@ -1,0 +1,176 @@
+using System.Linq;
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.EntityEffects;
+using Content.Shared.EntityEffects.Effects.StatusEffects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Hands.EntitySystems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class PathogenEmergentSymptomTests : GameTest
+{
+    private static readonly EmergentArchetypeData[] EmergentArchetypes =
+    {
+        new(
+            "StationFlu",
+            new[] { "Sneezing", "CoreViralSniffling", "CoreViralWateryEyes" },
+            new[]
+            {
+                "EmergentViralFeverChills",
+                "EmergentViralMuscleWeakness",
+                "EmergentViralLightHeadedness",
+            },
+            new[] { "EmergentViralHighFever", "EmergentViralFaintingSpell" }),
+        new(
+            "GreyLung",
+            new[] { "Coughing", "CoreBacterialThroatClearing", "CoreBacterialThroatDiscomfort" },
+            new[]
+            {
+                "EmergentBacterialCoughingFit",
+                "EmergentBacterialBreathlessness",
+                "EmergentBacterialSevereHoarseness",
+            },
+            new[] { "EmergentBacterialHypoxicAttack", "EmergentBacterialRespiratoryCollapse" }),
+        new(
+            "Mycosis",
+            new[] { "CoreFungalSkinIrritation", "CoreFungalEyeIrritation", "CoreFungalFlakingSkin" },
+            new[]
+            {
+                "EmergentFungalEyeInflammation",
+                "EmergentFungalCramps",
+                "EmergentFungalNumbFingers",
+            },
+            new[] { "EmergentFungalToxicMycosis", "EmergentFungalOcularSporeFlare" }),
+    };
+
+    [Test]
+    public async Task EmergentStrainsRollOneCoreTwoMechanicalSymptomsAndBothSignatures()
+    {
+        var server = Pair.Server;
+        var prototypes = server.ResolveDependency<IPrototypeManager>();
+        var registry = server.System<PathogenRegistrySystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            foreach (var data in EmergentArchetypes)
+            {
+                var archetype = prototypes.Index<PathogenArchetypePrototype>(data.Archetype);
+                Assert.Multiple(() =>
+                {
+                    Assert.That(archetype.StageOneSymptoms.Select(id => id.Id), Is.EquivalentTo(data.StageOne));
+                    Assert.That(archetype.StageTwoSymptomPool.Select(id => id.Id), Is.EquivalentTo(data.StageTwo));
+                    Assert.That(archetype.StageThreeSymptoms.Select(id => id.Id), Is.EquivalentTo(data.StageThree));
+                    Assert.That(archetype.MinStages, Is.EqualTo(3));
+                    Assert.That(archetype.MaxStages, Is.EqualTo(3));
+                });
+
+                foreach (var symptomId in archetype.StageTwoSymptomPool)
+                {
+                    var symptom = prototypes.Index(symptomId);
+                    Assert.That(symptom.MinStage, Is.EqualTo(2));
+                    Assert.That(symptom.Effects.Any(IsMechanicalStageTwoEffect), Is.True);
+                }
+
+                var stageThree = archetype.StageThreeSymptoms.Select(id => prototypes.Index(id)).ToList();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(stageThree.All(symptom => symptom.MinStage == 3), Is.True);
+                    Assert.That(
+                        stageThree.SelectMany(symptom => symptom.Effects).OfType<PathogenCappedDamage>().Count(),
+                        Is.EqualTo(1));
+                });
+
+                for (var i = 0; i < 12; i++)
+                {
+                    var strain = registry.Generate(archetype);
+                    var symptoms = strain.Symptoms.Select(id => prototypes.Index(id)).ToList();
+
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 1), Is.EqualTo(1));
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 2), Is.EqualTo(2));
+                        Assert.That(symptoms.Count(symptom => symptom.MinStage == 3), Is.EqualTo(2));
+                        Assert.That(strain.Symptoms.Select(id => id.Id), Does.Contain(data.StageThree[0]));
+                        Assert.That(strain.Symptoms.Select(id => id.Id), Does.Contain(data.StageThree[1]));
+                    });
+                }
+            }
+        });
+    }
+
+    [Test]
+    public async Task EmergentDamageStopsExactlyAtItsAuthoredCap()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var effects = server.System<SharedEntityEffectsSystem>();
+
+        EntityUid patient = default;
+        await server.WaitPost(() =>
+        {
+            patient = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+            var effect = new PathogenCappedDamage
+            {
+                DamageType = new ProtoId<DamageTypePrototype>("Heat"),
+                Amount = 3,
+                Maximum = 15,
+            };
+
+            for (var i = 0; i < 10; i++)
+                effects.ApplyEffect(patient, effect);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var damage = entities.GetComponent<DamageableComponent>(patient);
+            Assert.That(damage.Damage.DamageDict["Heat"], Is.EqualTo(FixedPoint2.New(15)));
+        });
+    }
+
+    [Test]
+    public async Task NumbFingersDropsOnlyTheActiveHandItem()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var effects = server.System<SharedEntityEffectsSystem>();
+        var hands = server.System<SharedHandsSystem>();
+        var map = await Pair.CreateTestMap();
+
+        EntityUid patient = default;
+        EntityUid item = default;
+        await server.WaitPost(() =>
+        {
+            var coordinates = new MapCoordinates(Vector2.Zero, map.MapId);
+            patient = entities.SpawnEntity("MobHuman", coordinates);
+            item = entities.SpawnEntity("Crowbar", coordinates);
+            Assert.That(hands.TryPickupAnyHand(patient, item), Is.True);
+            Assert.That(hands.GetActiveItem(patient), Is.EqualTo(item));
+
+            effects.ApplyEffect(patient, new PathogenDropActiveItem());
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(hands.GetActiveItem(patient), Is.Null);
+            Assert.That(entities.Deleted(item), Is.False);
+        });
+    }
+
+    private static bool IsMechanicalStageTwoEffect(EntityEffect effect)
+        => effect is MovementSpeedModifier or ModifyStatusEffect or Jitter or PathogenDropActiveItem;
+
+    private sealed record EmergentArchetypeData(
+        ProtoId<PathogenArchetypePrototype> Archetype,
+        string[] StageOne,
+        string[] StageTwo,
+        string[] StageThree);
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenHostEligibilityTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/PathogenHostEligibilityTests.cs
@@ -1,0 +1,89 @@
+using Content.IntegrationTests.Fixtures;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Shared._Starlight.Medical.Virology;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class PathogenHostEligibilityTests : GameTest
+{
+    private const string TestArchetype = "SpaceCold";
+
+    [Test]
+    [TestCase("MobMonkey")]
+    [TestCase("MobCow")]
+    [TestCase("MobMouse")]
+    [TestCase("MobBee")]
+    public async Task AnimalsCannotHostPathogens(string prototype)
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var animal = entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+            var strain = registry.Generate(TestArchetype)!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(pathogens.CanHost(animal), Is.False, $"{prototype} must not be a valid host.");
+                Assert.That(
+                    pathogens.TryInfect(animal, strain.Id, bypassImmunity: true),
+                    Is.False,
+                    $"{prototype} must resist even a forced infection.");
+                Assert.That(entities.HasComponent<PathogenInfectionComponent>(animal), Is.False);
+            });
+        });
+    }
+
+    [Test]
+    [TestCase("MobIPC")]
+    [TestCase("MobSkeletonPerson")]
+    public async Task SyntheticAndUndeadSpeciesAreTotallyImmune(string prototype)
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+        var hosts = server.System<PathogenHostSelectionSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var mob = entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+            var strain = registry.Generate(TestArchetype)!;
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    entities.GetComponent<PathogenImmunityComponent>(mob).Total,
+                    Is.True,
+                    $"{prototype} must declare total pathogen immunity.");
+                Assert.That(pathogens.CanHost(mob), Is.False);
+                Assert.That(hosts.IsEligibleAutomaticHost(mob), Is.False);
+                Assert.That(pathogens.TryInfect(mob, strain.Id, bypassImmunity: true), Is.False);
+            });
+        });
+    }
+
+    [Test]
+    public async Task CrewCanStillHostPathogens()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var crew = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+            var strain = registry.Generate(TestArchetype)!;
+
+            Assert.That(pathogens.CanHost(crew), Is.True);
+            Assert.That(pathogens.TryInfect(crew, strain.Id), Is.True);
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyAdminToolsTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyAdminToolsTests.cs
@@ -127,7 +127,7 @@ public sealed class VirologyAdminToolsTests : GameTest
         await SpawnPlayerHost();
 
         await server.WaitPost(() =>
-            console.ExecuteCommand($"virology custom {TestArchetype} spread=0 cap=0.25 symptoms=0 hosts=1"));
+            console.ExecuteCommand($"virology custom {TestArchetype} spread=0 cap=0.05 symptoms=0 hosts=1"));
 
         await server.WaitAssertion(() =>
         {
@@ -144,8 +144,8 @@ public sealed class VirologyAdminToolsTests : GameTest
                     "A zero spread multiplier must produce a strain that cannot transmit.");
                 Assert.That(
                     strain.MaxPrevalence,
-                    Is.LessThanOrEqualTo(0.25f),
-                    "The prevalence cap must not exceed what the admin asked for.");
+                    Is.EqualTo(0.05f).Within(0.0001f),
+                    "The prevalence cap must preserve what the admin asked for.");
                 Assert.That(
                     strain.Symptoms
                         .Select(id => prototypes.Index(id))

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyAdminToolsTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyAdminToolsTests.cs
@@ -1,0 +1,339 @@
+using System.Linq;
+using System.Numerics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Server.Administration.Managers;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Mind;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Verbs;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class VirologyAdminToolsTests : GameTest
+{
+    private const string TestArchetype = "SpaceCold";
+
+    private async Task<EntityUid> SpawnPlayerHost()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var minds = server.System<SharedMindSystem>();
+
+        EntityUid host = default;
+        await server.WaitPost(() =>
+        {
+            server.System<SharedMapSystem>().CreateMap(out var mapId);
+            host = entities.SpawnEntity("MobHuman", new MapCoordinates(Vector2.Zero, mapId));
+
+            var mindId = minds.CreateMind(ServerSession!.UserId);
+            minds.TransferTo(mindId, host);
+            server.PlayerMan.SetAttachedEntity(ServerSession, host);
+        });
+
+        await server.WaitRunTicks(1);
+        return host;
+    }
+
+    [Test]
+    public async Task InfectedRosterSeparatesLivingHostsFromCorpses()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+        var hosts = server.System<PathogenHostSelectionSystem>();
+        var mobState = server.System<MobStateSystem>();
+
+        var player = await SpawnPlayerHost();
+
+        Pathogen strain = default!;
+        EntityUid corpse = default;
+        await server.WaitPost(() =>
+        {
+            strain = registry.Generate(TestArchetype)!;
+            corpse = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+
+            Assert.That(pathogens.TryInfect(player, strain.Id), Is.True);
+            Assert.That(pathogens.TryInfect(corpse, strain.Id), Is.True);
+            mobState.ChangeMobState(corpse, MobState.Dead);
+        });
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            var crew = hosts.CountLivingCrew();
+            Assert.That(crew, Is.GreaterThan(0), "The denominator must count the living player.");
+
+            var infections = entities.GetComponent<PathogenInfectionComponent>(corpse).Infections;
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    infections.Any(infection => infection.Pathogen == strain.Id),
+                    Is.True,
+                    "A corpse keeps its infection, so the roster has to account for it.");
+                Assert.That(
+                    entities.GetComponent<MobStateComponent>(corpse).CurrentState,
+                    Is.EqualTo(MobState.Dead),
+                    "The dead carrier must not be counted as a living host.");
+            });
+        });
+    }
+
+    [Test]
+    public async Task CustomCommandInfectsAPlayerHost()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var registry = server.System<PathogenRegistrySystem>();
+
+        var host = await SpawnPlayerHost();
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology custom {TestArchetype} hosts=1"));
+
+        await server.WaitAssertion(() =>
+        {
+            var strain = registry.Strains.Values
+                .Where(candidate => candidate.Archetype == TestArchetype)
+                .MaxBy(candidate => candidate.Id);
+
+            Assert.That(strain, Is.Not.Null, "The outbreak must generate a runtime strain.");
+            Assert.That(
+                entities.GetComponent<PathogenInfectionComponent>(host).Infections
+                    .Select(infection => infection.Pathogen),
+                Does.Contain(strain!.Id),
+                "An admin outbreak must land on an eligible player host.");
+        });
+    }
+
+    [Test]
+    public async Task CustomCommandAppliesTuningOptions()
+    {
+        var server = Pair.Server;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var prototypes = server.ResolveDependency<IPrototypeManager>();
+        var registry = server.System<PathogenRegistrySystem>();
+
+        await SpawnPlayerHost();
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology custom {TestArchetype} spread=0 cap=0.25 symptoms=0 hosts=1"));
+
+        await server.WaitAssertion(() =>
+        {
+            var strain = registry.Strains.Values
+                .Where(candidate => candidate.Archetype == TestArchetype)
+                .MaxBy(candidate => candidate.Id);
+
+            Assert.That(strain, Is.Not.Null);
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    strain!.Transmissibility,
+                    Is.EqualTo(0f).Within(0.0001f),
+                    "A zero spread multiplier must produce a strain that cannot transmit.");
+                Assert.That(
+                    strain.MaxPrevalence,
+                    Is.LessThanOrEqualTo(0.25f),
+                    "The prevalence cap must not exceed what the admin asked for.");
+                Assert.That(
+                    strain.Symptoms
+                        .Select(id => prototypes.Index(id))
+                        .Count(symptom => symptom.MinStage == 2),
+                    Is.EqualTo(0),
+                    "symptoms=0 should suppress the random stage-two symptom draw.");
+            });
+        });
+    }
+
+    [Test]
+    public async Task InfectAndCureCommandsTargetOneHost()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+
+        var host = await SpawnPlayerHost();
+        var netHost = entities.GetNetEntity(host);
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology custom {TestArchetype} hosts=0"));
+
+        Pathogen strain = default!;
+        await server.WaitAssertion(() =>
+        {
+            strain = registry.Strains.Values
+                .Where(candidate => candidate.Archetype == TestArchetype)
+                .MaxBy(candidate => candidate.Id)!;
+            Assert.That(strain, Is.Not.Null);
+            Assert.That(entities.HasComponent<PathogenInfectionComponent>(host), Is.False);
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology infect {netHost} {strain.Id}"));
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                entities.GetComponent<PathogenInfectionComponent>(host).Infections
+                    .Select(infection => infection.Pathogen),
+                Does.Contain(strain.Id)));
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology cure {netHost} {strain.Id}"));
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(
+                entities.HasComponent<PathogenInfectionComponent>(host),
+                Is.False);
+            Assert.That(
+                pathogens.IsImmune(host, strain.Id),
+                Is.True,
+                "Admin cure should make the target immune to the cured strain.");
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology infect {netHost} {strain.Id}"));
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                entities.HasComponent<PathogenInfectionComponent>(host),
+                Is.False,
+                "The normal admin infect command must respect strain immunity."));
+    }
+
+    [Test]
+    public async Task CureAllClearsEveryInfection()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var pathogens = server.System<PathogenSystem>();
+
+        var host = await SpawnPlayerHost();
+        var strainId = 0;
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virology custom {TestArchetype} hosts=1"));
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(
+                entities.HasComponent<PathogenInfectionComponent>(host),
+                Is.True,
+                "The outbreak has to land before cureall means anything.");
+            strainId = entities.GetComponent<PathogenInfectionComponent>(host)
+                .Infections
+                .Single()
+                .Pathogen;
+        });
+
+        await server.WaitPost(() => console.ExecuteCommand("virology cureall"));
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(
+                entities.HasComponent<PathogenInfectionComponent>(host),
+                Is.False,
+                "The panic button must leave nobody infected.");
+            Assert.That(
+                pathogens.IsImmune(host, strainId),
+                Is.True,
+                "The panic button should make carriers immune to the strains it cured.");
+        });
+    }
+
+    [Test]
+    public async Task AdminVerbsCureAndImmunise()
+    {
+        var server = Pair.Server;
+        var entities = server.EntMan;
+        var admins = server.ResolveDependency<IAdminManager>();
+        var verbs = server.System<SharedVerbSystem>();
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+
+        var admin = await SpawnPlayerHost();
+
+        EntityUid patient = default;
+        Pathogen strain = default!;
+        await server.WaitPost(() =>
+        {
+            patient = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+            admins.PromoteHost(ServerSession!);
+
+            strain = registry.Generate(TestArchetype)!;
+            Assert.That(pathogens.TryInfect(patient, strain.Id), Is.True);
+        });
+        await server.WaitRunTicks(1);
+
+        var cureText = string.Empty;
+        var immuneText = string.Empty;
+
+        await server.WaitAssertion(() =>
+        {
+            cureText = Loc.GetString("verb-virology-cure-text");
+            immuneText = Loc.GetString("verb-virology-immune-text");
+
+            var offered = verbs.GetLocalVerbs(patient, admin, typeof(Verb))
+                .Where(verb => verb.Category?.Text == Loc.GetString("verb-categories-virology"))
+                .Select(verb => verb.Text)
+                .ToList();
+
+            Assert.That(
+                offered,
+                Is.EquivalentTo(new[] { cureText, immuneText }),
+                "The Virology category must hold exactly the cure and immunity verbs.");
+        });
+
+        await server.WaitPost(() =>
+        {
+            var cure = verbs.GetLocalVerbs(patient, admin, typeof(Verb))
+                .First(verb => verb.Text == cureText);
+            cure.Act!();
+        });
+        await server.WaitRunTicks(1);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(
+                entities.HasComponent<PathogenInfectionComponent>(patient),
+                Is.False,
+                "The cure verb must clear every strain the target carries.");
+            Assert.That(
+                pathogens.IsImmune(patient, strain.Id),
+                Is.True,
+                "The cure verb must grant immunity to each strain it clears.");
+        });
+
+        await server.WaitPost(() =>
+        {
+            var immune = verbs.GetLocalVerbs(patient, admin, typeof(Verb))
+                .First(verb => verb.Text == immuneText);
+            immune.Act!();
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(entities.GetComponent<PathogenImmunityComponent>(patient).Total, Is.True);
+            Assert.That(
+                pathogens.CanHost(patient),
+                Is.False,
+                "Total immunity must take the target out of the host pool entirely.");
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyContentTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyContentTests.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Shared._Starlight.Medical.Virology;
+using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class VirologyContentTests : GameTest
+{
+    [Test]
+    public async Task EverySymptomIsReachableAndLocalised()
+    {
+        var loc = Pair.Server.ResolveDependency<ILocalizationManager>();
+        var prototypes = Pair.Server.ResolveDependency<IPrototypeManager>();
+
+        await Pair.Server.WaitAssertion(() =>
+        {
+            var referenced = new HashSet<string>(
+                prototypes.EnumeratePrototypes<PathogenArchetypePrototype>()
+                    .SelectMany(archetype => archetype.StageThreeSymptoms
+                        .Concat(archetype.StageOneSymptoms)
+                        .Concat(archetype.StageTwoSymptomPool))
+                    .Select(symptom => symptom.Id));
+
+            Assert.Multiple(() =>
+            {
+                foreach (var symptom in prototypes.EnumeratePrototypes<PathogenSymptomPrototype>())
+                {
+                    Assert.That(
+                        loc.HasString(symptom.Name),
+                        Is.True,
+                        $"Symptom '{symptom.ID}' has no locale string for '{symptom.Name}'.");
+
+                    Assert.That(
+                        referenced.Contains(symptom.ID),
+                        Is.True,
+                        $"Symptom '{symptom.ID}' is in no archetype pool, so it can never fire.");
+                }
+            });
+        });
+    }
+
+    [Test]
+    public async Task EveryArchetypeIsLocalisedAndReferencesRealSymptoms()
+    {
+        var loc = Pair.Server.ResolveDependency<ILocalizationManager>();
+        var prototypes = Pair.Server.ResolveDependency<IPrototypeManager>();
+
+        await Pair.Server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var archetype in prototypes.EnumeratePrototypes<PathogenArchetypePrototype>())
+                {
+                    Assert.That(
+                        loc.HasString(archetype.Name),
+                        Is.True,
+                        $"Archetype '{archetype.ID}' has no locale string for '{archetype.Name}'.");
+
+                    if (archetype.Description is { } description)
+                    {
+                        Assert.That(
+                            loc.HasString(description),
+                            Is.True,
+                            $"Archetype '{archetype.ID}' has no locale string for '{description}'.");
+                    }
+
+                    var pool = archetype.StageThreeSymptoms
+                        .Concat(archetype.StageOneSymptoms)
+                        .Concat(archetype.StageTwoSymptomPool)
+                        .ToList();
+
+                    Assert.That(
+                        pool,
+                        Is.Not.Empty,
+                        $"Archetype '{archetype.ID}' has no symptoms at all.");
+
+                    foreach (var symptom in pool)
+                    {
+                        Assert.That(
+                            prototypes.HasIndex(symptom),
+                            Is.True,
+                            $"Archetype '{archetype.ID}' references missing symptom '{symptom}'.");
+                    }
+                }
+            });
+        });
+    }
+
+    /// <summary>
+    /// Selection is by which list a symptom sits in, not by its stage - the generator would
+    /// happily roll a stage three symptom out of the stage two pool. The tiering only holds
+    /// because the archetypes are authored carefully, so it is checked here rather than left
+    /// to good manners.
+    /// </summary>
+    [Test]
+    public async Task ArchetypeSymptomListsHoldOnlyTheirOwnStage()
+    {
+        var prototypes = Pair.Server.ResolveDependency<IPrototypeManager>();
+
+        await Pair.Server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var archetype in prototypes.EnumeratePrototypes<PathogenArchetypePrototype>())
+                {
+                    AssertStage(archetype, archetype.StageOneSymptoms, 1, nameof(archetype.StageOneSymptoms));
+                    AssertStage(archetype, archetype.StageTwoSymptomPool, 2, nameof(archetype.StageTwoSymptomPool));
+                    AssertStage(archetype, archetype.StageThreeSymptoms, 3, nameof(archetype.StageThreeSymptoms));
+                }
+            });
+
+            void AssertStage(
+                PathogenArchetypePrototype archetype,
+                List<ProtoId<PathogenSymptomPrototype>> symptoms,
+                int expected,
+                string field)
+            {
+                foreach (var symptom in symptoms)
+                {
+                    if (!prototypes.TryIndex(symptom, out var proto))
+                        continue;
+
+                    Assert.That(
+                        proto.MinStage,
+                        Is.EqualTo(expected),
+                        $"Archetype '{archetype.ID}' lists '{symptom}' under {field}, " +
+                        $"but that symptom is stage {proto.MinStage}.");
+                }
+            }
+        });
+    }
+}

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyContentTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyContentTests.cs
@@ -121,7 +121,12 @@ public sealed class VirologyContentTests : GameTest
             {
                 foreach (var symptom in symptoms)
                 {
-                    if (!prototypes.TryIndex(symptom, out var proto))
+                    Assert.That(
+                        prototypes.TryIndex(symptom, out var proto),
+                        Is.True,
+                        $"Archetype '{archetype.ID}' lists missing symptom '{symptom}' under {field}.");
+
+                    if (proto is null)
                         continue;
 
                     Assert.That(

--- a/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyTestCommandTests.cs
+++ b/Content.IntegrationTests/Tests/_Starlight/Medical/Virology/VirologyTestCommandTests.cs
@@ -1,0 +1,183 @@
+using System.Linq;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._Starlight.Medical.Virology;
+using Content.Shared._Starlight.Medical.Virology;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests.Tests._Starlight.Medical.Virology;
+
+[TestFixture]
+public sealed class VirologyTestCommandTests : GameTest
+{
+    [Test]
+    public async Task TestInfectBypassesStrainImmunity()
+    {
+        var server = Pair.Server;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var pathogens = server.System<PathogenSystem>();
+
+        EntityUid human = default;
+        Pathogen strain = default!;
+        await server.WaitPost(() =>
+        {
+            human = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace);
+            strain = registry.Generate("SpaceCold")!;
+            pathogens.GrantImmunity(human, strain.Id);
+        });
+        await server.WaitRunTicks(1);
+
+        var netHuman = entities.GetNetEntity(human);
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest infect {netHuman} {strain.Id}"));
+
+        await server.WaitAssertion(() =>
+            Assert.That(
+                entities.GetComponent<PathogenInfectionComponent>(human)
+                    .Infections
+                    .Select(infection => infection.Pathogen),
+                Does.Contain(strain.Id),
+                "virotest infect is the force/debug path and should bypass strain immunity."));
+    }
+
+    [Test]
+    public async Task AdminHarnessControlsLiveVirologyState()
+    {
+        var server = Pair.Server;
+        var console = server.ResolveDependency<IConsoleHost>();
+        var entities = server.EntMan;
+        var registry = server.System<PathogenRegistrySystem>();
+        var contamination = server.System<PathogenContaminationSystem>();
+
+        await server.WaitPost(() => console.ExecuteCommand("virotest setup"));
+
+        Pathogen virus = default!;
+        Pathogen fungus = default!;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(
+                registry.Strains.Values.Select(strain => strain.Archetype.Id),
+                Is.SupersetOf(new[]
+                {
+                    "SpaceCold",
+                    "ThroatRot",
+                    "SporeBloom",
+                    "StationFlu",
+                    "GreyLung",
+                    "Mycosis",
+                }));
+
+            virus = registry.Strains.Values
+                .Where(strain => strain.Archetype == "SpaceCold")
+                .MaxBy(strain => strain.Id)!;
+            fungus = registry.Strains.Values
+                .Where(strain => strain.Archetype == "SporeBloom")
+                .MaxBy(strain => strain.Id)!;
+        });
+
+        EntityUid human = default;
+        await server.WaitPost(() =>
+            human = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace));
+        var netHuman = entities.GetNetEntity(human);
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest infect {netHuman} {virus.Id}"));
+        await server.WaitAssertion(() =>
+        {
+            var infections = entities.GetComponent<PathogenInfectionComponent>(human);
+            var infection = infections.Infections.Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(infection.Pathogen, Is.EqualTo(virus.Id));
+                Assert.That(infection.SymptomIntervalOverride, Is.EqualTo(TimeSpan.FromSeconds(3)));
+            });
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest fast {netHuman} {virus.Id} 1"));
+        await server.WaitAssertion(() =>
+        {
+            var infection = entities.GetComponent<PathogenInfectionComponent>(human).Infections.Single();
+            Assert.That(infection.SymptomIntervalOverride, Is.EqualTo(TimeSpan.FromSeconds(1)));
+        });
+
+        EntityUid fungalHuman = default;
+        await server.WaitPost(() =>
+            fungalHuman = entities.SpawnEntity("MobHuman", MapCoordinates.Nullspace));
+        var netFungalHuman = entities.GetNetEntity(fungalHuman);
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest infect {netFungalHuman} {fungus.Id}"));
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest stage {netFungalHuman} {fungus.Id} {fungus.MaxStage}"));
+
+        // Infections advance once a second rather than once a tick, so the symptom timers
+        // this asserts on are not scheduled until the throttle in PathogenSystem lets a
+        // pass through.
+        await server.WaitRunTicks(35);
+        await server.WaitAssertion(() =>
+        {
+            var infection = entities.GetComponent<PathogenInfectionComponent>(fungalHuman)
+                .Infections
+                .Single(active => active.Pathogen == fungus.Id);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(infection.SymptomTimers, Has.Count.EqualTo(fungus.Symptoms.Count));
+                Assert.That(
+                    infection.SymptomTimers.Values.Distinct().Count(),
+                    Is.EqualTo(fungus.Symptoms.Count));
+            });
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest stage {netHuman} {virus.Id} 1"));
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest identify {netHuman} {virus.Id}"));
+        await server.WaitAssertion(() =>
+        {
+            var infection = entities.GetComponent<PathogenInfectionComponent>(human)
+                .Infections
+                .Single(active => active.Pathogen == virus.Id);
+            Assert.Multiple(() =>
+            {
+                Assert.That(infection.Stage, Is.EqualTo(1));
+                Assert.That(virus.Identification, Is.EqualTo(PathogenIdentificationStage.Complete));
+            });
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand("virotest contamination 10 20 30"));
+        await server.WaitAssertion(() =>
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(contamination.Contamination, Is.EqualTo(60f).Within(0.0001f));
+                Assert.That(
+                    contamination.GetContamination(PathogenType.Virus),
+                    Is.EqualTo(10f).Within(0.0001f));
+                Assert.That(
+                    contamination.GetContamination(PathogenType.Bacteria),
+                    Is.EqualTo(20f).Within(0.0001f));
+                Assert.That(
+                    contamination.GetContamination(PathogenType.Fungus),
+                    Is.EqualTo(30f).Within(0.0001f));
+            });
+        });
+
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest cure {netHuman} all"));
+        await server.WaitPost(() =>
+            console.ExecuteCommand($"virotest cure {netFungalHuman} all"));
+        await server.WaitAssertion(() =>
+        {
+            if (entities.TryGetComponent<PathogenInfectionComponent>(human, out var infections))
+                Assert.That(infections.Infections, Is.Empty);
+            if (entities.TryGetComponent<PathogenInfectionComponent>(fungalHuman, out var fungalInfections))
+                Assert.That(fungalInfections.Infections, Is.Empty);
+        });
+    }
+}

--- a/Content.Server/_Starlight/Medical/Virology/Commands/VirologyCommand.cs
+++ b/Content.Server/_Starlight/Medical/Virology/Commands/VirologyCommand.cs
@@ -1,0 +1,530 @@
+using System.Globalization;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Administration.Logs;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Starlight.Medical.Virology.Commands;
+
+/// <summary>
+/// The permanent admin-facing controls for running disease as an event: build a tuned
+/// strain, infect or cure targeted hosts, or stop everything. Distinct from
+/// <see cref="VirologyTestCommand"/>, which is developer scaffolding for verifying
+/// mechanics rather than running a shift.
+/// </summary>
+[AdminCommand(AdminFlags.Fun)]
+public sealed partial class VirologyCommand : IConsoleCommand
+{
+    private const int DefaultReleaseHosts = 2;
+
+    [Dependency] private IAdminLogManager _adminLog = default!;
+    [Dependency] private IEntityManager _entities = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    /// <summary>
+    /// How many hosts one roster line names before it summarises the rest. The roster is
+    /// meant to be readable at a glance during a shift, not a complete census.
+    /// </summary>
+    private const int RosterHostLimit = 10;
+
+    private static readonly string[] Subcommands =
+    [
+        "custom",
+        "infect",
+        "cure",
+        "cureall",
+        "infected",
+        "help",
+    ];
+
+    public string Command => "virology";
+
+    public string Description => "Runs disease as an admin event: build a strain, infect hosts, or cure the station.";
+
+    public string Help =>
+        "virology custom <archetype> [hosts=n] [spread=x] [stageDelay=x] [cap=x] [symptoms=n]\n" +
+        "  Creates a runtime strain from an archetype and optionally infects random living crew.\n" +
+        $"  hosts is the number of random hosts to infect; default {DefaultReleaseHosts}, use 0 to only create the strain.\n" +
+        "  spread and stageDelay are multipliers; 1 is the authored value, 0 disables that value.\n" +
+        "  cap is the maximum share of living crew that can carry it, from 0 to 1.\n" +
+        "  symptoms is the exact number of extra random symptoms to add.\n" +
+        "  examples: virology custom SpaceCold hosts=2\n" +
+        "            virology custom GreyLung hosts=0 spread=0.5 stageDelay=0.25 cap=0.30 symptoms=3\n" +
+        "virology infect <self|netEntity> <strainId>\n" +
+        "virology cure <self|netEntity> <strainId|all>\n" +
+        "virology cureall\n" +
+        "virology infected [strainId]\n" +
+        "  Lists every strain someone is currently carrying, with its share of living crew\n" +
+        "  against its own cap. Pass a strain id for the full host list and their stages.";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length == 0)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        switch (args[0].ToLowerInvariant())
+        {
+            case "custom":
+                Custom(shell, args);
+                break;
+            case "infect":
+                Infect(shell, args);
+                break;
+            case "cure":
+                Cure(shell, args);
+                break;
+            case "cureall":
+                CureAll(shell, args);
+                break;
+            case "infected":
+                Infected(shell, args);
+                break;
+            case "help":
+                shell.WriteLine(Help);
+                break;
+            default:
+                shell.WriteError($"Unknown virology subcommand '{args[0]}'.");
+                shell.WriteLine(Help);
+                break;
+        }
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+            return CompletionResult.FromHintOptions(Subcommands, "<subcommand>");
+
+        if (args.Length == 2 &&
+            args[0].Equals("custom", StringComparison.OrdinalIgnoreCase))
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.PrototypeIDs<PathogenArchetypePrototype>(),
+                "<pathogenArchetype>");
+        }
+
+        return CompletionResult.Empty;
+    }
+
+    private void Custom(IConsoleShell shell, string[] args)
+    {
+        if (args.Length < 2 ||
+            !TryResolveArchetype(shell, args[1], out var archetype))
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        var options = new PathogenGenerationOptions();
+        var hostCount = DefaultReleaseHosts;
+
+        foreach (var argument in args.Skip(2))
+        {
+            var parts = argument.Split('=', 2);
+            if (parts.Length != 2)
+            {
+                shell.WriteError($"'{argument}' is not a key=value option.");
+                return;
+            }
+
+            var key = parts[0].ToLowerInvariant();
+            if (key == "hosts")
+            {
+                if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out hostCount) ||
+                    hostCount < 0)
+                {
+                    shell.WriteError($"'{parts[1]}' is not a valid host count.");
+                    return;
+                }
+
+                continue;
+            }
+
+            if (key == "symptoms")
+            {
+                if (!int.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var extra) ||
+                    extra < 0)
+                {
+                    shell.WriteError($"'{parts[1]}' is not a valid symptom count.");
+                    return;
+                }
+
+                options.StageTwoSymptomCount = extra;
+                continue;
+            }
+
+            if (!float.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ||
+                value < 0f)
+            {
+                shell.WriteError($"'{parts[1]}' is not a valid value for '{key}'.");
+                return;
+            }
+
+            switch (key)
+            {
+                case "spread":
+                    options.TransmissibilityMultiplier = value;
+                    break;
+                case "stagedelay":
+                case "stages":
+                    options.StageDelayMultiplier = value;
+                    break;
+                case "cap":
+                    options.MaxPrevalenceCap = Math.Clamp(value, 0f, 1f);
+                    break;
+                default:
+                    shell.WriteError($"Unknown option '{key}'.");
+                    shell.WriteLine(Help);
+                    return;
+            }
+        }
+
+        var strain = _entities.System<PathogenRegistrySystem>().Generate(archetype, options);
+        Release(shell, strain, hostCount, "custom strain");
+    }
+
+    private void Infect(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target) ||
+            !TryParseStrain(shell, args[2], out var strain))
+        {
+            shell.WriteLine("Usage: virology infect <self|netEntity> <strainId>");
+            return;
+        }
+
+        var infected = _entities.System<PathogenSystem>().TryInfect(
+            target,
+            strain.Id,
+            cause: "admin infect");
+
+        shell.WriteLine(infected
+            ? $"Infected {Pretty(target)} with #{strain.Id} {strain.Designation}."
+            : $"Could not infect {Pretty(target)} with #{strain.Id}; it may already carry the strain, be immune to it, or be an invalid host.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} ran virology infect on {_entities.ToPrettyString(target):target} with {strain.Designation:strain} (infected={infected})");
+    }
+
+    private void Cure(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target))
+        {
+            shell.WriteLine("Usage: virology cure <self|netEntity> <strainId|all>");
+            return;
+        }
+
+        var pathogen = _entities.System<PathogenSystem>();
+        if (args[2].Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!_entities.TryGetComponent<PathogenInfectionComponent>(target, out var infections))
+            {
+                shell.WriteLine($"{Pretty(target)} has no infections.");
+                return;
+            }
+
+            var cured = 0;
+            foreach (var strainId in infections.Infections.Select(infection => infection.Pathogen).ToArray())
+            {
+                if (pathogen.Cure(target, strainId, grantImmunity: true, cause: "admin cure"))
+                    cured++;
+            }
+
+            shell.WriteLine($"Cured {cured} infection(s) from {Pretty(target)}.");
+            _adminLog.Add(LogType.Virology, LogImpact.Medium,
+                $"{Actor(shell)} ran virology cure all on {_entities.ToPrettyString(target):target} ({cured} cleared)");
+            return;
+        }
+
+        if (!TryParseStrain(shell, args[2], out var strain))
+            return;
+
+        var removed = pathogen.Cure(target, strain.Id, grantImmunity: true, cause: "admin cure");
+        shell.WriteLine(removed
+            ? $"Cured #{strain.Id} from {Pretty(target)}."
+            : $"{Pretty(target)} does not carry #{strain.Id}.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} ran virology cure on {_entities.ToPrettyString(target):target} for {strain.Designation:strain} (cured={removed})");
+    }
+
+    private void Release(IConsoleShell shell, Pathogen strain, int hostCount, string cause)
+    {
+        if (hostCount == 0)
+        {
+            WriteRelease(shell, strain, infected: 0);
+            _adminLog.Add(LogType.Virology, LogImpact.Medium,
+                $"{Actor(shell)} created {cause} {strain.Designation:strain} ({strain.Tier}/{strain.PathogenType}) without infecting any hosts");
+            return;
+        }
+
+        var hosts = _entities.System<PathogenHostSelectionSystem>().GetEligibleAutomaticHosts();
+        if (hosts.Count == 0)
+        {
+            shell.WriteError("No eligible hosts are available - nobody is alive and playable.");
+            return;
+        }
+
+        _random.Shuffle(hosts);
+
+        var pathogen = _entities.System<PathogenSystem>();
+        var infected = 0;
+        foreach (var host in hosts)
+        {
+            if (infected >= hostCount)
+                break;
+
+            if (pathogen.TryInfect(host, strain.Id, bypassImmunity: true, cause: $"admin {cause}"))
+                infected++;
+        }
+
+        WriteRelease(shell, strain, infected);
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} released {cause} {strain.Designation:strain} ({strain.Tier}/{strain.PathogenType}) on {infected} host(s)");
+    }
+
+    private static void WriteRelease(IConsoleShell shell, Pathogen strain, int infected)
+    {
+        shell.WriteLine(
+            $"Released #{strain.Id} {strain.Designation} [{strain.Archetype}] " +
+            $"{strain.Tier}/{strain.PathogenType} on {infected} host(s); " +
+            $"transmission={strain.Transmissibility:P1}; prevalence cap={strain.MaxPrevalence:P1}; " +
+            $"stages={strain.MaxStage}.");
+    }
+
+    /// <summary>
+    /// The panic button. An outbreak that has got out of hand needs one action that stops
+    /// it, not a cure applied person by person while it keeps spreading behind you.
+    /// </summary>
+    private void CureAll(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteLine("Usage: virology cureall");
+            return;
+        }
+
+        // Collected first: curing clears the component, and that must not happen while the
+        // query that produced it is still being enumerated.
+        var carriers = new List<EntityUid>();
+        var query = _entities.EntityQueryEnumerator<PathogenInfectionComponent>();
+        while (query.MoveNext(out var uid, out _))
+            carriers.Add(uid);
+
+        var pathogen = _entities.System<PathogenSystem>();
+        var cured = 0;
+        foreach (var carrier in carriers)
+        {
+            if (!_entities.TryGetComponent<PathogenInfectionComponent>(carrier, out var infections))
+                continue;
+
+            foreach (var infection in infections.Infections.ToArray())
+            {
+                if (pathogen.Cure(carrier, infection.Pathogen, grantImmunity: true, cause: "admin cureall"))
+                    cured++;
+            }
+        }
+
+        shell.WriteLine($"Cured {cured} infection(s) across {carriers.Count} carrier(s).");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} cured every active infection on the station ({cured} across {carriers.Count} carriers)");
+    }
+
+    /// <summary>
+    /// Who is carrying what, right now. Dead carriers are counted separately because a
+    /// corpse keeps its infection but does not occupy prevalence budget, so folding it into
+    /// the share would report an outbreak as larger than the cap actually treats it.
+    /// </summary>
+    private void Infected(IConsoleShell shell, string[] args)
+    {
+        if (args.Length > 2)
+        {
+            shell.WriteLine("Usage: virology infected [strainId]");
+            return;
+        }
+
+        Pathogen? requested = null;
+        if (args.Length == 2)
+        {
+            if (!TryParseStrain(shell, args[1], out var parsed))
+                return;
+
+            requested = parsed;
+        }
+
+        var living = new Dictionary<int, List<EntityUid>>();
+        var dead = new Dictionary<int, List<EntityUid>>();
+        var mobStates = _entities.GetEntityQuery<MobStateComponent>();
+
+        var query = _entities.EntityQueryEnumerator<PathogenInfectionComponent>();
+        while (query.MoveNext(out var uid, out var infections))
+        {
+            var isDead = mobStates.TryGetComponent(uid, out var mobState) &&
+                mobState.CurrentState == MobState.Dead;
+
+            foreach (var infection in infections.Infections)
+            {
+                if (requested is { } only && infection.Pathogen != only.Id)
+                    continue;
+
+                var bucket = isDead ? dead : living;
+                if (!bucket.TryGetValue(infection.Pathogen, out var hosts))
+                    bucket[infection.Pathogen] = hosts = new List<EntityUid>();
+
+                hosts.Add(uid);
+            }
+        }
+
+        var registry = _entities.System<PathogenRegistrySystem>();
+        var livingCrew = _entities.System<PathogenHostSelectionSystem>().CountLivingCrew();
+
+        shell.WriteLine($"Active infections - living crew={livingCrew}");
+
+        var strainIds = new HashSet<int>(living.Keys);
+        strainIds.UnionWith(dead.Keys);
+
+        if (strainIds.Count == 0)
+        {
+            shell.WriteLine("  no active infections.");
+            return;
+        }
+
+        var rows = strainIds
+            .Select(id => (Id: id, Strain: registry.TryGetStrain(id, out var strain) ? strain : null))
+            .Where(row => row.Strain is not null)
+            .OrderByDescending(row => row.Strain!.Tier)
+            .ThenByDescending(row => living.GetValueOrDefault(row.Id)?.Count ?? 0)
+            .ThenBy(row => row.Id);
+
+        foreach (var (id, strain) in rows)
+        {
+            var alive = living.GetValueOrDefault(id) ?? new List<EntityUid>();
+            var corpses = dead.GetValueOrDefault(id) ?? new List<EntityUid>();
+
+            var share = livingCrew > 0 ? alive.Count / (float) livingCrew : 0f;
+            var deadNote = corpses.Count > 0 ? $" +{corpses.Count} dead" : string.Empty;
+
+            shell.WriteLine(
+                $"#{id} {strain!.Designation} [{strain.Archetype}] {strain.Tier}/{strain.PathogenType} " +
+                $"{alive.Count} host(s){deadNote} {share:P1}/{strain.MaxPrevalence:P0}");
+
+            if (requested is null)
+            {
+                shell.WriteLine($"  {FormatHosts(alive)}");
+                continue;
+            }
+
+            foreach (var host in alive)
+                shell.WriteLine($"  {Pretty(host)} {FormatStage(host, id, strain)}");
+
+            foreach (var host in corpses)
+                shell.WriteLine($"  {Pretty(host)} {FormatStage(host, id, strain)} (dead)");
+        }
+    }
+
+    private string FormatHosts(List<EntityUid> hosts)
+    {
+        if (hosts.Count == 0)
+            return "no living hosts";
+
+        var shown = hosts
+            .Take(RosterHostLimit)
+            .Select(host => _entities.GetNetEntity(host).ToString());
+
+        var line = string.Join(", ", shown);
+        var hidden = hosts.Count - RosterHostLimit;
+
+        return hidden > 0 ? $"{line}, +{hidden} more" : line;
+    }
+
+    private string FormatStage(EntityUid host, int strainId, Pathogen strain)
+    {
+        if (!_entities.TryGetComponent<PathogenInfectionComponent>(host, out var infections))
+            return "stage ?";
+
+        foreach (var infection in infections.Infections)
+        {
+            if (infection.Pathogen == strainId)
+                return $"stage {infection.Stage}/{strain.MaxStage}";
+        }
+
+        return "stage ?";
+    }
+
+    private bool TryResolveArchetype(
+        IConsoleShell shell,
+        string value,
+        out PathogenArchetypePrototype archetype)
+    {
+        if (!_prototypes.TryIndex(new ProtoId<PathogenArchetypePrototype>(value), out var found))
+        {
+            shell.WriteError($"Unknown pathogen archetype '{value}'.");
+            archetype = default!;
+            return false;
+        }
+
+        archetype = found;
+        return true;
+    }
+
+    private bool TryParseStrain(IConsoleShell shell, string value, out Pathogen strain)
+    {
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var strainId) ||
+            !_entities.System<PathogenRegistrySystem>().TryGetStrain(strainId, out var found))
+        {
+            shell.WriteError($"Unknown runtime strain id '{value}'. Create one with 'virology custom <archetype> hosts=0'.");
+            strain = default!;
+            return false;
+        }
+
+        strain = found;
+        return true;
+    }
+
+    private bool TryResolveTarget(IConsoleShell shell, string value, out EntityUid target)
+    {
+        if (value.Equals("self", StringComparison.OrdinalIgnoreCase))
+        {
+            if (shell.Player?.AttachedEntity is { } attached)
+            {
+                target = attached;
+                return true;
+            }
+
+            shell.WriteError("'self' requires a player-attached entity.");
+            target = default;
+            return false;
+        }
+
+        if (NetEntity.TryParse(value, out var netEntity) &&
+            _entities.TryGetEntity(netEntity, out var entity) &&
+            entity is { } resolved)
+        {
+            target = resolved;
+            return true;
+        }
+
+        shell.WriteError($"'{value}' is not a valid network entity.");
+        target = default;
+        return false;
+    }
+
+    private string Pretty(EntityUid uid)
+        => $"{_entities.ToPrettyString(uid)} [net {_entities.GetNetEntity(uid)}]";
+
+    private static string Actor(IConsoleShell shell)
+        => shell.Player?.Name ?? "An administrator";
+}

--- a/Content.Server/_Starlight/Medical/Virology/Commands/VirologyTestCommand.cs
+++ b/Content.Server/_Starlight/Medical/Virology/Commands/VirologyTestCommand.cs
@@ -1,0 +1,681 @@
+using System.Globalization;
+using System.Linq;
+using Content.Server.Administration;
+using Content.Server.Administration.Logs;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Robust.Shared.Console;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Starlight.Medical.Virology.Commands;
+
+/// <summary>
+/// Deterministic admin controls for exercising passive virology mechanics in a live test round.
+/// </summary>
+[AdminCommand(AdminFlags.Debug)]
+public sealed partial class VirologyTestCommand : IConsoleCommand
+{
+    private static readonly TimeSpan DefaultTestSymptomInterval = TimeSpan.FromSeconds(3);
+
+    [Dependency] private IAdminLogManager _adminLog = default!;
+    [Dependency] private IEntityManager _entities = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+
+    private static readonly string[] Subcommands =
+    [
+        "setup",
+        "generate",
+        "strains",
+        "status",
+        "infect",
+        "cure",
+        "stage",
+        "fast",
+        "identify",
+        "symptoms",
+        "symptom",
+        "contamination",
+        "sample",
+        "help",
+    ];
+
+    private static readonly ProtoId<PathogenArchetypePrototype>[] TestArchetypes =
+    [
+        "SpaceCold",
+        "ThroatRot",
+        "SporeBloom",
+        "StationFlu",
+        "GreyLung",
+        "Mycosis",
+    ];
+
+    public string Command => "virotest";
+
+    public string Description => "Controls runtime pathogen state for live virology testing.";
+
+    public string Help =>
+        "virotest setup\n" +
+        "virotest generate <archetype>\n" +
+        "virotest strains\n" +
+        "virotest status [self|netEntity]\n" +
+        "virotest infect <self|netEntity> <strainId>\n" +
+        "virotest cure <self|netEntity> <strainId|all>\n" +
+        "virotest stage <self|netEntity> <strainId> <stage>\n" +
+        "virotest fast <self|netEntity> <strainId|all> [seconds|off]\n" +
+        "virotest identify <self|netEntity> <strainId|all>\n" +
+        "virotest symptoms\n" +
+        "virotest symptom <self|netEntity> <symptomId>\n" +
+        "virotest contamination [virus bacteria fungus]\n" +
+        "virotest sample";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length == 0)
+        {
+            shell.WriteLine(Help);
+            return;
+        }
+
+        switch (args[0].ToLowerInvariant())
+        {
+            case "setup":
+                Setup(shell, args);
+                break;
+            case "generate":
+                Generate(shell, args);
+                break;
+            case "strains":
+                ListStrains(shell);
+                break;
+            case "status":
+                Status(shell, args);
+                break;
+            case "infect":
+                Infect(shell, args);
+                break;
+            case "cure":
+                Cure(shell, args);
+                break;
+            case "stage":
+                SetStage(shell, args);
+                break;
+            case "fast":
+                FastSymptoms(shell, args);
+                break;
+            case "identify":
+                Identify(shell, args);
+                break;
+            case "symptoms":
+                ListSymptoms(shell, args);
+                break;
+            case "symptom":
+                ForceSymptom(shell, args);
+                break;
+            case "contamination":
+                Contamination(shell, args);
+                break;
+            case "sample":
+                Sample(shell, args);
+                break;
+            case "help":
+                shell.WriteLine(Help);
+                break;
+            default:
+                shell.WriteError($"Unknown virotest subcommand '{args[0]}'.");
+                shell.WriteLine(Help);
+                break;
+        }
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        if (args.Length == 1)
+            return CompletionResult.FromHintOptions(Subcommands, "<subcommand>");
+
+        if (args.Length == 2 && args[0].Equals("generate", StringComparison.OrdinalIgnoreCase))
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.PrototypeIDs<PathogenArchetypePrototype>(),
+                "<pathogenArchetype>");
+        }
+
+        if (args.Length == 3 && args[0].Equals("symptom", StringComparison.OrdinalIgnoreCase))
+        {
+            return CompletionResult.FromHintOptions(
+                CompletionHelper.PrototypeIDs<PathogenSymptomPrototype>(),
+                "<pathogenSymptom>");
+        }
+
+        return CompletionResult.Empty;
+    }
+
+    private void Setup(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteLine("Usage: virotest setup");
+            return;
+        }
+
+        EnsureTestStrains(shell);
+        shell.WriteLine("Test strains are ready.");
+    }
+
+    private void Generate(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 2)
+        {
+            shell.WriteLine("Usage: virotest generate <archetype>");
+            return;
+        }
+
+        var registry = _entities.System<PathogenRegistrySystem>();
+        var strain = registry.Generate(new ProtoId<PathogenArchetypePrototype>(args[1]));
+        if (strain is null)
+        {
+            shell.WriteError($"Unknown pathogen archetype '{args[1]}'.");
+            return;
+        }
+
+        WriteStrain(shell, strain);
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} generated runtime strain {strain.Designation:strain} from archetype {args[1]}");
+    }
+
+    private void EnsureTestStrains(IConsoleShell shell)
+    {
+        var registry = _entities.System<PathogenRegistrySystem>();
+        foreach (var archetype in TestArchetypes)
+        {
+            var strain = registry.Strains.Values.FirstOrDefault(existing => existing.Archetype == archetype) ??
+                registry.Generate(archetype);
+
+            if (strain is null)
+            {
+                shell.WriteError($"Could not generate test strain from '{archetype}'.");
+                continue;
+            }
+
+            WriteStrain(shell, strain);
+        }
+    }
+
+    private void ListStrains(IConsoleShell shell)
+    {
+        var strains = _entities.System<PathogenRegistrySystem>().Strains.Values
+            .OrderBy(strain => strain.Id)
+            .ToList();
+
+        if (strains.Count == 0)
+        {
+            shell.WriteLine("No runtime pathogen strains exist.");
+            return;
+        }
+
+        foreach (var strain in strains)
+            WriteStrain(shell, strain);
+    }
+
+    private static void WriteStrain(IConsoleShell shell, Pathogen strain)
+    {
+        shell.WriteLine(
+            $"#{strain.Id} {strain.Designation} [{strain.Archetype}] " +
+            $"{strain.Tier}/{strain.PathogenType}; stages={strain.MaxStage}; " +
+            $"transmission={strain.Transmissibility:P1}; range={strain.SpreadRange:0.00}; " +
+            $"prevalence={strain.MaxPrevalence:P1}");
+        shell.WriteLine($"  symptoms: {string.Join(", ", strain.Symptoms)}");
+    }
+
+    private void Status(IConsoleShell shell, string[] args)
+    {
+        if (args.Length > 2 ||
+            !TryResolveOptionalTarget(shell, args, 1, out var target))
+        {
+            shell.WriteLine("Usage: virotest status [self|netEntity]");
+            return;
+        }
+
+        var hostSelection = _entities.System<PathogenHostSelectionSystem>();
+        shell.WriteLine(
+            $"{Pretty(target)}: canHost={hostSelection.CanHost(target)}, " +
+            $"automaticHost={hostSelection.IsEligibleAutomaticHost(target)}");
+
+        if (!_entities.TryGetComponent<PathogenInfectionComponent>(target, out var infections) ||
+            infections.Infections.Count == 0)
+        {
+            shell.WriteLine("  infections: none");
+            return;
+        }
+
+        var registry = _entities.System<PathogenRegistrySystem>();
+        foreach (var infection in infections.Infections.OrderBy(infection => infection.Pathogen))
+        {
+            if (!registry.TryGetStrain(infection.Pathogen, out var strain))
+            {
+                shell.WriteLine($"  #{infection.Pathogen}: missing strain");
+                continue;
+            }
+
+            var nextStage = infection.Stage >= strain.MaxStage
+                ? "max"
+                : $"{Math.Max(0d, (infection.NextStage - _timing.CurTime).TotalSeconds):0.0}s";
+            var remaining = infection.EndTime == TimeSpan.Zero
+                ? "never"
+                : $"{Math.Max(0d, (infection.EndTime - _timing.CurTime).TotalSeconds):0.0}s";
+
+            shell.WriteLine(
+                $"  #{strain.Id} {strain.Designation}: stage={infection.Stage}/{strain.MaxStage}, " +
+                $"next={nextStage}, clears={remaining}, identification={strain.Identification}, " +
+                $"symptomInterval={(infection.SymptomIntervalOverride is { } interval ? $"{interval.TotalSeconds:0.0}s" : "normal")}");
+        }
+    }
+
+    private void Infect(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target) ||
+            !TryParseStrain(shell, args[2], out var strain))
+        {
+            shell.WriteLine("Usage: virotest infect <self|netEntity> <strainId>");
+            return;
+        }
+
+        var pathogen = _entities.System<PathogenSystem>();
+        var infected = pathogen.TryInfect(target, strain.Id, bypassImmunity: true, cause: "virotest infect");
+        if (infected)
+            pathogen.TrySetSymptomInterval(target, strain.Id, DefaultTestSymptomInterval);
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} ran virotest infect on {_entities.ToPrettyString(target):target} with {strain.Designation:strain} (infected={infected})");
+
+        shell.WriteLine(infected
+            ? $"Force-infected {Pretty(target)} with #{strain.Id} {strain.Designation}; " +
+                $"bypassed immunity; test symptom interval={DefaultTestSymptomInterval.TotalSeconds:0.0}s."
+            : $"Could not infect {Pretty(target)} with #{strain.Id}; it may already carry the strain or be an invalid host.");
+    }
+
+    private void Cure(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target))
+        {
+            shell.WriteLine("Usage: virotest cure <self|netEntity> <strainId|all>");
+            return;
+        }
+
+        var pathogen = _entities.System<PathogenSystem>();
+        if (args[2].Equals("all", StringComparison.OrdinalIgnoreCase))
+        {
+            if (!_entities.TryGetComponent<PathogenInfectionComponent>(target, out var infections))
+            {
+                shell.WriteLine($"{Pretty(target)} has no infections.");
+                return;
+            }
+
+            var cured = 0;
+            foreach (var strainId in infections.Infections.Select(infection => infection.Pathogen).ToArray())
+            {
+                if (pathogen.Cure(target, strainId, cause: "virotest cure"))
+                    cured++;
+            }
+
+            shell.WriteLine($"Cured {cured} infection(s) from {Pretty(target)}.");
+            _adminLog.Add(LogType.Virology, LogImpact.Medium,
+                $"{Actor(shell)} ran virotest cure all on {_entities.ToPrettyString(target):target} ({cured} cleared)");
+            return;
+        }
+
+        if (!TryParseStrain(shell, args[2], out var strain))
+            return;
+
+        var removed = pathogen.Cure(target, strain.Id, cause: "virotest cure");
+        shell.WriteLine(removed
+            ? $"Cured #{strain.Id} from {Pretty(target)}."
+            : $"{Pretty(target)} does not carry #{strain.Id}.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} ran virotest cure on {_entities.ToPrettyString(target):target} for {strain.Designation:strain} (cured={removed})");
+    }
+
+    private void SetStage(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 4 ||
+            !TryResolveTarget(shell, args[1], out var target) ||
+            !TryParseStrain(shell, args[2], out var strain) ||
+            !int.TryParse(args[3], NumberStyles.Integer, CultureInfo.InvariantCulture, out var stage))
+        {
+            shell.WriteLine("Usage: virotest stage <self|netEntity> <strainId> <stage>");
+            return;
+        }
+
+        var changed = _entities.System<PathogenSystem>().TrySetStage(target, strain.Id, stage, out var actual);
+        shell.WriteLine(changed
+            ? $"Set #{strain.Id} on {Pretty(target)} to stage {actual}/{strain.MaxStage}."
+            : $"{Pretty(target)} does not carry #{strain.Id}.");
+
+        if (changed)
+        {
+            _adminLog.Add(LogType.Virology, LogImpact.Medium,
+                $"{Actor(shell)} set {strain.Designation:strain} on {_entities.ToPrettyString(target):target} to stage {actual}");
+        }
+    }
+
+    private void FastSymptoms(IConsoleShell shell, string[] args)
+    {
+        if (args.Length is < 3 or > 4 ||
+            !TryResolveTarget(shell, args[1], out var target))
+        {
+            shell.WriteLine("Usage: virotest fast <self|netEntity> <strainId|all> [seconds|off]");
+            return;
+        }
+
+        TimeSpan? interval = DefaultTestSymptomInterval;
+        if (args.Length == 4)
+        {
+            if (args[3].Equals("off", StringComparison.OrdinalIgnoreCase))
+            {
+                interval = null;
+            }
+            else if (!TryParseFloat(args[3], out var seconds) || seconds < 0.5f)
+            {
+                shell.WriteError("Symptom interval must be at least 0.5 seconds, or 'off'.");
+                return;
+            }
+            else
+            {
+                interval = TimeSpan.FromSeconds(seconds);
+            }
+        }
+
+        if (!_entities.TryGetComponent<PathogenInfectionComponent>(target, out var infections))
+        {
+            shell.WriteLine($"{Pretty(target)} has no infections.");
+            return;
+        }
+
+        var all = args[2].Equals("all", StringComparison.OrdinalIgnoreCase);
+        Pathogen? requested = null;
+        if (!all)
+        {
+            if (!TryParseStrain(shell, args[2], out var parsed))
+                return;
+
+            requested = parsed;
+        }
+
+        var pathogen = _entities.System<PathogenSystem>();
+        var changed = 0;
+        foreach (var infection in infections.Infections)
+        {
+            if (!all && infection.Pathogen != requested!.Id)
+                continue;
+
+            if (pathogen.TrySetSymptomInterval(target, infection.Pathogen, interval))
+                changed++;
+        }
+
+        var cadence = interval is { } value
+            ? $"{value.TotalSeconds:0.0}s"
+            : "normal";
+        shell.WriteLine($"Set {changed} infection symptom interval(s) on {Pretty(target)} to {cadence}.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} set the symptom interval on {_entities.ToPrettyString(target):target} to {cadence} for {changed} infection(s)");
+    }
+
+    private void Identify(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target) ||
+            !_entities.TryGetComponent<PathogenInfectionComponent>(target, out var infections))
+        {
+            shell.WriteLine("Usage: virotest identify <self|netEntity> <strainId|all>");
+            return;
+        }
+
+        var identifyAll = args[2].Equals("all", StringComparison.OrdinalIgnoreCase);
+        Pathogen? requested = null;
+        if (!identifyAll)
+        {
+            if (!TryParseStrain(shell, args[2], out var parsed))
+                return;
+
+            requested = parsed;
+        }
+
+        var registry = _entities.System<PathogenRegistrySystem>();
+        var changed = 0;
+        foreach (var infection in infections.Infections)
+        {
+            if (!identifyAll && infection.Pathogen != requested!.Id)
+                continue;
+
+            if (!registry.TryGetStrain(infection.Pathogen, out var strain))
+                continue;
+
+            if (strain.Identification != PathogenIdentificationStage.Complete)
+                changed++;
+            registry.IdentifyFully(infection.Pathogen);
+        }
+
+        shell.WriteLine($"Fully identified {changed} strain(s) carried by {Pretty(target)}.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} fully identified {changed} strain(s) carried by {_entities.ToPrettyString(target):target}");
+    }
+
+    private void ListSymptoms(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteLine("Usage: virotest symptoms");
+            return;
+        }
+
+        foreach (var symptom in _prototypes.EnumeratePrototypes<PathogenSymptomPrototype>()
+                    .OrderBy(symptom => symptom.ID))
+        {
+            shell.WriteLine(
+                $"{symptom.ID}: name={symptom.Name}; minStage={symptom.MinStage}; " +
+                $"interval={symptom.Interval.TotalSeconds:0.0}s; effects={symptom.Effects.Count}");
+        }
+    }
+
+    private void ForceSymptom(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 3 ||
+            !TryResolveTarget(shell, args[1], out var target) ||
+            !TryResolveSymptom(shell, args[2], out var symptomId, out var symptom))
+        {
+            shell.WriteLine("Usage: virotest symptom <self|netEntity> <symptomId>");
+            return;
+        }
+
+        if (!_entities.System<PathogenSystem>().TryExpressSymptom(
+                target,
+                symptomId,
+                out _))
+        {
+            shell.WriteError($"Unknown pathogen symptom '{args[2]}'.");
+            return;
+        }
+
+        shell.WriteLine($"Applied {symptom.ID} to {Pretty(target)}.");
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} ran virotest symptom on {_entities.ToPrettyString(target):target} with {symptom.ID:symptom}");
+    }
+
+    private void Contamination(IConsoleShell shell, string[] args)
+    {
+        var contamination = _entities.System<PathogenContaminationSystem>();
+        var sources = _entities.System<PathogenContaminationSourceSystem>();
+
+        if (args.Length == 1)
+        {
+            WriteContamination(shell, contamination, sources);
+            return;
+        }
+
+        if (args.Length != 4 ||
+            !TryParseFloat(args[1], out var virus) ||
+            !TryParseFloat(args[2], out var bacteria) ||
+            !TryParseFloat(args[3], out var fungus))
+        {
+            shell.WriteLine("Usage: virotest contamination [virus bacteria fungus]");
+            return;
+        }
+
+        contamination.SetContamination(new Dictionary<PathogenType, float>
+        {
+            [PathogenType.Virus] = Math.Max(0f, virus),
+            [PathogenType.Bacteria] = Math.Max(0f, bacteria),
+            [PathogenType.Fungus] = Math.Max(0f, fungus),
+        });
+        WriteContamination(shell, contamination, sources);
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} set station contamination to virus={virus:0.00}, bacteria={bacteria:0.00}, fungus={fungus:0.00}");
+    }
+
+    private static void WriteContamination(
+        IConsoleShell shell,
+        PathogenContaminationSystem contamination,
+        PathogenContaminationSourceSystem sources)
+    {
+        shell.WriteLine(
+            $"contamination={contamination.Contamination:0.00}; " +
+            $"virus={contamination.GetContamination(PathogenType.Virus):0.00}; " +
+            $"bacteria={contamination.GetContamination(PathogenType.Bacteria):0.00}; " +
+            $"fungus={contamination.GetContamination(PathogenType.Fungus):0.00}; " +
+            $"physicalSources={sources.ActiveSourceCount}; " +
+            $"baselineSources={sources.BaselineSourceCount}; " +
+            $"ignoredBaselineSources={sources.IgnoredBaselineSourceCount}; " +
+            $"baselineEstablished={sources.HasBaseline}");
+        shell.WriteLine($"  active sources: {FormatSourceReport(sources.SourceReport)}");
+        shell.WriteLine($"  ignored baseline: {FormatSourceReport(sources.IgnoredBaselineReport)}");
+    }
+
+    private static string FormatSourceReport(IReadOnlyList<PathogenContaminationSourceReport> report)
+    {
+        if (report.Count == 0)
+            return "none";
+
+        return string.Join(
+            "; ",
+            report.Select(entry => $"{entry.Kind}: count={entry.Count}, value={entry.Contamination:0.00}"));
+    }
+
+    private void Sample(IConsoleShell shell, string[] args)
+    {
+        if (args.Length != 1)
+        {
+            shell.WriteLine("Usage: virotest sample");
+            return;
+        }
+
+        var sources = _entities.System<PathogenContaminationSourceSystem>();
+        if (!sources.SampleNow())
+        {
+            shell.WriteError("Physical sources can only be sampled during a live round.");
+            return;
+        }
+
+        WriteContamination(shell, _entities.System<PathogenContaminationSystem>(), sources);
+
+        _adminLog.Add(LogType.Virology, LogImpact.Medium,
+            $"{Actor(shell)} forced a contamination sampling pass");
+    }
+
+    private bool TryParseStrain(IConsoleShell shell, string value, out Pathogen strain)
+    {
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var strainId) ||
+            !_entities.System<PathogenRegistrySystem>().TryGetStrain(strainId, out var found))
+        {
+            shell.WriteError($"Unknown runtime strain id '{value}'. Run 'virotest strains'.");
+            strain = default!;
+            return false;
+        }
+
+        strain = found;
+        return true;
+    }
+
+    private bool TryResolveSymptom(
+        IConsoleShell shell,
+        string value,
+        out ProtoId<PathogenSymptomPrototype> symptomId,
+        out PathogenSymptomPrototype symptom)
+    {
+        symptomId = new ProtoId<PathogenSymptomPrototype>(value);
+        if (_prototypes.TryIndex(symptomId, out var found))
+        {
+            symptom = found;
+            return true;
+        }
+
+        shell.WriteError($"Unknown pathogen symptom '{value}'. Run 'virotest symptoms'.");
+        symptom = default!;
+        return false;
+    }
+
+    private bool TryResolveOptionalTarget(
+        IConsoleShell shell,
+        string[] args,
+        int index,
+        out EntityUid target)
+    {
+        if (args.Length > index)
+            return TryResolveTarget(shell, args[index], out target);
+
+        if (shell.Player?.AttachedEntity is { } attached)
+        {
+            target = attached;
+            return true;
+        }
+
+        target = default;
+        return false;
+    }
+
+    private bool TryResolveTarget(IConsoleShell shell, string value, out EntityUid target)
+    {
+        if (value.Equals("self", StringComparison.OrdinalIgnoreCase))
+        {
+            if (shell.Player?.AttachedEntity is { } attached)
+            {
+                target = attached;
+                return true;
+            }
+
+            shell.WriteError("'self' requires a player-attached entity.");
+            target = default;
+            return false;
+        }
+
+        if (NetEntity.TryParse(value, out var netEntity) &&
+            _entities.TryGetEntity(netEntity, out var entity) &&
+            entity is { } resolved)
+        {
+            target = resolved;
+            return true;
+        }
+
+        shell.WriteError($"'{value}' is not a valid network entity.");
+        target = default;
+        return false;
+    }
+
+    private static bool TryParseFloat(string value, out float result)
+        => float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+
+    private string Pretty(EntityUid uid)
+        => $"{_entities.ToPrettyString(uid)} [net {_entities.GetNetEntity(uid)}]";
+
+    private static string Actor(IConsoleShell shell)
+        => shell.Player?.Name ?? "An administrator";
+}

--- a/Content.Server/_Starlight/Medical/Virology/Commands/VirologyTestCommand.cs
+++ b/Content.Server/_Starlight/Medical/Virology/Commands/VirologyTestCommand.cs
@@ -500,7 +500,7 @@ public sealed partial class VirologyTestCommand : IConsoleCommand
                 symptomId,
                 out _))
         {
-            shell.WriteError($"Unknown pathogen symptom '{args[2]}'.");
+            shell.WriteError($"Could not express pathogen symptom '{symptom.ID}' on {Pretty(target)}.");
             return;
         }
 

--- a/Content.Server/_Starlight/Medical/Virology/PathogenContaminationPool.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenContaminationPool.cs
@@ -1,0 +1,85 @@
+using System.Linq;
+using Content.Shared._Starlight.Medical.Virology;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Stores a bounded snapshot of the station's current pathogen-type source load.
+/// </summary>
+internal sealed class PathogenContaminationPool
+{
+    private const float Maximum = 100f;
+    private const float EqualityTolerance = 0.0001f;
+
+    private static readonly PathogenType[] Types = Enum.GetValues<PathogenType>();
+    private readonly Dictionary<PathogenType, float> _byType = Types.ToDictionary(type => type, _ => 0f);
+
+    public float Total { get; private set; }
+
+    public float Get(PathogenType type)
+        => _byType[type];
+
+    /// <summary>
+    /// Updates the contamination pool from raw per-type source contributions.
+    /// Values are normalized into a bounded 0-100 pool.
+    /// </summary>
+    public void Set(IReadOnlyDictionary<PathogenType, float> contributions)
+    {
+        var requested = Types.Sum(type =>
+            contributions.TryGetValue(type, out var amount)
+                ? Math.Max(0f, amount)
+                : 0f);
+
+        var scale = requested > Maximum
+            ? Maximum / requested
+            : 1f;
+        foreach (var type in Types)
+        {
+            _byType[type] = contributions.TryGetValue(type, out var amount)
+                ? Math.Max(0f, amount) * scale
+                : 0f;
+        }
+
+        Total = Math.Min(Maximum, requested);
+    }
+
+    /// <summary>
+    /// Which pathogen types are currently in the lead, or nothing while the station is clean.
+    ///
+    /// Several can lead at once, and that is the ordinary case rather than an edge case: rot
+    /// and mold both feed bacteria and fungus in equal measure, so a station dirtied by
+    /// either has the two exactly level. Returning a single winner would settle every one of
+    /// those ties the same way, and the type that always lost would never be picked.
+    /// </summary>
+    public IReadOnlyList<PathogenType> GetDominantTypes()
+    {
+        var maximum = 0f;
+        foreach (var type in Types)
+            maximum = Math.Max(maximum, Get(type));
+
+        var leaders = new List<PathogenType>();
+        if (maximum <= 0f)
+            return leaders;
+
+        foreach (var type in Types)
+        {
+            // Compared against a tolerance rather than ==, because these values arrive after
+            // a divide and a rescale. Two that should match can differ in the last decimal,
+            // and an undetected tie is what would bias the pick.
+            if (Get(type) >= maximum - EqualityTolerance)
+                leaders.Add(type);
+        }
+
+        return leaders;
+    }
+
+    public void Reset()
+    {
+        foreach (var type in Types)
+        {
+            _byType[type] = 0f;
+        }
+
+        Total = 0f;
+    }
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSourceSystem.Collectors.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSourceSystem.Collectors.cs
@@ -1,0 +1,317 @@
+using System.Linq;
+using Content.Server.Botany.Components;
+using Content.Shared._Starlight.CCVar;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Atmos.Rotting;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Disposal.Unit;
+using Content.Shared.Fluids.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Tag;
+using Robust.Shared.Map;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// The collectors: every way the station itself becomes a pathogen source. Each pass
+/// walks one kind of neglect - rot, puddles, organic trash, dead plants - and reports
+/// what it finds through <see cref="AddSource"/>.
+/// </summary>
+public sealed partial class PathogenContaminationSourceSystem
+{
+    private void CollectRotSources()
+    {
+        var corpseContamination = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationRottingCorpse));
+        var foodContamination = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationRottenFood));
+
+        // Everything perishable in the game is either a mob or edible, so these two branches
+        // cover it. Anything that rots and is neither would go uncounted rather than being
+        // guessed at.
+        //
+        // The guards match every other collector: something stowed in a bag, a crate or a
+        // disposal unit has been dealt with, and something adrift in space is not the
+        // station's problem any more.
+        var query = EntityQueryEnumerator<RottingComponent, PerishableComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out _, out var perishable, out var transform))
+        {
+            if (!_rotting.IsRotProgressing(uid, perishable) ||
+                transform.MapID == MapId.Nullspace ||
+                transform.GridUid is null ||
+                _containers.IsEntityInContainer(uid))
+            {
+                continue;
+            }
+
+            if (HasComp<MobStateComponent>(uid))
+            {
+                AddSource(
+                    uid,
+                    RotSignatures,
+                    corpseContamination,
+                    PathogenContaminationSourceKind.RottingCorpse);
+                continue;
+            }
+
+            if (HasComp<EdibleComponent>(uid))
+            {
+                AddSource(
+                    uid,
+                    RotSignatures,
+                    foodContamination,
+                    PathogenContaminationSourceKind.RottingEdible);
+            }
+        }
+    }
+
+    private void CollectRottenFoodSources()
+    {
+        var contamination = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationRottenFood));
+
+        var query = EntityQueryEnumerator<TagComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var tags, out var transform))
+        {
+            if (transform.MapID == MapId.Nullspace ||
+                transform.GridUid is null ||
+                _containers.IsEntityInContainer(uid) ||
+                HasComp<RottingComponent>(uid) ||
+                !_tags.HasTag(tags, RottenFoodTag))
+            {
+                continue;
+            }
+
+            AddSource(
+                uid,
+                RotSignatures,
+                contamination,
+                PathogenContaminationSourceKind.SpoiledFood);
+        }
+    }
+
+    private void CollectPuddleSources()
+    {
+        var biologicalPerUnit = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationBiologicalPuddlePerUnit));
+        var biologicalMaximum = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationBiologicalPuddleMaximum));
+        var foodPerUnit = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationFoodPuddlePerUnit));
+        var foodMaximum = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationFoodPuddleMaximum));
+        var waterPerUnit = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationWaterPuddlePerUnit));
+        var waterMaximum = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationWaterPuddleMaximum));
+        var waterMinimumVolume = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationWaterPuddleMinimumVolume));
+        var moldPerUnit = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationMoldPuddlePerUnit));
+        var moldMaximum = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationMoldPuddleMaximum));
+
+        var query = EntityQueryEnumerator<PuddleComponent>();
+        while (query.MoveNext(out var uid, out var puddle))
+        {
+            if (!_solutions.ResolveSolution(
+                    uid,
+                    puddle.SolutionName,
+                    ref puddle.Solution,
+                    out var solution))
+            {
+                continue;
+            }
+
+            var biologicalVolume = 0f;
+            var foodVolume = 0f;
+            var moldVolume = 0f;
+            var waterVolume = 0f;
+            foreach (var quantity in solution.Contents)
+            {
+                var reagentId = quantity.Reagent.Prototype;
+                var volume = quantity.Quantity.Float();
+
+                if (reagentId == NutrimentReagent || reagentId == ProteinReagent)
+                    foodVolume += volume;
+
+                if (reagentId == MoldReagent)
+                    moldVolume += volume;
+
+                if (reagentId == WaterReagent)
+                    waterVolume += volume;
+
+                if (_prototypes.TryIndex<ReagentPrototype>(reagentId, out var reagent) &&
+                    reagent.Group == "Biological")
+                {
+                    biologicalVolume += volume;
+                }
+            }
+
+            var biologicalContamination = PathogenContaminationMath.PuddleContamination(
+                biologicalVolume,
+                biologicalPerUnit,
+                biologicalMaximum);
+            AddSource(
+                uid,
+                [PathogenType.Bacteria],
+                biologicalContamination,
+                PathogenContaminationSourceKind.BiologicalPuddle);
+
+            var foodContamination = PathogenContaminationMath.PuddleContamination(
+                foodVolume,
+                foodPerUnit,
+                foodMaximum);
+            AddSource(
+                uid,
+                [PathogenType.Bacteria],
+                foodContamination,
+                PathogenContaminationSourceKind.FoodPuddle);
+
+            var moldContamination = PathogenContaminationMath.PuddleContamination(
+                moldVolume,
+                moldPerUnit,
+                moldMaximum);
+            // Mold feeds both halves of medical neglect: bacterial grime and fungal bloom.
+            // Each gets the authored value in full rather than half of it, so a mold puddle
+            // is worth twice what a single-type puddle of the same size is.
+            AddSource(
+                uid,
+                [PathogenType.Bacteria, PathogenType.Fungus],
+                moldContamination,
+                PathogenContaminationSourceKind.MoldPuddle,
+                perType: true);
+
+            // Standing water is the one floor source fungus gets, and blood is already
+            // bacteria's. The volume gate matters: mopping leaves small water smears
+            // behind, and cleaning up blood must not breed fungus as a side effect.
+            if (waterVolume >= waterMinimumVolume)
+            {
+                var waterContamination = PathogenContaminationMath.PuddleContamination(
+                    waterVolume,
+                    waterPerUnit,
+                    waterMaximum);
+                AddSource(
+                    uid,
+                    [PathogenType.Fungus],
+                    waterContamination,
+                    PathogenContaminationSourceKind.WaterPuddle);
+            }
+        }
+    }
+
+    private void CollectOrganicTrashSources()
+    {
+        var contamination = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationOrganicTrash));
+
+        var query = EntityQueryEnumerator<TagComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var tags, out var transform))
+        {
+            if (transform.MapID == MapId.Nullspace ||
+                transform.GridUid is null ||
+                _containers.IsEntityInContainer(uid) ||
+                !_tags.HasTag(tags, OrganicTrashTag))
+            {
+                continue;
+            }
+
+            AddSource(
+                uid,
+                [PathogenType.Bacteria],
+                contamination,
+                PathogenContaminationSourceKind.OrganicTrash);
+        }
+    }
+
+    private void OnBeingDisposed(Entity<BeingDisposedComponent> entity, ref ComponentStartup args)
+    {
+        MarkDisposed(entity.Owner);
+    }
+
+    /// <summary>
+    /// Stamps everything going down a disposal, contents included, so it stays out of the
+    /// contamination count once it lands. Marking beats clearing the rubbish tags: rot is
+    /// found by component rather than by tag, so tag removal only ever silenced half of it.
+    /// </summary>
+    private void MarkDisposed(EntityUid uid)
+    {
+        EnsureComp<PathogenDisposedComponent>(uid);
+
+        var children = Transform(uid).ChildEnumerator;
+        while (children.MoveNext(out var child))
+        {
+            MarkDisposed(child);
+        }
+    }
+
+    private void CollectDeadPlantSources()
+    {
+        var contamination = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationDeadPlant));
+
+        var query = EntityQueryEnumerator<PlantHolderComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var plant, out var transform))
+        {
+            if (!plant.Dead ||
+                plant.Seed is null ||
+                transform.MapID == MapId.Nullspace ||
+                transform.GridUid is null)
+            {
+                continue;
+            }
+
+            AddSource(
+                uid,
+                [PathogenType.Fungus],
+                contamination,
+                PathogenContaminationSourceKind.DeadPlant);
+        }
+    }
+
+    internal float GetViralCarrierContamination()
+    {
+        var perCarrier = Math.Max(
+            0f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationViralCarrier));
+        if (perCarrier <= 0f)
+            return 0f;
+
+        var carriers = 0;
+        var query = EntityQueryEnumerator<PathogenInfectionComponent, MobStateComponent, TransformComponent>();
+        while (query.MoveNext(out _, out var infections, out var mobState, out var transform))
+        {
+            if (mobState.CurrentState == MobState.Dead ||
+                transform.MapID == MapId.Nullspace ||
+                transform.GridUid is null)
+            {
+                continue;
+            }
+
+            if (infections.Infections.Any(infection =>
+                    _registry.TryGetStrain(infection.Pathogen, out var strain) &&
+                    strain.PathogenType == PathogenType.Virus))
+            {
+                carriers++;
+            }
+        }
+
+        return carriers * perCarrier;
+    }
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSourceSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSourceSystem.cs
@@ -1,0 +1,316 @@
+using System.Linq;
+using Content.Server.Atmos.Rotting;
+using Content.Server.GameTicking;
+using Content.Shared._Starlight.CCVar;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Chemistry.EntitySystems;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.Disposal.Unit;
+using Content.Shared.GameTicking;
+using Content.Shared.Tag;
+using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Samples physical station-neglect sources and derives the current contamination
+/// snapshot directly from them.
+/// </summary>
+public sealed partial class PathogenContaminationSourceSystem : EntitySystem
+{
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private SharedContainerSystem _containers = default!;
+    [Dependency] private GameTicker _ticker = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private PathogenContaminationSystem _contamination = default!;
+    [Dependency] private PathogenRegistrySystem _registry = default!;
+    [Dependency] private RottingSystem _rotting = default!;
+    [Dependency] private SharedSolutionContainerSystem _solutions = default!;
+    [Dependency] private TagSystem _tags = default!;
+
+    private readonly Dictionary<EntityUid, SourceSnapshot> _sources = new();
+    private readonly HashSet<EntityUid> _baselineSources = new();
+    private readonly HashSet<EntityUid> _ignoredBaselineSources = new();
+    private readonly Dictionary<PathogenContaminationSourceKind, SourceReportBuilder> _sourceReport = new();
+    private readonly Dictionary<PathogenContaminationSourceKind, SourceReportBuilder> _ignoredBaselineReport = new();
+    private readonly List<PathogenContaminationSourceReport> _lastSourceReport = new();
+    private readonly List<PathogenContaminationSourceReport> _lastIgnoredBaselineReport = new();
+
+    private static readonly ProtoId<TagPrototype> OrganicTrashTag = "OrganicTrash";
+    private static readonly ProtoId<TagPrototype> RottenFoodTag = "PathogenRottenFood";
+    private static readonly ProtoId<ReagentPrototype> NutrimentReagent = "Nutriment";
+    private static readonly ProtoId<ReagentPrototype> ProteinReagent = "Protein";
+    private static readonly ProtoId<ReagentPrototype> MoldReagent = "Mold";
+    private static readonly ProtoId<ReagentPrototype> WaterReagent = "Water";
+    private static readonly PathogenType[] RotSignatures =
+    [
+        PathogenType.Bacteria,
+        PathogenType.Fungus,
+    ];
+
+    private TimeSpan _nextSample;
+    private bool _hasBaseline;
+
+    public int ActiveSourceCount => _sources.Count;
+    public int BaselineSourceCount => _baselineSources.Count;
+    public int IgnoredBaselineSourceCount => _ignoredBaselineSources.Count;
+    public bool HasBaseline => _hasBaseline;
+    public IReadOnlyList<PathogenContaminationSourceReport> SourceReport => _lastSourceReport;
+    public IReadOnlyList<PathogenContaminationSourceReport> IgnoredBaselineReport => _lastIgnoredBaselineReport;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
+        SubscribeLocalEvent<BeingDisposedComponent, ComponentStartup>(OnBeingDisposed);
+    }
+
+    /// <summary>
+    /// The baseline is taken the instant the round starts.
+    /// </summary>
+    private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
+    {
+        if (ev.New != GameRunLevel.InRound || _hasBaseline)
+            return;
+
+        SampleSources();
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_ticker.RunLevel != GameRunLevel.InRound)
+            return;
+
+        if (_timing.CurTime < _nextSample)
+            return;
+
+        SampleSources();
+    }
+
+    /// <summary>
+    /// Rebuilds the physical-source snapshot immediately while in a live round.
+    /// </summary>
+    public bool SampleNow()
+    {
+        if (_ticker.RunLevel != GameRunLevel.InRound)
+            return false;
+
+        SampleSources();
+        return true;
+    }
+
+    /// <summary>
+    /// Rebuilds the source snapshot without the live-round gate <see cref="SampleNow"/>
+    /// enforces for admin use. Integration tests have no round, so they cannot reach the
+    /// collectors any other way.
+    /// </summary>
+    internal void SampleSourcesForTest()
+        => SampleSources();
+
+    internal void ResetSourceStateForTest()
+        => ResetSourceState();
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+        => ResetSourceState();
+
+    private void ResetSourceState()
+    {
+        _sources.Clear();
+        _baselineSources.Clear();
+        _ignoredBaselineSources.Clear();
+        _sourceReport.Clear();
+        _ignoredBaselineReport.Clear();
+        _lastSourceReport.Clear();
+        _lastIgnoredBaselineReport.Clear();
+        _nextSample = TimeSpan.Zero;
+        _hasBaseline = false;
+    }
+
+    private void SampleSources()
+    {
+        var interval = Math.Max(
+            1f,
+            _config.GetCVar(StarlightCCVars.VirologyContaminationSampleInterval));
+
+        _nextSample = _timing.CurTime + TimeSpan.FromSeconds(interval);
+        _sources.Clear();
+        _ignoredBaselineSources.Clear();
+        _sourceReport.Clear();
+        _ignoredBaselineReport.Clear();
+
+        CollectRotSources();
+        CollectRottenFoodSources();
+        CollectPuddleSources();
+        CollectOrganicTrashSources();
+        CollectDeadPlantSources();
+
+        _hasBaseline = true;
+        PublishSourceReport(_sourceReport, _lastSourceReport);
+        PublishSourceReport(_ignoredBaselineReport, _lastIgnoredBaselineReport);
+        RefreshContamination();
+    }
+
+    private void RefreshContamination()
+    {
+        var contributions = Enum.GetValues<PathogenType>()
+            .ToDictionary(type => type, _ => 0f);
+
+        foreach (var snapshot in _sources.Values)
+        {
+            foreach (var (type, value) in snapshot.Contributions)
+                contributions[type] += value;
+        }
+
+        contributions[PathogenType.Virus] += GetViralCarrierContamination();
+
+        _contamination.SetContamination(contributions);
+    }
+
+    /// <summary>
+    /// Records one physical source. <paramref name="contamination"/> is split evenly across
+    /// <paramref name="pathogenTypes"/> unless <paramref name="perType"/> is set, in which
+    /// case each type receives the full amount and the source contributes that much again
+    /// for every type it feeds.
+    /// </summary>
+    private void AddSource(
+        EntityUid uid,
+        IReadOnlyCollection<PathogenType> pathogenTypes,
+        float contamination,
+        PathogenContaminationSourceKind kind,
+        bool perType = false)
+    {
+        if (contamination <= 0f ||
+            pathogenTypes.Count == 0 ||
+            pathogenTypes.Contains(PathogenType.Virus) ||
+            HasComp<PathogenDisposedComponent>(uid))
+        {
+            return;
+        }
+
+        if (!_hasBaseline)
+        {
+            _baselineSources.Add(uid);
+            _ignoredBaselineSources.Add(uid);
+            RecordSource(_ignoredBaselineReport, kind, contamination);
+            return;
+        }
+
+        if (_baselineSources.Contains(uid))
+        {
+            _ignoredBaselineSources.Add(uid);
+            RecordSource(_ignoredBaselineReport, kind, contamination);
+            return;
+        }
+
+        RecordSource(_sourceReport, kind, contamination);
+
+        if (_sources.TryGetValue(uid, out var existing))
+        {
+            existing.Add(pathogenTypes, contamination, perType);
+            return;
+        }
+
+        _sources.Add(uid, new SourceSnapshot(pathogenTypes, contamination, perType));
+    }
+
+    private static void RecordSource(
+        Dictionary<PathogenContaminationSourceKind, SourceReportBuilder> report,
+        PathogenContaminationSourceKind kind,
+        float contamination)
+    {
+        if (!report.TryGetValue(kind, out var builder))
+        {
+            report.Add(kind, new SourceReportBuilder(1, contamination));
+            return;
+        }
+
+        builder.Count++;
+        builder.Contamination += contamination;
+    }
+
+    private static void PublishSourceReport(
+        Dictionary<PathogenContaminationSourceKind, SourceReportBuilder> source,
+        List<PathogenContaminationSourceReport> target)
+    {
+        target.Clear();
+
+        foreach (var (kind, builder) in source.OrderBy(entry => entry.Key))
+        {
+            target.Add(new PathogenContaminationSourceReport(
+                kind,
+                builder.Count,
+                builder.Contamination));
+        }
+    }
+
+    private sealed class SourceSnapshot
+    {
+        public readonly Dictionary<PathogenType, float> Contributions = new();
+
+        public SourceSnapshot(
+            IReadOnlyCollection<PathogenType> pathogenTypes,
+            float contamination,
+            bool perType)
+        {
+            Add(pathogenTypes, contamination, perType);
+        }
+
+        public void Add(
+            IReadOnlyCollection<PathogenType> pathogenTypes,
+            float contamination,
+            bool perType)
+        {
+            var share = perType ? contamination : contamination / pathogenTypes.Count;
+            foreach (var type in pathogenTypes)
+            {
+                Contributions[type] = Contributions.TryGetValue(type, out var existing)
+                    ? existing + share
+                    : share;
+            }
+        }
+    }
+
+    private sealed class SourceReportBuilder
+    {
+        public int Count;
+        public float Contamination;
+
+        public SourceReportBuilder(int count, float contamination)
+        {
+            Count = count;
+            Contamination = contamination;
+        }
+    }
+}
+
+public enum PathogenContaminationSourceKind : byte
+{
+    RottingCorpse,
+    RottingEdible,
+    SpoiledFood,
+    BiologicalPuddle,
+    FoodPuddle,
+    MoldPuddle,
+    WaterPuddle,
+    OrganicTrash,
+    DeadPlant,
+}
+
+public readonly record struct PathogenContaminationSourceReport(
+    PathogenContaminationSourceKind Kind,
+    int Count,
+    float Contamination);
+
+internal static class PathogenContaminationMath
+{
+    public static float PuddleContamination(float biologicalVolume, float perUnit, float maximum)
+        => Math.Clamp(Math.Max(0f, biologicalVolume) * Math.Max(0f, perUnit), 0f, Math.Max(0f, maximum));
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenContaminationSystem.cs
@@ -1,0 +1,33 @@
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.GameTicking;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Owns the round's station contamination snapshot.
+/// </summary>
+public sealed partial class PathogenContaminationSystem : EntitySystem
+{
+    private readonly PathogenContaminationPool _contamination = new();
+
+    public float Contamination => _contamination.Total;
+
+    public float GetContamination(PathogenType type)
+        => _contamination.Get(type);
+
+    public IReadOnlyList<PathogenType> GetDominantTypes()
+        => _contamination.GetDominantTypes();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    public void SetContamination(IReadOnlyDictionary<PathogenType, float> contributions)
+        => _contamination.Set(contributions);
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+        => _contamination.Reset();
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenHostSelectionSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenHostSelectionSystem.cs
@@ -1,0 +1,101 @@
+using Content.Server.Afk;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Bed.Cryostorage;
+using Content.Shared.Humanoid;
+using Content.Shared.Mind.Components;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Server.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Player;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Central eligibility rules for automatic pathogen hosts. Natural transmission uses
+/// biological host eligibility only, so going AFK cannot grant disease immunity.
+/// </summary>
+public sealed partial class PathogenHostSelectionSystem : EntitySystem
+{
+    [Dependency] private IAfkManager _afk = default!;
+    [Dependency] private IPlayerManager _players = default!;
+
+    public List<EntityUid> GetEligibleAutomaticHosts()
+    {
+        var hosts = new List<EntityUid>();
+
+        foreach (var session in _players.Sessions)
+        {
+            if (session.AttachedEntity is not { Valid: true } uid ||
+                !IsEligibleAutomaticHost(session, uid))
+            {
+                continue;
+            }
+
+            hosts.Add(uid);
+        }
+
+        return hosts;
+    }
+
+    public bool IsEligibleAutomaticHost(EntityUid uid)
+    {
+        return _players.TryGetSessionByEntity(uid, out var session) &&
+            IsEligibleAutomaticHost(session, uid);
+    }
+
+    /// <summary>
+    /// Every living humanoid, played or not. This is the denominator a strain's prevalence
+    /// is measured against, so it deliberately counts more than
+    /// <see cref="GetEligibleAutomaticHosts"/> - an SSD crewman still occupies a share of
+    /// the outbreak.
+    /// </summary>
+    public int CountLivingCrew()
+    {
+        var crew = 0;
+
+        var query = EntityQueryEnumerator<HumanoidAppearanceComponent, MobStateComponent>();
+        while (query.MoveNext(out _, out _, out var mobState))
+        {
+            if (mobState.CurrentState != MobState.Dead)
+                crew++;
+        }
+
+        return crew;
+    }
+
+    /// <summary>
+    /// Whether a pathogen can live in this entity at all.
+    ///
+    /// Crew only: HumanoidAppearance separates playable species from animals and NPCs. This
+    /// also keeps the prevalence cap consistent, since the cap is measured against living
+    /// crew and an infected animal would spend budget without counting toward it.
+    ///
+    /// Humanoids that should never be infected - synthetics, the undead - opt out with
+    /// <see cref="PathogenImmunityComponent.Total"/>.
+    /// </summary>
+    public bool CanHost(EntityUid uid)
+    {
+        if (!HasComp<HumanoidAppearanceComponent>(uid) ||
+            !TryComp<MobStateComponent>(uid, out var mobState) ||
+            mobState.CurrentState == MobState.Dead)
+        {
+            return false;
+        }
+
+        return !TryComp<PathogenImmunityComponent>(uid, out var immunity) || !immunity.Total;
+    }
+
+    private bool IsEligibleAutomaticHost(ICommonSession session, EntityUid uid)
+    {
+        return session.Status == SessionStatus.InGame &&
+            !_afk.IsAfk(session) &&
+            Exists(uid) &&
+            !TerminatingOrDeleted(uid) &&
+            HasComp<HumanoidAppearanceComponent>(uid) &&
+            !HasComp<CryostorageContainedComponent>(uid) &&
+            TryComp<MindContainerComponent>(uid, out var mind) &&
+            mind.HasMind &&
+            CanHost(uid);
+    }
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenHostSelectionSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenHostSelectionSystem.cs
@@ -12,7 +12,7 @@ using Robust.Shared.Player;
 namespace Content.Server._Starlight.Medical.Virology;
 
 /// <summary>
-/// Central eligibility rules for automatic pathogen hosts. Natural transmission uses
+/// Central eligibility rules for automatic pathogen hosts. Future natural transmission will use
 /// biological host eligibility only, so going AFK cannot grant disease immunity.
 /// </summary>
 public sealed partial class PathogenHostSelectionSystem : EntitySystem

--- a/Content.Server/_Starlight/Medical/Virology/PathogenRegistrySystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenRegistrySystem.cs
@@ -1,0 +1,255 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.GameTicking;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Owns every strain that exists this round. Strains are rolled from archetypes rather
+/// than authored, so this is the only place that knows what a given strain actually is -
+/// everything else refers to them by id.
+///
+/// Cleared on round restart. Strain ids are meaningless across rounds.
+/// </summary>
+public sealed partial class PathogenRegistrySystem : EntitySystem
+{
+    [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private IRobustRandom _random = default!;
+
+    private const string DesignationLetters = "ABCDEFGHJKLMNPRSTVWXYZ";
+    private const int DefaultStageTwoSymptomCount = 2;
+
+    private readonly Dictionary<int, Pathogen> _strains = new();
+
+    private int _nextId = 1;
+
+    public IReadOnlyDictionary<int, Pathogen> Strains => _strains;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnCleanup);
+    }
+
+    private void OnCleanup(RoundRestartCleanupEvent ev)
+    {
+        _strains.Clear();
+        _nextId = 1;
+    }
+
+    /// <summary>
+    /// Rolls a new strain from an archetype and registers it for the rest of the round.
+    /// </summary>
+    public Pathogen? Generate(ProtoId<PathogenArchetypePrototype> archetypeId)
+    {
+        return !_proto.TryIndex(archetypeId, out var archetype) ? null : Generate(archetype);
+    }
+
+    public Pathogen Generate(PathogenArchetypePrototype archetype)
+        => Generate(archetype, new PathogenGenerationOptions());
+
+    internal Pathogen Generate(
+        PathogenArchetypePrototype archetype,
+        PathogenGenerationOptions options)
+    {
+        var transmissibilityMultiplier = Math.Max(0f, options.TransmissibilityMultiplier);
+        var stageDelayMultiplier = Math.Max(0f, options.StageDelayMultiplier);
+
+        var strain = new Pathogen
+        {
+            Id = _nextId++,
+            Designation = RollDesignation(),
+            Archetype = archetype.ID,
+            PathogenType = archetype.PathogenType,
+            Tier = archetype.Tier,
+            Beneficial = archetype.Beneficial,
+            ImmunityOnRecovery = archetype.ImmunityOnRecovery,
+            RespawnOnExtinction = archetype.RespawnOnExtinction,
+            MaxPrevalence = Math.Min(
+                archetype.MaxPrevalence,
+                Math.Max(0f, options.MaxPrevalenceCap)),
+            Transmissibility =
+                _random.NextFloat(archetype.MinTransmissibility, archetype.MaxTransmissibility) *
+                transmissibilityMultiplier,
+            SpreadRange = _random.NextFloat(archetype.MinSpreadRange, archetype.MaxSpreadRange),
+            Incubation = RollTime(archetype.MinIncubation, archetype.MaxIncubation),
+            MaxStage = _random.Next(archetype.MinStages, archetype.MaxStages + 1),
+            StageDelay = ScaleTime(
+                RollTime(archetype.MinStageDelay, archetype.MaxStageDelay),
+                stageDelayMultiplier),
+            Duration = RollTime(archetype.MinDuration, archetype.MaxDuration),
+            Symptoms = RollSymptoms(archetype, options),
+        };
+
+        _strains[strain.Id] = strain;
+
+        return strain;
+    }
+
+    public bool TryGetStrain(int id, [NotNullWhen(true)] out Pathogen? strain)
+        => _strains.TryGetValue(id, out strain);
+
+    public PathogenAnalysisResult CanAnalyzeSample(
+        int strainId,
+        EntityUid? host,
+        bool sourceSample)
+    {
+        if (!TryGetStrain(strainId, out var strain))
+            return PathogenAnalysisResult.Invalid;
+
+        if (sourceSample)
+            return PathogenAnalysisResult.Accepted;
+
+        if (host is not { } patient)
+            return PathogenAnalysisResult.Invalid;
+
+        // The distinct-host rule only exists to stop one patient being swabbed twice to
+        // skip half the identification. Once the strain is fully identified it serves no
+        // purpose, and enforcing it would make replacing a lost or stolen culture
+        // needlessly painful - identification lives on the strain, so a single fresh
+        // sample should be enough to grow another.
+        if (strain.Identification == PathogenIdentificationStage.Complete)
+            return PathogenAnalysisResult.Accepted;
+
+        return strain.SampledHosts.Contains(patient)
+            ? PathogenAnalysisResult.DuplicateHost
+            : PathogenAnalysisResult.Accepted;
+    }
+
+    /// <summary>
+    /// Advances station-wide identification. Patient specimens require two distinct
+    /// hosts; a source specimen completes the strain immediately.
+    /// </summary>
+    public PathogenAnalysisResult AnalyzeSample(
+        int strainId,
+        EntityUid? host,
+        bool sourceSample)
+    {
+        var allowed = CanAnalyzeSample(strainId, host, sourceSample);
+        if (allowed != PathogenAnalysisResult.Accepted ||
+            !TryGetStrain(strainId, out var strain))
+        {
+            return allowed;
+        }
+
+        if (sourceSample)
+        {
+            var completedNow = strain.Identification != PathogenIdentificationStage.Complete;
+            strain.Identification = PathogenIdentificationStage.Complete;
+            return completedNow
+                ? PathogenAnalysisResult.Completed
+                : PathogenAnalysisResult.AlreadyComplete;
+        }
+
+        var patient = host!.Value;
+        strain.SampledHosts.Add(patient);
+
+        if (strain.Identification == PathogenIdentificationStage.Unidentified)
+        {
+            strain.Identification = PathogenIdentificationStage.Partial;
+            return PathogenAnalysisResult.Partial;
+        }
+
+        if (strain.Identification == PathogenIdentificationStage.Partial)
+        {
+            strain.Identification = PathogenIdentificationStage.Complete;
+            return PathogenAnalysisResult.Completed;
+        }
+
+        return PathogenAnalysisResult.AlreadyComplete;
+    }
+
+    public bool IdentifyFully(int strainId)
+    {
+        if (!TryGetStrain(strainId, out var strain))
+            return false;
+
+        strain.Identification = PathogenIdentificationStage.Complete;
+        return true;
+    }
+
+    /// <summary>
+    /// One optional stage-one warning, all fixed symptoms, then a random draw from the
+    /// tier-specific pool.
+    /// </summary>
+    private List<ProtoId<PathogenSymptomPrototype>> RollSymptoms(
+        PathogenArchetypePrototype archetype,
+        PathogenGenerationOptions options)
+    {
+        var symptoms = new List<ProtoId<PathogenSymptomPrototype>>();
+
+        if (archetype.StageOneSymptoms.Count > 0)
+            symptoms.Add(_random.Pick(archetype.StageOneSymptoms));
+
+        foreach (var symptom in archetype.StageThreeSymptoms)
+        {
+            if (!symptoms.Contains(symptom))
+                symptoms.Add(symptom);
+        }
+
+        var pool = archetype.StageTwoSymptomPool
+            .Where(x => !symptoms.Contains(x))
+            .ToList();
+
+        var wanted = Math.Max(0, options.StageTwoSymptomCount ?? DefaultStageTwoSymptomCount);
+        var count = Math.Min(wanted, pool.Count);
+
+        for (var i = 0; i < count; i++)
+        {
+            var index = _random.Next(pool.Count);
+            symptoms.Add(pool[index]);
+            pool.RemoveAt(index);
+        }
+
+        symptoms.Sort((left, right) =>
+        {
+            var leftStage = _proto.Index(left).MinStage;
+            var rightStage = _proto.Index(right).MinStage;
+            return leftStage.CompareTo(rightStage);
+        });
+
+        return symptoms;
+    }
+
+    private TimeSpan RollTime(TimeSpan min, TimeSpan max)
+    {
+        if (max <= min)
+            return min;
+
+        return TimeSpan.FromSeconds(_random.NextFloat((float) min.TotalSeconds, (float) max.TotalSeconds));
+    }
+
+    private static TimeSpan ScaleTime(TimeSpan time, float multiplier)
+        => TimeSpan.FromSeconds(time.TotalSeconds * multiplier);
+
+
+    private string RollDesignation()
+    {
+        var first = DesignationLetters[_random.Next(DesignationLetters.Length)];
+        var second = DesignationLetters[_random.Next(DesignationLetters.Length)];
+
+        return $"{first}{second}-{_random.Next(100, 1000)}";
+    }
+}
+
+internal sealed class PathogenGenerationOptions
+{
+    public float MaxPrevalenceCap = 1f;
+    public float TransmissibilityMultiplier = 1f;
+    public float StageDelayMultiplier = 1f;
+    public int? StageTwoSymptomCount;
+}
+
+public enum PathogenAnalysisResult : byte
+{
+    Invalid,
+    DuplicateHost,
+    Accepted,
+    Partial,
+    Completed,
+    AlreadyComplete,
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenSystem.cs
@@ -1,0 +1,489 @@
+using System.Linq;
+using Content.Server.Administration.Logs;
+using Content.Shared._Starlight.CCVar;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Database;
+using Content.Shared.EntityEffects;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server._Starlight.Medical.Virology;
+
+/// <summary>
+/// Drives the lifecycle of every active infection: incubation, staging, symptom expression,
+/// and recovery. A host carries at most one strain.
+/// </summary>
+public sealed partial class PathogenSystem : EntitySystem
+{
+    [Dependency] private IAdminLogManager _adminLog = default!;
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedEntityEffectsSystem _effects = default!;
+    [Dependency] private PathogenHostSelectionSystem _hosts = default!;
+    [Dependency] private PathogenRegistrySystem _registry = default!;
+
+    /// <summary>
+    /// Entities whose last infection cleared this tick. Collected and drained after the
+    /// query, since removing a component mid-enumeration of that same component is not safe.
+    /// </summary>
+    private readonly List<EntityUid> _cleared = new();
+
+    /// <summary>
+    /// Strains that lost their last host this tick, for the respawn pass.
+    /// </summary>
+    private readonly List<int> _extinct = new();
+
+    /// <summary>
+    /// How often infections are advanced. Incubation, stages and symptoms are all authored
+    /// in tens of seconds at the shortest, so re-evaluating them every tick only burns
+    /// prototype lookups to arrive at the same answer.
+    /// </summary>
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(1);
+
+    private TimeSpan _nextTick;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PathogenInfectionComponent, MobStateChangedEvent>(OnMobStateChanged);
+    }
+
+    /// <summary>
+    /// Natural recovery is otherwise the only way into the respawn queue, and a host that
+    /// dies never recovers. A carrier dying is not the crew running out of people who can
+    /// catch this - the survivors still can - so the strain has to get its chance to
+    /// reappear rather than silently leaving the round with the body.
+    /// </summary>
+    private void OnMobStateChanged(
+        Entity<PathogenInfectionComponent> entity,
+        ref MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        foreach (var infection in entity.Comp.Infections)
+        {
+            if (_registry.TryGetStrain(infection.Pathogen, out var strain))
+                QueueExtinctionRespawn(strain);
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // Left outside the throttle: losing a last host is a discrete event rather than
+        // something that has to be re-evaluated, and the pass costs nothing while the queue
+        // is empty, which is nearly always.
+        RespawnExtinctStrains();
+
+        var curTime = _timing.CurTime;
+
+        if (curTime < _nextTick)
+            return;
+
+        _nextTick = curTime + TickInterval;
+
+        var mobStates = GetEntityQuery<MobStateComponent>();
+
+        var query = EntityQueryEnumerator<PathogenInfectionComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            // The dead stop developing symptoms. They keep their infections, so a body
+            // is still worth swabbing.
+            if (mobStates.TryGetComponent(uid, out var mobState) && mobState.CurrentState == MobState.Dead)
+                continue;
+
+            for (var i = comp.Infections.Count - 1; i >= 0; i--)
+            {
+                var infection = comp.Infections[i];
+
+                if (!_registry.TryGetStrain(infection.Pathogen, out var strain))
+                {
+                    // Strain no longer exists - round restarted underneath us.
+                    comp.Infections.RemoveAt(i);
+                    continue;
+                }
+
+                if (infection.EndTime != TimeSpan.Zero && curTime >= infection.EndTime)
+                {
+                    comp.Infections.RemoveAt(i);
+
+                    if (strain.ImmunityOnRecovery)
+                        GrantImmunity(uid, strain.Id);
+
+                    QueueExtinctionRespawn(strain);
+
+                    continue;
+                }
+
+                if (infection.Stage < strain.MaxStage && curTime >= infection.NextStage)
+                {
+                    infection.Stage++;
+                    infection.NextStage = curTime + strain.StageDelay;
+                }
+
+                // Still incubating.
+                if (infection.Stage < 1)
+                    continue;
+
+                ExpressSymptoms(uid, infection, strain, curTime);
+            }
+
+            if (comp.Infections.Count == 0)
+                _cleared.Add(uid);
+        }
+
+        foreach (var uid in _cleared)
+            RemCompDeferred<PathogenInfectionComponent>(uid);
+
+        _cleared.Clear();
+    }
+
+    /// <summary>
+    /// An ambient strain that loses its last host reappears on someone else. The station
+    /// does not get rid of a cold by waiting; it gets rid of it by running out of people
+    /// who can still catch it, which the immunity check below handles on its own.
+    /// </summary>
+    private void RespawnExtinctStrains()
+    {
+        if (_extinct.Count == 0)
+            return;
+
+        if (!_config.GetCVar(StarlightCCVars.VirologyRespawnOnExtinction))
+        {
+            _extinct.Clear();
+            return;
+        }
+
+        foreach (var strainId in _extinct)
+        {
+            if (AnyHostCarries(strainId))
+                continue;
+
+            if (!TryPickRandomHost(strainId, out var host))
+                continue;
+
+            TryInfect(host, strainId, cause: "ambient extinction respawn");
+        }
+
+        _extinct.Clear();
+    }
+
+    private void QueueExtinctionRespawn(Pathogen strain)
+    {
+        if (!strain.RespawnOnExtinction ||
+            !_config.GetCVar(StarlightCCVars.VirologyRespawnOnExtinction))
+        {
+            return;
+        }
+
+        _extinct.Add(strain.Id);
+    }
+
+    private bool AnyHostCarries(int strainId)
+    {
+        var mobStates = GetEntityQuery<MobStateComponent>();
+        var query = EntityQueryEnumerator<PathogenInfectionComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            // A strain sitting in a corpse is not in circulation. Counting it here would
+            // let one body suppress the respawn forever, so the strain could neither
+            // spread nor come back.
+            if (mobStates.TryGetComponent(uid, out var mobState) && mobState.CurrentState == MobState.Dead)
+                continue;
+
+            foreach (var infection in comp.Infections)
+            {
+                if (infection.Pathogen == strainId)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Picks a living, non-immune host at random. Returns false when the crew has
+    /// collectively run out of people who can catch this, which is how a strain finally
+    /// dies out for good.
+    /// </summary>
+    private bool TryPickRandomHost(int strainId, out EntityUid host)
+    {
+        var candidates = _hosts.GetEligibleAutomaticHosts()
+            .Where(uid => !IsImmune(uid, strainId) && !IsInfected(uid, strainId))
+            .ToList();
+
+        if (candidates.Count == 0)
+        {
+            host = default;
+            return false;
+        }
+
+        host = _random.Pick(candidates);
+        return true;
+    }
+
+    private void ExpressSymptoms(EntityUid uid, PathogenInfection infection, Pathogen strain, TimeSpan curTime)
+    {
+        // The eligible count only feeds the stagger below, which only applies under an admin
+        // interval override. Counting it otherwise is a second pass over every symptom
+        // prototype for a number nothing reads.
+        var eligibleSymptoms = 0;
+        if (infection.SymptomIntervalOverride is not null)
+        {
+            foreach (var symptomId in strain.Symptoms)
+            {
+                if (_proto.TryIndex(symptomId, out var symptom) &&
+                    infection.Stage >= symptom.MinStage)
+                {
+                    eligibleSymptoms++;
+                }
+            }
+        }
+
+        var eligibleIndex = 0;
+        foreach (var symptomId in strain.Symptoms)
+        {
+            if (!_proto.TryIndex(symptomId, out var symptom))
+                continue;
+
+            if (infection.Stage < symptom.MinStage)
+                continue;
+
+            // First tick this symptom is eligible: schedule it instead of firing now, so
+            // reaching a new stage doesn't dump every newly unlocked symptom at once.
+            if (!infection.SymptomTimers.TryGetValue(symptomId, out var next))
+            {
+                var delay = NextInterval(symptom, infection);
+                if (infection.SymptomIntervalOverride is { } interval && eligibleSymptoms > 1)
+                    delay += interval * ((double) eligibleIndex / eligibleSymptoms);
+
+                infection.SymptomTimers[symptomId] = curTime + delay;
+                eligibleIndex++;
+                continue;
+            }
+
+            eligibleIndex++;
+            if (curTime < next)
+                continue;
+
+            infection.SymptomTimers[symptomId] = curTime + NextInterval(symptom, infection);
+
+            foreach (var effect in symptom.Effects)
+                _effects.TryApplyEffect(uid, effect, 1f);
+        }
+    }
+
+    private TimeSpan NextInterval(PathogenSymptomPrototype symptom, PathogenInfection infection)
+    {
+        if (infection.SymptomIntervalOverride is { } interval)
+            return interval;
+
+        if (symptom.IntervalVariance <= 0f)
+            return symptom.Interval;
+
+        var factor = 1f + _random.NextFloat(-symptom.IntervalVariance, symptom.IntervalVariance);
+        return symptom.Interval * Math.Max(0.1f, factor);
+    }
+
+    public bool TryExpressSymptom(
+        EntityUid uid,
+        ProtoId<PathogenSymptomPrototype> symptomId,
+        out PathogenSymptomPrototype? symptom)
+    {
+        if (!_proto.TryIndex(symptomId, out symptom))
+            return false;
+
+        foreach (var effect in symptom.Effects)
+            _effects.TryApplyEffect(uid, effect, 1f);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Infects an entity unless it is immune or invalid. A higher-tier strain displaces
+    /// the current strain and grants immunity to the displaced strain; an equal or
+    /// lower-tier strain bounces off.
+    /// </summary>
+    public bool TryInfect(EntityUid uid, int strainId, bool bypassImmunity = false, string cause = "unknown")
+    {
+        if (!_registry.TryGetStrain(strainId, out var strain))
+            return false;
+
+        if (!CanHost(uid))
+            return false;
+
+        if (!bypassImmunity && IsImmune(uid, strainId))
+            return false;
+
+        var comp = EnsureComp<PathogenInfectionComponent>(uid);
+
+        if (comp.Infections.Count > 0)
+        {
+            var existing = comp.Infections[0];
+            if (existing.Pathogen == strainId)
+                return false;
+
+            if (!_registry.TryGetStrain(existing.Pathogen, out var existingStrain))
+            {
+                comp.Infections.Clear();
+            }
+            else
+            {
+                if (strain.Tier <= existingStrain.Tier)
+                    return false;
+
+                GrantImmunity(uid, existingStrain.Id);
+                comp.Infections.Clear();
+            }
+        }
+
+        var curTime = _timing.CurTime;
+
+        comp.Infections.Add(new PathogenInfection
+        {
+            Pathogen = strainId,
+            Stage = 0,
+            NextStage = curTime + strain.Incubation,
+            EndTime = strain.Duration == TimeSpan.Zero
+                ? TimeSpan.Zero
+                : curTime + strain.Incubation + strain.Duration,
+        });
+
+        // Logged here rather than at each call site so every route - natural spread, a
+        // contamination source, an admin verb - lands one entry, and the cause is what
+        // separates an outbreak running its course from someone spreading it deliberately.
+        _adminLog.Add(LogType.Virology, LogImpact.Low,
+            $"{ToPrettyString(uid):host} was infected with {strain.Designation:strain} ({strain.Tier}/{strain.PathogenType}) via {cause}");
+
+        return true;
+    }
+
+    /// <summary>
+    /// Clears one strain from a host. Unlike natural recovery this does not grant immunity
+    /// by default, so curing someone does not also vaccinate them.
+    /// </summary>
+    public bool Cure(EntityUid uid, int strainId, bool grantImmunity = false, string cause = "unknown")
+    {
+        if (!TryComp<PathogenInfectionComponent>(uid, out var comp))
+            return false;
+
+        if (comp.Infections.RemoveAll(x => x.Pathogen == strainId) == 0)
+            return false;
+
+        if (grantImmunity)
+            GrantImmunity(uid, strainId);
+
+        var designation = _registry.TryGetStrain(strainId, out var strain)
+            ? strain.Designation
+            : $"#{strainId}";
+
+        // One interpolated literal, no concatenation: the overload takes a LogStringHandler,
+        // and a '+' would collapse it to a plain string and lose the structured fields.
+        var immunity = grantImmunity ? " and became immune" : string.Empty;
+
+        _adminLog.Add(LogType.Virology, LogImpact.Low,
+            $"{ToPrettyString(uid):host} was cured of {designation:strain} via {cause}{immunity}");
+
+        if (comp.Infections.Count == 0)
+            RemCompDeferred<PathogenInfectionComponent>(uid);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Moves an existing infection to a requested stage and restarts its stage and symptom
+    /// timers. Used by admin testing tools so passive progression can be checked without
+    /// waiting through incubation.
+    /// </summary>
+    public bool TrySetStage(EntityUid uid, int strainId, int stage, out int actualStage)
+    {
+        actualStage = 0;
+
+        if (!_registry.TryGetStrain(strainId, out var strain) ||
+            !TryComp<PathogenInfectionComponent>(uid, out var comp))
+        {
+            return false;
+        }
+
+        foreach (var infection in comp.Infections)
+        {
+            if (infection.Pathogen != strainId)
+                continue;
+
+            actualStage = Math.Clamp(stage, 0, strain.MaxStage);
+            infection.Stage = actualStage;
+            infection.NextStage = _timing.CurTime + strain.StageDelay;
+            infection.SymptomTimers.Clear();
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Overrides symptom cadence for an existing infection. This is intended for admin
+    /// live testing; null restores the authored symptom intervals.
+    /// </summary>
+    public bool TrySetSymptomInterval(EntityUid uid, int strainId, TimeSpan? interval)
+    {
+        if (!TryComp<PathogenInfectionComponent>(uid, out var comp))
+            return false;
+
+        foreach (var infection in comp.Infections)
+        {
+            if (infection.Pathogen != strainId)
+                continue;
+
+            infection.SymptomIntervalOverride = interval;
+            infection.SymptomTimers.Clear();
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool IsInfected(EntityUid uid, int strainId)
+    {
+        if (!TryComp<PathogenInfectionComponent>(uid, out var comp))
+            return false;
+
+        foreach (var infection in comp.Infections)
+        {
+            if (infection.Pathogen == strainId)
+                return true;
+        }
+
+        return false;
+    }
+
+    public bool IsImmune(EntityUid uid, int strainId)
+    {
+        if (!TryComp<PathogenImmunityComponent>(uid, out var comp))
+            return false;
+
+        return comp.Total || comp.Immune.Contains(strainId);
+    }
+
+    public void GrantImmunity(EntityUid uid, int strainId)
+    {
+        var comp = EnsureComp<PathogenImmunityComponent>(uid);
+        comp.Immune.Add(strainId);
+    }
+
+    /// <summary>
+    /// Whether this entity is something a pathogen can live in at all.
+    /// Requires a living mob; silicons and anything else unsuitable opt out with
+    /// <see cref="PathogenImmunityComponent.Total"/>.
+    /// </summary>
+    public bool CanHost(EntityUid uid)
+        => _hosts.CanHost(uid);
+}

--- a/Content.Server/_Starlight/Medical/Virology/PathogenSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/PathogenSystem.cs
@@ -148,9 +148,9 @@ public sealed partial class PathogenSystem : EntitySystem
     }
 
     /// <summary>
-    /// An ambient strain that loses its last host reappears on someone else. The station
-    /// does not get rid of a cold by waiting; it gets rid of it by running out of people
-    /// who can still catch it, which the immunity check below handles on its own.
+    /// When extinction respawn is enabled, an ambient strain that loses its last host
+    /// reappears on someone else. The station does not get rid of a cold by waiting; it
+    /// gets rid of it by running out of people who can still catch it.
     /// </summary>
     private void RespawnExtinctStrains()
     {
@@ -342,6 +342,7 @@ public sealed partial class PathogenSystem : EntitySystem
                     return false;
 
                 GrantImmunity(uid, existingStrain.Id);
+                QueueExtinctionRespawn(existingStrain);
                 comp.Infections.Clear();
             }
         }

--- a/Content.Server/_Starlight/Medical/Virology/VirologyAdminVerbSystem.cs
+++ b/Content.Server/_Starlight/Medical/Virology/VirologyAdminVerbSystem.cs
@@ -1,0 +1,64 @@
+using Content.Server.Administration.Managers;
+using Content.Shared._Starlight.Medical.Virology;
+using Content.Shared.Administration;
+using Content.Shared.Database;
+using Content.Shared.Verbs;
+using Robust.Shared.Player;
+
+namespace Content.Server._Starlight.Medical.Virology;
+public sealed partial class VirologyAdminVerbSystem : EntitySystem
+{
+    [Dependency] private IAdminManager _adminManager = default!;
+    [Dependency] private PathogenSystem _pathogen = default!;
+
+
+    private static readonly VerbCategory VirologyCategory =
+        new("verb-categories-virology", "/Textures/Interface/VerbIcons/bubbles.svg.192dpi.png");
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<GetVerbsEvent<Verb>>(AddVirologyVerbs);
+    }
+
+    private void AddVirologyVerbs(GetVerbsEvent<Verb> args)
+    {
+        if (!TryComp<ActorComponent>(args.User, out var actor) ||
+            !_adminManager.HasAdminFlag(actor.PlayerSession, AdminFlags.Fun))
+        {
+            return;
+        }
+
+        if (!_pathogen.CanHost(args.Target))
+            return;
+
+        var target = args.Target;
+
+        args.Verbs.Add(new Verb
+        {
+            Text = Loc.GetString("verb-virology-cure-text"),
+            Category = VirologyCategory,
+            Priority = 1,
+            Act = () =>
+            {
+                if (!TryComp<PathogenInfectionComponent>(target, out var infections))
+                    return;
+
+                foreach (var infection in infections.Infections.ToArray())
+                    _pathogen.Cure(target, infection.Pathogen, grantImmunity: true, cause: "admin verb");
+            },
+            Impact = LogImpact.Medium,
+            Message = Loc.GetString("verb-virology-cure-message"),
+        });
+
+        args.Verbs.Add(new Verb
+        {
+            Text = Loc.GetString("verb-virology-immune-text"),
+            Category = VirologyCategory,
+            Act = () => EnsureComp<PathogenImmunityComponent>(target).Total = true,
+            Impact = LogImpact.Medium,
+            Message = Loc.GetString("verb-virology-immune-message"),
+        });
+    }
+}

--- a/Content.Shared.Database/LogType.cs
+++ b/Content.Shared.Database/LogType.cs
@@ -491,5 +491,6 @@ public enum LogType
     RoundstartRulesAdded = 1002,
     Sparks = 1003,
     Scent = 1004,
+    Virology = 1005, // Starlight
     #endregion
 }

--- a/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
+++ b/Content.Shared/StatusEffectNew/StatusEffectSystem.Relay.cs
@@ -1,6 +1,7 @@
 using Content.Shared._Starlight.Medical.Body.Events;
 using Content.Shared.Damage.Events;
 using Content.Shared.Damage.Systems;
+using Content.Shared.Eye.Blinding.Systems; // Starlight
 using Content.Shared.Mobs.Events;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
@@ -36,6 +37,7 @@ public sealed partial class StatusEffectsSystem
         SubscribeLocalEvent<StatusEffectContainerComponent, BeforeAlertSeverityCheckEvent>(RelayStatusEffectEvent);
 
         SubscribeLocalEvent<StatusEffectContainerComponent, AccentGetEvent>(RelayStatusEffectEvent);
+        SubscribeLocalEvent<StatusEffectContainerComponent, GetBlurEvent>(RelayStatusEffectEvent); // Starlight
 
         SubscribeLocalEvent<StatusEffectContainerComponent, BleedModifierEvent>(RefRelayStatusEffectEvent);
     }

--- a/Content.Shared/_Starlight/CCVar/StarlightCCVars.Virology.cs
+++ b/Content.Shared/_Starlight/CCVar/StarlightCCVars.Virology.cs
@@ -1,0 +1,54 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Starlight.CCVar;
+
+public sealed partial class StarlightCCVars
+{
+    public static readonly CVarDef<bool> VirologyRespawnOnExtinction =
+        CVarDef.Create("virology.respawn_on_extinction", false, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationSampleInterval =
+        CVarDef.Create("virology.contamination_sample_interval", 10f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationRottingCorpse =
+        CVarDef.Create("virology.contamination_rotting_corpse", 3f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationRottenFood =
+        CVarDef.Create("virology.contamination_rotten_food", 1.5f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationBiologicalPuddlePerUnit =
+        CVarDef.Create("virology.contamination_biological_puddle_per_unit", 0.06f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationBiologicalPuddleMaximum =
+        CVarDef.Create("virology.contamination_biological_puddle_maximum", 2.4f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationFoodPuddlePerUnit =
+        CVarDef.Create("virology.contamination_food_puddle_per_unit", 0.03f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationFoodPuddleMaximum =
+        CVarDef.Create("virology.contamination_food_puddle_maximum", 1.2f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationWaterPuddlePerUnit =
+        CVarDef.Create("virology.contamination_water_puddle_per_unit", 0.01f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationWaterPuddleMaximum =
+        CVarDef.Create("virology.contamination_water_puddle_maximum", 0.4f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationWaterPuddleMinimumVolume =
+        CVarDef.Create("virology.contamination_water_puddle_minimum_volume", 25f, CVar.SERVERONLY | CVar.ARCHIVE); // Water below this volume is ignored entirely.
+
+    public static readonly CVarDef<float> VirologyContaminationMoldPuddlePerUnit =
+        CVarDef.Create("virology.contamination_mold_puddle_per_unit", 0.06f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationMoldPuddleMaximum =
+        CVarDef.Create("virology.contamination_mold_puddle_maximum", 1.8f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationOrganicTrash =
+        CVarDef.Create("virology.contamination_organic_trash", 0.1f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationDeadPlant =
+        CVarDef.Create("virology.contamination_dead_plant", 0.75f, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> VirologyContaminationViralCarrier =
+        CVarDef.Create("virology.contamination_viral_carrier", 0.5f, CVar.SERVERONLY | CVar.ARCHIVE);
+}

--- a/Content.Shared/_Starlight/Medical/Virology/Pathogen.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/Pathogen.cs
@@ -1,0 +1,55 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// A concrete strain. These are built at runtime rather than authored, because
+/// a strain has to be unknown to the crew until someone diagnoses it.
+/// Strains live in the registry for the length of a round and are referenced by
+/// <see cref="Id"/> everywhere else.
+/// </summary>
+public sealed class Pathogen
+{
+    public int Id; // Round-unique. This is what infections and immunities store.
+
+    public string Designation = string.Empty; // Rolled code such as "RH-882"
+
+    public ProtoId<PathogenArchetypePrototype> Archetype;
+
+    public PathogenType PathogenType = PathogenType.Virus;
+
+    public PathogenTier Tier = PathogenTier.Ambient;
+
+    public bool Beneficial;
+
+    public bool ImmunityOnRecovery = true;
+
+    public bool RespawnOnExtinction;
+
+    public float MaxPrevalence = 0.15f; // Largest share of living crew that can carry this at once.
+
+    public float Transmissibility;
+
+    public float SpreadRange;
+
+    public TimeSpan Incubation;
+
+    public int MaxStage = 1;
+
+    public TimeSpan StageDelay;
+
+    public TimeSpan Duration;
+
+    public List<ProtoId<PathogenSymptomPrototype>> Symptoms = new();
+
+    public PathogenIdentificationStage Identification; // Station-wide diagnosis progress for this runtime strain.
+
+    public HashSet<EntityUid> SampledHosts = new(); // Patient identities already used for analysis.
+}
+
+public enum PathogenIdentificationStage : byte
+{
+    Unidentified,
+    Partial,
+    Complete,
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenArchetypePrototype.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenArchetypePrototype.cs
@@ -1,0 +1,134 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// A template a concrete strain is rolled from when an outbreak is seeded.
+///
+/// Strains are generated rather than authored so that identification stays meaningful.
+/// A fixed strain is memorised after a few shifts, after which nobody ever touches
+/// the diagnoser again and cataloguing rewards knowledge the player already had. An
+/// archetype keeps the character while leaving the specifics unknown until someone
+/// actually runs a sample.
+///
+/// Set a min and max to the same value for anything that should not vary.
+/// </summary>
+[Prototype]
+public sealed partial class PathogenArchetypePrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Base name. Generated strains append a designation code, so this reads as
+    /// "space cold RH-882".
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name;
+
+    [DataField]
+    public LocId? Description;
+
+    [DataField]
+    public PathogenType PathogenType = PathogenType.Virus;
+
+    [DataField]
+    public PathogenTier Tier = PathogenTier.Ambient;
+
+    /// <summary>
+    /// Weight for automatic ambient seeding. Zero means it is never seeded on its own and only
+    /// appears when something asks for it by name - which is how engineered strains work.
+    /// </summary>
+    [DataField]
+    public float SeedWeight = 1f;
+
+    [DataField]
+    public bool Beneficial;
+
+    [DataField]
+    public bool ImmunityOnRecovery = true;
+
+    /// <summary>
+    /// Whether this respawns onto a random host when its last carrier loses it.
+    /// Ambient strains do; the station never really gets rid of a cold, it just develops
+    /// herd immunity until there is nobody left to infect.
+    /// </summary>
+    [DataField]
+    public bool RespawnOnExtinction;
+
+    /// <summary>
+    /// Largest share of living crew that can carry this at once.
+    /// </summary>
+    [DataField]
+    public float MaxPrevalence = 0.15f;
+
+    // --- Symptoms ---
+    //
+    // A rolled strain takes one entry from StageOneSymptoms, two entries from
+    // StageTwoSymptomPool by default, and every entry in StageThreeSymptoms. Each list is
+    // expected to hold symptoms of its own stage; nothing enforces that at load, so
+    // VirologyContentTests checks it instead.
+
+    /// <summary>
+    /// One is picked at random. Every strain shows a single early type-level warning, and
+    /// which one it is changes between rounds so the tell cannot be memorised.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<PathogenSymptomPrototype>> StageOneSymptoms = new();
+
+    /// <summary>
+    /// The middle of the illness, drawn from at random. This is where one strain differs
+    /// from the next.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<PathogenSymptomPrototype>> StageTwoSymptomPool = new();
+
+    /// <summary>
+    /// All of these are always present. Reaching the last stage of an archetype looks the
+    /// same every time, which is what keeps it recognisable once it has been catalogued.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<PathogenSymptomPrototype>> StageThreeSymptoms = new();
+
+    // --- Rolled numbers ---
+
+    [DataField]
+    public float MinTransmissibility = 0.03f;
+
+    [DataField]
+    public float MaxTransmissibility = 0.06f;
+
+    [DataField]
+    public float MinSpreadRange = 1.5f;
+
+    [DataField]
+    public float MaxSpreadRange = 2f;
+
+    [DataField]
+    public TimeSpan MinIncubation = TimeSpan.FromSeconds(60);
+
+    [DataField]
+    public TimeSpan MaxIncubation = TimeSpan.FromSeconds(150);
+
+    [DataField]
+    public int MinStages = 2;
+
+    [DataField]
+    public int MaxStages = 3;
+
+    [DataField]
+    public TimeSpan MinStageDelay = TimeSpan.FromSeconds(90);
+
+    [DataField]
+    public TimeSpan MaxStageDelay = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// Zero for both means the strain never clears on its own.
+    /// </summary>
+    [DataField]
+    public TimeSpan MinDuration = TimeSpan.FromMinutes(8);
+
+    [DataField]
+    public TimeSpan MaxDuration = TimeSpan.FromMinutes(15);
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenArchetypePrototype.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenArchetypePrototype.cs
@@ -3,7 +3,7 @@ using Robust.Shared.Prototypes;
 namespace Content.Shared._Starlight.Medical.Virology;
 
 /// <summary>
-/// A template a concrete strain is rolled from when an outbreak is seeded.
+/// A template a concrete strain is rolled from when virology creates a disease.
 ///
 /// Strains are generated rather than authored so that identification stays meaningful.
 /// A fixed strain is memorised after a few shifts, after which nobody ever touches
@@ -27,30 +27,47 @@ public sealed partial class PathogenArchetypePrototype : IPrototype
     [DataField(required: true)]
     public LocId Name;
 
+    /// <summary>
+    /// Analyzer description shown after the strain has been catalogued.
+    /// </summary>
     [DataField]
     public LocId? Description;
 
+    /// <summary>
+    /// Broad family used by symptoms and contamination. Later spread and PPE systems also
+    /// use this to choose the transmission route and protection checks.
+    /// </summary>
     [DataField]
     public PathogenType PathogenType = PathogenType.Virus;
 
+    /// <summary>
+    /// Severity tier. Higher tiers can replace lower-tier active infections.
+    /// </summary>
     [DataField]
     public PathogenTier Tier = PathogenTier.Ambient;
 
     /// <summary>
-    /// Weight for automatic ambient seeding. Zero means it is never seeded on its own and only
-    /// appears when something asks for it by name - which is how engineered strains work.
+    /// Future weight for automatic ambient seeding. Zero means seeding code should only
+    /// create it when something asks for it by name, which is how engineered strains work.
     /// </summary>
     [DataField]
     public float SeedWeight = 1f;
 
+    /// <summary>
+    /// Whether this archetype's effects are intended to help the host.
+    /// </summary>
     [DataField]
     public bool Beneficial;
 
+    /// <summary>
+    /// Whether natural recovery grants immunity to this specific rolled strain.
+    /// </summary>
     [DataField]
     public bool ImmunityOnRecovery = true;
 
     /// <summary>
-    /// Whether this respawns onto a random host when its last carrier loses it.
+    /// Whether this may respawn onto a random host when its last carrier loses it and
+    /// the extinction respawn gate is enabled.
     /// Ambient strains do; the station never really gets rid of a cold, it just develops
     /// herd immunity until there is nobody left to infect.
     /// </summary>
@@ -93,42 +110,79 @@ public sealed partial class PathogenArchetypePrototype : IPrototype
 
     // --- Rolled numbers ---
 
+    /// <summary>
+    /// Minimum rolled transmission strength. Stored and reported in PR A; later spread
+    /// code consumes it as a multiplier.
+    /// </summary>
     [DataField]
     public float MinTransmissibility = 0.03f;
 
+    /// <summary>
+    /// Maximum rolled transmission strength. Stored and reported in PR A; later spread
+    /// code consumes it as a multiplier.
+    /// </summary>
     [DataField]
     public float MaxTransmissibility = 0.06f;
 
+    /// <summary>
+    /// Minimum future spread radius in tiles.
+    /// </summary>
     [DataField]
     public float MinSpreadRange = 1.5f;
 
+    /// <summary>
+    /// Maximum future spread radius in tiles.
+    /// </summary>
     [DataField]
     public float MaxSpreadRange = 2f;
 
+    /// <summary>
+    /// Minimum time from infection to stage 1. Authored as seconds in YAML.
+    /// </summary>
     [DataField]
     public TimeSpan MinIncubation = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Maximum time from infection to stage 1. Authored as seconds in YAML.
+    /// </summary>
     [DataField]
     public TimeSpan MaxIncubation = TimeSpan.FromSeconds(150);
 
+    /// <summary>
+    /// Minimum final stage a rolled strain can have, inclusive.
+    /// </summary>
     [DataField]
     public int MinStages = 2;
 
+    /// <summary>
+    /// Maximum final stage a rolled strain can have, inclusive.
+    /// </summary>
     [DataField]
     public int MaxStages = 3;
 
+    /// <summary>
+    /// Minimum time between stage increases after incubation. Authored as seconds in YAML.
+    /// </summary>
     [DataField]
     public TimeSpan MinStageDelay = TimeSpan.FromSeconds(90);
 
+    /// <summary>
+    /// Maximum time between stage increases after incubation. Authored as seconds in YAML.
+    /// </summary>
     [DataField]
     public TimeSpan MaxStageDelay = TimeSpan.FromSeconds(180);
 
     /// <summary>
-    /// Zero for both means the strain never clears on its own.
+    /// Minimum time from stage 1 to natural recovery. Authored as seconds in YAML.
+    /// Zero for both duration bounds means the strain never clears on its own.
     /// </summary>
     [DataField]
     public TimeSpan MinDuration = TimeSpan.FromMinutes(8);
 
+    /// <summary>
+    /// Maximum time from stage 1 to natural recovery. Authored as seconds in YAML.
+    /// Zero for both duration bounds means the strain never clears on its own.
+    /// </summary>
     [DataField]
     public TimeSpan MaxDuration = TimeSpan.FromMinutes(15);
 }

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenDisposedComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenDisposedComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// Marks something the crew has thrown away. Binning rubbish is dealing with it, so a
+/// disposed entity stops counting as contamination for good rather than resuming the moment
+/// it is dumped onto the disposal room floor.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PathogenDisposedComponent : Component;

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenImmunityComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenImmunityComponent.cs
@@ -1,0 +1,23 @@
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// Tracks what a host can no longer catch, from recovery or from vaccination.
+/// Accumulated immunity is also what retires an ambient strain: once nobody left can catch
+/// it, it stops respawning.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PathogenImmunityComponent : Component
+{
+    /// <summary>
+    /// Strain ids this host is immune to.
+    /// </summary>
+    [DataField]
+    public HashSet<int> Immune = new();
+
+    /// <summary>
+    /// Immune to everything, permanently. For hosts that should never be infected, such as
+    /// synthetics and the undead.
+    /// </summary>
+    [DataField]
+    public bool Total;
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenInfectionComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenInfectionComponent.cs
@@ -1,0 +1,59 @@
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// Present on anything currently carrying one or more pathogens.
+/// Removed automatically once the last infection clears.
+/// </summary>
+[RegisterComponent]
+public sealed partial class PathogenInfectionComponent : Component
+{
+    [DataField]
+    public List<PathogenInfection> Infections = new();
+}
+
+/// <summary>
+/// One active infection on one host.
+/// </summary>
+[DataDefinition]
+public sealed partial class PathogenInfection
+{
+    /// <summary>
+    /// Strain id, resolved through the registry. Strains are generated per round rather
+    /// than authored, so this is an id rather than a prototype reference.
+    /// </summary>
+    [DataField(required: true)]
+    public int Pathogen;
+
+    /// <summary>
+    /// 0-3. Zero while incubating. Transmission is already active, but symptoms start at 1.
+    /// </summary>
+    [DataField]
+    public int Stage;
+
+    /// <summary>
+    /// When the next stage increment happens.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextStage;
+
+    /// <summary>
+    /// When this clears on its own.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan EndTime;
+
+    /// <summary>
+    /// Next expression time, keyed by symptom prototype id.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<string, TimeSpan> SymptomTimers = new();
+
+    /// <summary>
+    /// Admin-test override for symptom cadence. Null uses each symptom prototype's
+    /// normal interval.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public TimeSpan? SymptomIntervalOverride;
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenInfectionComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenInfectionComponent.cs
@@ -9,6 +9,10 @@ namespace Content.Shared._Starlight.Medical.Virology;
 [RegisterComponent]
 public sealed partial class PathogenInfectionComponent : Component
 {
+    /// <summary>
+    /// Active infection records on this host. The current runtime keeps at most one,
+    /// but the list keeps the serialized shape open for future stacked infections.
+    /// </summary>
     [DataField]
     public List<PathogenInfection> Infections = new();
 }
@@ -27,7 +31,7 @@ public sealed partial class PathogenInfection
     public int Pathogen;
 
     /// <summary>
-    /// 0-3. Zero while incubating. Transmission is already active, but symptoms start at 1.
+    /// 0-3. Zero while incubating; symptoms start at 1.
     /// </summary>
     [DataField]
     public int Stage;
@@ -49,6 +53,13 @@ public sealed partial class PathogenInfection
     /// </summary>
     [ViewVariables(VVAccess.ReadOnly)]
     public Dictionary<string, TimeSpan> SymptomTimers = new();
+
+    /// <summary>
+    /// Cumulative damage already applied by capped pathogen damage effects, keyed by
+    /// damage type id. Pre-existing wounds do not consume this infection's cap.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public Dictionary<string, float> CappedDamage = new();
 
     /// <summary>
     /// Admin-test override for symptom cadence. Null uses each symptom prototype's

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenMildBlurComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenMildBlurComponent.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Eye.Blinding.Components;
+using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.StatusEffectNew;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class PathogenMildBlurComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public float Magnitude = 1.5f;
+}
+
+public sealed partial class PathogenMildBlurSystem : EntitySystem
+{
+    [Dependency] private BlurryVisionSystem _blurryVision = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<PathogenMildBlurComponent, StatusEffectAppliedEvent>(OnChanged);
+        SubscribeLocalEvent<PathogenMildBlurComponent, StatusEffectRemovedEvent>(OnChanged);
+        SubscribeLocalEvent<PathogenMildBlurComponent, StatusEffectRelayedEvent<GetBlurEvent>>(OnGetBlur);
+    }
+
+    private void OnChanged(Entity<PathogenMildBlurComponent> entity, ref StatusEffectAppliedEvent args)
+        => Refresh(args.Target);
+
+    private void OnChanged(Entity<PathogenMildBlurComponent> entity, ref StatusEffectRemovedEvent args)
+        => Refresh(args.Target);
+
+    private void OnGetBlur(
+        Entity<PathogenMildBlurComponent> entity,
+        ref StatusEffectRelayedEvent<GetBlurEvent> args)
+    {
+        args.Args.Blur += entity.Comp.Magnitude;
+    }
+
+    private void Refresh(EntityUid target)
+    {
+        if (!TryComp<BlindableComponent>(target, out var blindable))
+            return;
+
+        _blurryVision.UpdateBlurMagnitude((target, blindable), blindable.IsWearingGlasses);
+    }
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomEffects.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomEffects.cs
@@ -1,0 +1,65 @@
+using Content.Shared.Damage;
+using Content.Shared.Damage.Components;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Systems;
+using Content.Shared.EntityEffects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+public sealed partial class PathogenCappedDamageEffectSystem
+    : EntityEffectSystem<DamageableComponent, PathogenCappedDamage>
+{
+    [Dependency] private DamageableSystem _damageable = default!;
+
+    protected override void Effect(
+        Entity<DamageableComponent> entity,
+        ref EntityEffectEvent<PathogenCappedDamage> args)
+    {
+        var current = entity.Comp.Damage.DamageDict.GetValueOrDefault(args.Effect.DamageType.Id).Float();
+        var amount = Math.Min(args.Effect.Amount * args.Scale, args.Effect.Maximum - current);
+        if (amount <= 0f)
+            return;
+
+        var damage = new DamageSpecifier();
+        damage.DamageDict[args.Effect.DamageType.Id] = FixedPoint2.New(amount);
+        _damageable.TryChangeDamage(
+            entity.AsNullable(),
+            damage,
+            args.Effect.IgnoreResistances,
+            interruptsDoAfters: false);
+    }
+}
+
+public sealed partial class PathogenCappedDamage : EntityEffectBase<PathogenCappedDamage>
+{
+    [DataField(required: true)]
+    public ProtoId<DamageTypePrototype> DamageType;
+
+    [DataField(required: true)]
+    public float Amount;
+
+    [DataField(required: true)]
+    public float Maximum;
+
+    [DataField]
+    public bool IgnoreResistances = true;
+}
+
+public sealed partial class PathogenDropActiveItemEffectSystem
+    : EntityEffectSystem<HandsComponent, PathogenDropActiveItem>
+{
+    [Dependency] private SharedHandsSystem _hands = default!;
+
+    protected override void Effect(
+        Entity<HandsComponent> entity,
+        ref EntityEffectEvent<PathogenDropActiveItem> args)
+    {
+        _hands.TryDrop(entity.AsNullable(), checkActionBlocker: false);
+    }
+}
+
+public sealed partial class PathogenDropActiveItem : EntityEffectBase<PathogenDropActiveItem>;

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomEffects.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomEffects.cs
@@ -19,32 +19,70 @@ public sealed partial class PathogenCappedDamageEffectSystem
         Entity<DamageableComponent> entity,
         ref EntityEffectEvent<PathogenCappedDamage> args)
     {
-        var current = entity.Comp.Damage.DamageDict.GetValueOrDefault(args.Effect.DamageType.Id).Float();
-        var amount = Math.Min(args.Effect.Amount * args.Scale, args.Effect.Maximum - current);
+        var damageType = args.Effect.DamageType.Id;
+        PathogenInfection? infection = null;
+
+        // Only one infection is supported at a time today; if stacked infections are ever
+        // added, this needs to select the record belonging to the strain that fired.
+        if (TryComp<PathogenInfectionComponent>(entity.Owner, out var infections) &&
+            infections.Infections.Count > 0)
+        {
+            infection = infections.Infections[0];
+        }
+
+        // Without an infection record to bill against, the cap falls back to the host's
+        // total damage of this type.
+        var cappedCurrent = infection?.CappedDamage.GetValueOrDefault(damageType)
+            ?? entity.Comp.Damage.DamageDict.GetValueOrDefault(damageType).Float();
+
+        var amount = Math.Min(args.Effect.Amount * args.Scale, args.Effect.Maximum - cappedCurrent);
         if (amount <= 0f)
             return;
 
         var damage = new DamageSpecifier();
-        damage.DamageDict[args.Effect.DamageType.Id] = FixedPoint2.New(amount);
-        _damageable.TryChangeDamage(
-            entity.AsNullable(),
-            damage,
-            args.Effect.IgnoreResistances,
-            interruptsDoAfters: false);
+        damage.DamageDict[damageType] = FixedPoint2.New(amount);
+        if (!_damageable.TryChangeDamage(
+                entity.AsNullable(),
+                damage,
+                out var applied,
+                args.Effect.IgnoreResistances,
+                interruptsDoAfters: false))
+        {
+            return;
+        }
+
+        if (infection is null)
+            return;
+
+        var appliedAmount = Math.Max(0f, applied.DamageDict.GetValueOrDefault(damageType).Float());
+        infection.CappedDamage[damageType] = cappedCurrent + appliedAmount;
     }
 }
 
 public sealed partial class PathogenCappedDamage : EntityEffectBase<PathogenCappedDamage>
 {
+    /// <summary>
+    /// Damage type this symptom applies.
+    /// </summary>
     [DataField(required: true)]
     public ProtoId<DamageTypePrototype> DamageType;
 
+    /// <summary>
+    /// Damage attempted on each symptom expression, before resistance modifiers.
+    /// </summary>
     [DataField(required: true)]
     public float Amount;
 
+    /// <summary>
+    /// Maximum cumulative damage this effect can add during one infection. When used
+    /// without an active infection record, this falls back to the host's current damage.
+    /// </summary>
     [DataField(required: true)]
     public float Maximum;
 
+    /// <summary>
+    /// Whether the damage bypasses normal resistance modifiers.
+    /// </summary>
     [DataField]
     public bool IgnoreResistances = true;
 }

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomPrototype.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomPrototype.cs
@@ -1,0 +1,47 @@
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// A single expressible symptom. Strains are built by combining these, so a symptom
+/// should be self-contained and say nothing about which strain is carrying it.
+/// </summary>
+[Prototype]
+public sealed partial class PathogenSymptomPrototype : IPrototype
+{
+    [ViewVariables]
+    [IdDataField]
+    public string ID { get; private set; } = default!;
+
+    /// <summary>
+    /// Shown by the analyzer once the strain has been catalogued.
+    /// </summary>
+    [DataField(required: true)]
+    public LocId Name;
+
+    /// <summary>
+    /// The stage the host must reach before this expresses at all.
+    /// </summary>
+    [DataField]
+    public int MinStage = 1;
+
+    /// <summary>
+    /// Average time between expressions.
+    /// </summary>
+    [DataField]
+    public TimeSpan Interval = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Fraction of <see cref="Interval"/> to randomly vary each expression by.eak.
+    /// </summary>
+    [DataField]
+    public float IntervalVariance = 0.35f;
+
+    /// <summary>
+    /// What actually happens to the host. Reuses the standard entity effect library,
+    /// so anything a reagent can do, a symptom can do.
+    /// </summary>
+    [DataField]
+    public List<EntityEffect> Effects = new();
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomPrototype.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenSymptomPrototype.cs
@@ -10,6 +10,9 @@ namespace Content.Shared._Starlight.Medical.Virology;
 [Prototype]
 public sealed partial class PathogenSymptomPrototype : IPrototype
 {
+    /// <summary>
+    /// Prototype id used by archetype symptom lists and runtime strains.
+    /// </summary>
     [ViewVariables]
     [IdDataField]
     public string ID { get; private set; } = default!;
@@ -33,7 +36,8 @@ public sealed partial class PathogenSymptomPrototype : IPrototype
     public TimeSpan Interval = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// Fraction of <see cref="Interval"/> to randomly vary each expression by.eak.
+    /// Fraction of <see cref="Interval"/> used as +/- random variance for each expression.
+    /// For example, 0.35 allows the next interval to roll 35% shorter or longer.
     /// </summary>
     [DataField]
     public float IntervalVariance = 0.35f;

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenTier.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenTier.cs
@@ -1,0 +1,23 @@
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// How serious a strain is. Determines which prevalence budget it draws from.
+/// </summary>
+public enum PathogenTier : byte
+{
+    /// <summary>
+    /// Harmless and self-clearing. Respawns after it dies out.
+    /// </summary>
+    Ambient,
+
+    /// <summary>
+    /// Seeded when station contamination crosses a milestone. Survivable, and does not
+    /// respawn once cured.
+    /// </summary>
+    Emergent,
+
+    /// <summary>
+    /// Deliberately engineered.
+    /// </summary>
+    Virulent,
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenTier.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenTier.cs
@@ -6,13 +6,13 @@ namespace Content.Shared._Starlight.Medical.Virology;
 public enum PathogenTier : byte
 {
     /// <summary>
-    /// Harmless and self-clearing. Respawns after it dies out.
+    /// Harmless and self-clearing. Eligible for extinction respawn when that gate is enabled.
     /// </summary>
     Ambient,
 
     /// <summary>
-    /// Seeded when station contamination crosses a milestone. Survivable, and does not
-    /// respawn once cured.
+    /// Survivable escalation tier. Future milestone seeding creates these from station
+    /// contamination; they do not respawn once cured.
     /// </summary>
     Emergent,
 

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenType.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenType.cs
@@ -1,0 +1,22 @@
+namespace Content.Shared._Starlight.Medical.Virology;
+
+/// <summary>
+/// Broad transmission family. Determines spread, symptoms, protection and contamination.
+/// </summary>
+public enum PathogenType : byte
+{
+    /// <summary>
+    /// Spreads through proximity.
+    /// </summary>
+    Virus,
+
+    /// <summary>
+    /// Spreads through physical contact only.
+    /// </summary>
+    Bacteria,
+
+    /// <summary>
+    /// Spreads from environmental sources only, never directly between hosts.
+    /// </summary>
+    Fungus,
+}

--- a/Content.Shared/_Starlight/Medical/Virology/PathogenType.cs
+++ b/Content.Shared/_Starlight/Medical/Virology/PathogenType.cs
@@ -1,22 +1,23 @@
 namespace Content.Shared._Starlight.Medical.Virology;
 
 /// <summary>
-/// Broad transmission family. Determines spread, symptoms, protection and contamination.
+/// Broad pathogen family. Currently drives symptoms and contamination; transmission and
+/// protection rules are not implemented yet.
 /// </summary>
 public enum PathogenType : byte
 {
     /// <summary>
-    /// Spreads through proximity.
+    /// Viral symptoms and contamination. Proximity spread is not implemented yet.
     /// </summary>
     Virus,
 
     /// <summary>
-    /// Spreads through physical contact only.
+    /// Bacterial symptoms and contamination. Contact spread is not implemented yet.
     /// </summary>
     Bacteria,
 
     /// <summary>
-    /// Spreads from environmental sources only, never directly between hosts.
+    /// Fungal symptoms and contamination. Environmental-only spread is not implemented yet.
     /// </summary>
     Fungus,
 }

--- a/Resources/Locale/en-US/_Starlight/virology/admin.ftl
+++ b/Resources/Locale/en-US/_Starlight/virology/admin.ftl
@@ -1,0 +1,6 @@
+verb-categories-virology = Virology
+
+verb-virology-cure-text = Cure All Diseases
+verb-virology-cure-message = Clear every pathogen this person is carrying.
+verb-virology-immune-text = Make Disease Immune
+verb-virology-immune-message = Make this person immune to every pathogen, present and future.

--- a/Resources/Locale/en-US/_Starlight/virology/virology.ftl
+++ b/Resources/Locale/en-US/_Starlight/virology/virology.ftl
@@ -100,19 +100,19 @@ pathogen-symptom-emergent-fungal-ocular-spore-flare-visible = {CAPITALIZE(THE($e
 
 # Strains
 pathogen-name-space-cold = space cold
-pathogen-desc-space-cold = A common and thoroughly unremarkable rhinovirus. Spreads readily, clears on its own, and has never killed anyone. Reliably makes an entire department miserable.
+pathogen-desc-space-cold = A common and thoroughly unremarkable rhinovirus. Self-limiting and rarely dangerous, but reliably makes an entire department miserable.
 
 pathogen-name-throat-rot = throat infection
 pathogen-desc-throat-rot = A mild bacterial infection of the upper airway. Slower to take hold than a cold, more stubborn once it has.
 
 pathogen-name-spore-bloom = spore rash
-pathogen-desc-spore-bloom = A mild surface fungal infection affecting exposed skin and eyes. It does not spread between people, but is difficult to clear from a room once settled.
+pathogen-desc-spore-bloom = A mild surface fungal infection affecting exposed skin and eyes. Unpleasant, visible, and usually self-limiting.
 
 pathogen-name-station-flu = station flu
-pathogen-desc-station-flu = A self-limiting viral flare-up that appears when the station has let contamination get ahead of it. Miserable, obvious, and worth virology's time, but not an antagonist weapon.
+pathogen-desc-station-flu = A self-limiting viral flare-up. Miserable, obvious, and worth virology's time, but not an antagonist weapon.
 
 pathogen-name-grey-lung = grey lung
-pathogen-desc-grey-lung = A bacterial airway infection that thrives in neglected medbay queues and dirty workrooms. It spreads steadily, then clears once treated and contained.
+pathogen-desc-grey-lung = A bacterial airway infection that leaves patients coughing, breathless, and visibly weakened before it clears with care.
 
 pathogen-name-mycosis = mycosis
-pathogen-desc-mycosis = A fungal infection of the skin, eyes, and muscles that lingers in neglected spaces. It is dangerous enough to demand treatment, but is built to create work rather than casualties.
+pathogen-desc-mycosis = A fungal infection of the skin, eyes, and muscles. It is dangerous enough to demand treatment, but is built to create work rather than casualties.

--- a/Resources/Locale/en-US/_Starlight/virology/virology.ftl
+++ b/Resources/Locale/en-US/_Starlight/virology/virology.ftl
@@ -1,0 +1,118 @@
+# Symptoms
+pathogen-symptom-sneezing = sneezing
+pathogen-symptom-coughing = coughing
+
+# Ambient structured symptoms
+pathogen-symptom-core-viral-sniffling = core sniffling
+pathogen-symptom-core-viral-watery-eyes = core watery eyes
+pathogen-symptom-core-bacterial-throat-clearing = core throat clearing
+pathogen-symptom-core-bacterial-throat-discomfort = core throat discomfort
+pathogen-symptom-core-fungal-skin-irritation = core skin irritation
+pathogen-symptom-core-fungal-eye-irritation = core eye irritation
+pathogen-symptom-core-fungal-flaking-skin = core flaking skin
+
+pathogen-symptom-ambient-viral-fatigue = mild fatigue
+pathogen-symptom-ambient-viral-blocked-nose = blocked nose
+pathogen-symptom-ambient-viral-mild-headache = mild headache
+pathogen-symptom-ambient-viral-cold-sensation = cold sensation
+pathogen-symptom-ambient-viral-dry-cough = dry cough
+pathogen-symptom-ambient-viral-sinus-pressure = sinus pressure
+pathogen-symptom-ambient-bacterial-dry-mouth = dry mouth
+pathogen-symptom-ambient-bacterial-painful-swallowing = painful swallowing
+pathogen-symptom-ambient-bacterial-swollen-throat = swollen throat
+pathogen-symptom-ambient-bacterial-unpleasant-taste = unpleasant taste
+pathogen-symptom-ambient-bacterial-mild-fatigue = mild fatigue
+pathogen-symptom-ambient-bacterial-voice-cracking = voice cracking
+pathogen-symptom-ambient-fungal-rash = fungal rash
+pathogen-symptom-ambient-fungal-dry-skin = dry skin
+pathogen-symptom-ambient-fungal-mild-sweating = mild sweating
+pathogen-symptom-ambient-fungal-spore-sneezing = spore sneezing
+pathogen-symptom-ambient-fungal-eye-irritation = eye irritation
+pathogen-symptom-ambient-fungal-crawling-skin = crawling skin sensation
+
+pathogen-symptom-ambient-viral-shivering = light shivering
+pathogen-symptom-ambient-bacterial-coughing-fit = coughing fits
+pathogen-symptom-ambient-fungal-eye-blur = irritated-eye blur
+
+# Emergent structured symptoms
+pathogen-symptom-emergent-viral-fever-chills = fever chills
+pathogen-symptom-emergent-viral-muscle-weakness = muscle weakness
+pathogen-symptom-emergent-viral-light-headedness = light-headedness
+pathogen-symptom-emergent-viral-high-fever = high fever
+pathogen-symptom-emergent-viral-fainting-spell = fainting spells
+pathogen-symptom-emergent-bacterial-coughing-fit = severe coughing fits
+pathogen-symptom-emergent-bacterial-breathlessness = breathlessness
+pathogen-symptom-emergent-bacterial-severe-hoarseness = severe hoarseness
+pathogen-symptom-emergent-bacterial-hypoxic-attack = hypoxic attacks
+pathogen-symptom-emergent-bacterial-respiratory-collapse = respiratory collapse
+pathogen-symptom-emergent-fungal-eye-inflammation = eye inflammation
+pathogen-symptom-emergent-fungal-cramps = fungal cramps
+pathogen-symptom-emergent-fungal-numb-fingers = numb fingers
+pathogen-symptom-emergent-fungal-toxic-mycosis = toxic mycosis
+pathogen-symptom-emergent-fungal-ocular-spore-flare = ocular spore flares
+
+# Public stage-one signs
+pathogen-symptom-core-viral-sniffling-visible = {CAPITALIZE(THE($entity))} sniffles and wipes their nose.
+pathogen-symptom-core-viral-watery-eyes-visible = {CAPITALIZE(THE($entity))} rubs their watery eyes.
+pathogen-symptom-core-bacterial-throat-clearing-visible = {CAPITALIZE(THE($entity))} repeatedly clears their throat.
+pathogen-symptom-core-bacterial-throat-discomfort-visible = {CAPITALIZE(THE($entity))} winces and rubs their throat.
+pathogen-symptom-core-fungal-skin-irritation-visible = {CAPITALIZE(THE($entity))} scratches at irritated skin.
+pathogen-symptom-core-fungal-eye-irritation-visible = {CAPITALIZE(THE($entity))} rubs their irritated eyes.
+pathogen-symptom-core-fungal-flaking-skin-visible = {CAPITALIZE(THE($entity))} brushes flaky skin from their clothing.
+
+# Harmless ambient stage-two sensations
+pathogen-symptom-ambient-viral-blocked-nose-popup = Your nose feels hopelessly blocked.
+pathogen-symptom-ambient-viral-mild-headache-popup = A faint pressure settles behind your forehead.
+pathogen-symptom-ambient-viral-cold-sensation-popup = You feel cold despite the comfortable air.
+pathogen-symptom-ambient-viral-sinus-pressure-popup = Pressure builds gently around your sinuses.
+pathogen-symptom-ambient-bacterial-dry-mouth-popup = Your mouth feels unusually dry.
+pathogen-symptom-ambient-bacterial-painful-swallowing-popup = Your throat stings when you swallow.
+pathogen-symptom-ambient-bacterial-swollen-throat-popup = Your throat feels slightly swollen.
+pathogen-symptom-ambient-bacterial-unpleasant-taste-popup = A bitter taste lingers in your mouth.
+pathogen-symptom-ambient-bacterial-voice-cracking-visible = {CAPITALIZE(POSS-ADJ($entity))} voice cracks unexpectedly.
+pathogen-symptom-ambient-fungal-rash-popup = A patchy rash prickles across your skin.
+pathogen-symptom-ambient-fungal-dry-skin-popup = Your skin feels dry and flaky.
+pathogen-symptom-ambient-fungal-mild-sweating-popup = Your skin feels faintly clammy.
+pathogen-symptom-ambient-fungal-eye-irritation-popup = Your eyes feel gritty and irritated.
+pathogen-symptom-ambient-fungal-crawling-skin-popup = A crawling sensation passes across your skin.
+
+# Weak but noticeable ambient stage-three signatures
+pathogen-symptom-ambient-viral-shivering-popup = A light shiver passes through you.
+pathogen-symptom-ambient-bacterial-coughing-fit-popup = The coughing fit briefly takes the strength from your legs.
+pathogen-symptom-ambient-fungal-eye-blur-visible = {CAPITALIZE(THE($entity))} rubs their irritated eyes.
+
+# Emergent mechanical symptoms
+pathogen-symptom-emergent-viral-fever-chills-visible = {CAPITALIZE(THE($entity))} shivers violently with fever.
+pathogen-symptom-emergent-viral-muscle-weakness-popup = Your aching muscles suddenly lose their strength.
+pathogen-symptom-emergent-viral-light-headedness-popup = The room tilts as your vision swims.
+pathogen-symptom-emergent-viral-high-fever-popup = A scorching fever clouds your vision.
+pathogen-symptom-emergent-viral-fainting-spell-visible = {CAPITALIZE(THE($entity))} goes limp and collapses.
+pathogen-symptom-emergent-bacterial-coughing-fit-popup = A harsh coughing fit drains the strength from your legs.
+pathogen-symptom-emergent-bacterial-breathlessness-popup = Your lungs tighten, leaving you unable to run properly.
+pathogen-symptom-emergent-bacterial-severe-hoarseness-visible = {CAPITALIZE(POSS-ADJ($entity))} voice breaks into a rough rasp.
+pathogen-symptom-emergent-bacterial-hypoxic-attack-popup = Air refuses to reach your lungs as your vision dims.
+pathogen-symptom-emergent-bacterial-respiratory-collapse-visible = {CAPITALIZE(THE($entity))} gasps for air and collapses.
+pathogen-symptom-emergent-fungal-eye-inflammation-visible = {CAPITALIZE(THE($entity))} rubs frantically at their inflamed eyes.
+pathogen-symptom-emergent-fungal-cramps-popup = A painful cramp seizes your muscles.
+pathogen-symptom-emergent-fungal-numb-fingers-popup = Your fingers go numb and lose their grip.
+pathogen-symptom-emergent-fungal-toxic-mycosis-popup = A wave of fungal sickness turns your stomach.
+pathogen-symptom-emergent-fungal-ocular-spore-flare-visible = {CAPITALIZE(THE($entity))} clutches at their eyes as their vision fails.
+
+# Strains
+pathogen-name-space-cold = space cold
+pathogen-desc-space-cold = A common and thoroughly unremarkable rhinovirus. Spreads readily, clears on its own, and has never killed anyone. Reliably makes an entire department miserable.
+
+pathogen-name-throat-rot = throat infection
+pathogen-desc-throat-rot = A mild bacterial infection of the upper airway. Slower to take hold than a cold, more stubborn once it has.
+
+pathogen-name-spore-bloom = spore rash
+pathogen-desc-spore-bloom = A mild surface fungal infection affecting exposed skin and eyes. It does not spread between people, but is difficult to clear from a room once settled.
+
+pathogen-name-station-flu = station flu
+pathogen-desc-station-flu = A self-limiting viral flare-up that appears when the station has let contamination get ahead of it. Miserable, obvious, and worth virology's time, but not an antagonist weapon.
+
+pathogen-name-grey-lung = grey lung
+pathogen-desc-grey-lung = A bacterial airway infection that thrives in neglected medbay queues and dirty workrooms. It spreads steadily, then clears once treated and contained.
+
+pathogen-name-mycosis = mycosis
+pathogen-desc-mycosis = A fungal infection of the skin, eyes, and muscles that lingers in neglected spaces. It is dangerous enough to demand treatment, but is built to create work rather than casualties.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -103,6 +103,9 @@
     - Common
     - Science
   - type: ZombieImmune
+  # Starlight - nothing organic to infect.
+  - type: PathogenImmunity
+    total: true
   - type: Repairable
     damageValue: -10 # 10 seconds to repair from crit
     doAfterDelay: 1

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/bowl.yml
@@ -83,6 +83,7 @@
     state: bowl-trash
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Trash
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/plate.yml
@@ -76,6 +76,7 @@
     storedOffset: 0,-6
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Trash
   - type: SpaceGarbage
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Containers/tin.yml
@@ -73,6 +73,7 @@
       Steel: 100
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Trash
 
 # Tins

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meat.yml
@@ -549,6 +549,7 @@
     - Meat
     - Trash
     - Recyclable
+    - PathogenRottenFood # Starlight
   - type: Sprite
     state: rotten
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -455,6 +455,7 @@
         - ItemMask
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Recyclable
     - Trash
     - BananaPeel
@@ -1264,6 +1265,7 @@
     size: Tiny
   - type: Tag
     tags:
+      - OrganicTrash # Starlight
       - Trash
   - type: SolutionContainerManager
     solutions:
@@ -2463,6 +2465,7 @@
     state: pit
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Recyclable
     - Trash
   - type: SolutionContainerManager
@@ -2782,6 +2785,7 @@
     size: Tiny
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Recyclable
     - Trash
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/snacks.yml
@@ -618,6 +618,7 @@
     size: Tiny
   - type: Tag
     tags:
+    - OrganicTrash # Starlight
     - Trash
   - type: PhysicalComposition
     materialComposition:

--- a/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Mobs/Species/ipc.yml
@@ -164,6 +164,9 @@
   - type: HumanoidAppearance
     species: IPC
   - type: ZombieImmune
+  # Starlight - a chassis of machine parts running on coolant has nothing to infect.
+  - type: PathogenImmunity
+    total: true
   - type: TypingIndicator
     proto: robot
   - type: Speech

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/skeleton.yml
@@ -55,6 +55,9 @@
   - type: Speech
     speechVerb: Skeleton
   - type: ZombieImmune
+  # Starlight - no soft tissue left for a pathogen to live in.
+  - type: PathogenImmunity
+    total: true
   - type: Vocal
     sounds:
       Male: Skeleton

--- a/Resources/Prototypes/_Starlight/Medical/Virology/archetypes.yml
+++ b/Resources/Prototypes/_Starlight/Medical/Virology/archetypes.yml
@@ -1,0 +1,216 @@
+﻿# Archetypes, not strains. Each of these is a template used to roll a concrete strain at
+# a spawning event; the character stays fixed, the specifics do not.
+
+# Ambients are irritating, visible, self-clearing. If any of these ever ruin
+# someone's shift, the numbers to change are the duration and prevalence ranges,
+# not the symptom pool.
+
+- type: pathogenArchetype
+  id: SpaceCold
+  name: pathogen-name-space-cold
+  description: pathogen-desc-space-cold
+  pathogenType: Virus
+  seedWeight: 1.5
+  respawnOnExtinction: true
+  tier: Ambient
+  maxPrevalence: 0.10
+  stageOneSymptoms:
+  - Sneezing
+  - CoreViralSniffling
+  - CoreViralWateryEyes
+  stageThreeSymptoms:
+  - AmbientViralShivering
+  stageTwoSymptomPool:
+  - AmbientViralFatigue
+  - AmbientViralBlockedNose
+  - AmbientViralMildHeadache
+  - AmbientViralColdSensation
+  - AmbientViralDryCough
+  - AmbientViralSinusPressure
+  minTransmissibility: 0.04
+  maxTransmissibility: 0.06
+  minSpreadRange: 1.5
+  maxSpreadRange: 2.0
+  minIncubation: 60
+  maxIncubation: 150
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 90
+  maxStageDelay: 180
+  minDuration: 480
+  maxDuration: 900
+
+- type: pathogenArchetype
+  id: ThroatRot
+  name: pathogen-name-throat-rot
+  description: pathogen-desc-throat-rot
+  pathogenType: Bacteria
+  seedWeight: 1
+  respawnOnExtinction: true
+  tier: Ambient
+  maxPrevalence: 0.10
+  stageOneSymptoms:
+  - Coughing
+  - CoreBacterialThroatClearing
+  - CoreBacterialThroatDiscomfort
+  stageThreeSymptoms:
+  - AmbientBacterialCoughingFit
+  stageTwoSymptomPool:
+  - AmbientBacterialDryMouth
+  - AmbientBacterialPainfulSwallowing
+  - AmbientBacterialSwollenThroat
+  - AmbientBacterialUnpleasantTaste
+  - AmbientBacterialMildFatigue
+  - AmbientBacterialVoiceCracking
+  minTransmissibility: 0.03
+  maxTransmissibility: 0.045
+  minSpreadRange: 1.5
+  maxSpreadRange: 2.0
+  minIncubation: 90
+  maxIncubation: 210
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 120
+  maxStageDelay: 210
+  minDuration: 600
+  maxDuration: 1080
+
+# Fungus is environmental only. So transmission values stay is zero
+- type: pathogenArchetype
+  id: SporeBloom
+  name: pathogen-name-spore-bloom
+  description: pathogen-desc-spore-bloom
+  pathogenType: Fungus
+  seedWeight: 0.8
+  respawnOnExtinction: true
+  tier: Ambient
+  maxPrevalence: 0.08
+  stageOneSymptoms:
+  - CoreFungalSkinIrritation
+  - CoreFungalEyeIrritation
+  - CoreFungalFlakingSkin
+  stageThreeSymptoms:
+  - AmbientFungalEyeBlur
+  stageTwoSymptomPool:
+  - AmbientFungalRash
+  - AmbientFungalDrySkin
+  - AmbientFungalMildSweating
+  - AmbientFungalSporeSneezing
+  - AmbientFungalEyeIrritation
+  - AmbientFungalCrawlingSkin
+  minTransmissibility: 0
+  maxTransmissibility: 0
+  minSpreadRange: 2.0
+  maxSpreadRange: 2.5
+  minIncubation: 120
+  maxIncubation: 240
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 150
+  maxStageDelay: 240
+  minDuration: 720
+  maxDuration: 1200
+
+# --- Emergent ---
+# These are station-neglect outbreaks, not antagonist diseases. seedWeight 0 keeps them
+# out of ambient milestone selection until the contamination system deliberately spawns one.
+
+- type: pathogenArchetype
+  id: StationFlu
+  name: pathogen-name-station-flu
+  description: pathogen-desc-station-flu
+  pathogenType: Virus
+  seedWeight: 0
+  respawnOnExtinction: false
+  tier: Emergent
+  maxPrevalence: 0.15
+  stageOneSymptoms:
+  - Sneezing
+  - CoreViralSniffling
+  - CoreViralWateryEyes
+  stageThreeSymptoms:
+  - EmergentViralHighFever
+  - EmergentViralFaintingSpell
+  stageTwoSymptomPool:
+  - EmergentViralFeverChills
+  - EmergentViralMuscleWeakness
+  - EmergentViralLightHeadedness
+  minTransmissibility: 0.035
+  maxTransmissibility: 0.055
+  minSpreadRange: 1.5
+  maxSpreadRange: 2.0
+  minIncubation: 120
+  maxIncubation: 240
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 120
+  maxStageDelay: 210
+  minDuration: 900
+  maxDuration: 1500
+
+- type: pathogenArchetype
+  id: GreyLung
+  name: pathogen-name-grey-lung
+  description: pathogen-desc-grey-lung
+  pathogenType: Bacteria
+  seedWeight: 0
+  respawnOnExtinction: false
+  tier: Emergent
+  maxPrevalence: 0.15
+  stageOneSymptoms:
+  - Coughing
+  - CoreBacterialThroatClearing
+  - CoreBacterialThroatDiscomfort
+  stageThreeSymptoms:
+  - EmergentBacterialHypoxicAttack
+  - EmergentBacterialRespiratoryCollapse
+  stageTwoSymptomPool:
+  - EmergentBacterialCoughingFit
+  - EmergentBacterialBreathlessness
+  - EmergentBacterialSevereHoarseness
+  minTransmissibility: 0.025
+  maxTransmissibility: 0.045
+  minSpreadRange: 1.5
+  maxSpreadRange: 2.0
+  minIncubation: 150
+  maxIncubation: 300
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 150
+  maxStageDelay: 240
+  minDuration: 1080
+  maxDuration: 1800
+
+- type: pathogenArchetype
+  id: Mycosis
+  name: pathogen-name-mycosis
+  description: pathogen-desc-mycosis
+  pathogenType: Fungus
+  seedWeight: 0
+  respawnOnExtinction: false
+  tier: Emergent
+  maxPrevalence: 0.12
+  stageOneSymptoms:
+  - CoreFungalSkinIrritation
+  - CoreFungalEyeIrritation
+  - CoreFungalFlakingSkin
+  stageThreeSymptoms:
+  - EmergentFungalToxicMycosis
+  - EmergentFungalOcularSporeFlare
+  stageTwoSymptomPool:
+  - EmergentFungalEyeInflammation
+  - EmergentFungalCramps
+  - EmergentFungalNumbFingers
+  # Fungus is environmental only; treatment contact and quarantine do not spread it.
+  minTransmissibility: 0
+  maxTransmissibility: 0
+  minSpreadRange: 2.0
+  maxSpreadRange: 2.5
+  minIncubation: 180
+  maxIncubation: 360
+  minStages: 3
+  maxStages: 3
+  minStageDelay: 180
+  maxStageDelay: 300
+  minDuration: 1200
+  maxDuration: 2100

--- a/Resources/Prototypes/_Starlight/Medical/Virology/status_effects.yml
+++ b/Resources/Prototypes/_Starlight/Medical/Virology/status_effects.yml
@@ -1,0 +1,17 @@
+- type: entity
+  parent: StatusEffectSlowdown
+  id: PathogenThroatSlowdownStatusEffect
+  name: throat irritation
+
+- type: entity
+  parent: MobStatusEffectDebuff
+  id: PathogenMildBlurStatusEffect
+  name: irritated eyes
+  components:
+  - type: PathogenMildBlur
+    magnitude: 1.5
+
+- type: entity
+  parent: StatusEffectSlowdown
+  id: PathogenEmergentSlowdownStatusEffect
+  name: pathogen weakness

--- a/Resources/Prototypes/_Starlight/Medical/Virology/symptoms.yml
+++ b/Resources/Prototypes/_Starlight/Medical/Virology/symptoms.yml
@@ -1,0 +1,651 @@
+# Symptoms are the spliceable unit. A symptom knows nothing about which strain carries it,
+# so anything here can be combined with anything else.
+#
+# HARD RULE for the ambient tier: nothing in this file may deal lasting damage or
+# meaningfully impair a shift. Ambient strains exist to be visible and irritating, not
+# to hurt people.
+
+- type: pathogenSymptom
+  id: Sneezing
+  name: pathogen-symptom-sneezing
+  minStage: 1
+  interval: 45
+  effects:
+  - !type:Emote
+    emote: Sneeze
+    showInChat: true
+    force: true
+
+- type: pathogenSymptom
+  id: Coughing
+  name: pathogen-symptom-coughing
+  minStage: 1
+  interval: 40
+  effects:
+  - !type:Emote
+    emote: Cough
+    showInChat: true
+    force: true
+
+# --- Ambient stage-one core pools ---
+# Every option is externally visible. Ambient, emergent, and virulent archetypes can
+# share these pools while selecting only one warning for each generated strain.
+
+- type: pathogenSymptom
+  id: CoreViralSniffling
+  name: pathogen-symptom-core-viral-sniffling
+  minStage: 1
+  interval: 55
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-viral-sniffling-visible
+
+- type: pathogenSymptom
+  id: CoreViralWateryEyes
+  name: pathogen-symptom-core-viral-watery-eyes
+  minStage: 1
+  interval: 60
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-viral-watery-eyes-visible
+
+- type: pathogenSymptom
+  id: CoreBacterialThroatClearing
+  name: pathogen-symptom-core-bacterial-throat-clearing
+  minStage: 1
+  interval: 55
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-bacterial-throat-clearing-visible
+
+- type: pathogenSymptom
+  id: CoreBacterialThroatDiscomfort
+  name: pathogen-symptom-core-bacterial-throat-discomfort
+  minStage: 1
+  interval: 60
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-bacterial-throat-discomfort-visible
+
+- type: pathogenSymptom
+  id: CoreFungalSkinIrritation
+  name: pathogen-symptom-core-fungal-skin-irritation
+  minStage: 1
+  interval: 55
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-fungal-skin-irritation-visible
+
+- type: pathogenSymptom
+  id: CoreFungalEyeIrritation
+  name: pathogen-symptom-core-fungal-eye-irritation
+  minStage: 1
+  interval: 60
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-fungal-eye-irritation-visible
+
+- type: pathogenSymptom
+  id: CoreFungalFlakingSkin
+  name: pathogen-symptom-core-fungal-flaking-skin
+  minStage: 1
+  interval: 60
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-core-fungal-flaking-skin-visible
+
+# --- Ambient stage-two pools ---
+# These are flavour only. Each ambient strain rolls exactly two from its type's pool.
+
+- type: pathogenSymptom
+  id: AmbientViralFatigue
+  name: pathogen-symptom-ambient-viral-fatigue
+  minStage: 2
+  interval: 75
+  effects:
+  - !type:Emote
+    emote: Yawn
+    showInChat: true
+    force: true
+
+- type: pathogenSymptom
+  id: AmbientViralBlockedNose
+  name: pathogen-symptom-ambient-viral-blocked-nose
+  minStage: 2
+  interval: 80
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-viral-blocked-nose-popup
+
+- type: pathogenSymptom
+  id: AmbientViralMildHeadache
+  name: pathogen-symptom-ambient-viral-mild-headache
+  minStage: 2
+  interval: 95
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-viral-mild-headache-popup
+
+- type: pathogenSymptom
+  id: AmbientViralColdSensation
+  name: pathogen-symptom-ambient-viral-cold-sensation
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-viral-cold-sensation-popup
+
+- type: pathogenSymptom
+  id: AmbientViralDryCough
+  name: pathogen-symptom-ambient-viral-dry-cough
+  minStage: 2
+  interval: 75
+  effects:
+  - !type:Emote
+    emote: Cough
+    showInChat: true
+    force: true
+
+- type: pathogenSymptom
+  id: AmbientViralSinusPressure
+  name: pathogen-symptom-ambient-viral-sinus-pressure
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-viral-sinus-pressure-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialDryMouth
+  name: pathogen-symptom-ambient-bacterial-dry-mouth
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-bacterial-dry-mouth-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialPainfulSwallowing
+  name: pathogen-symptom-ambient-bacterial-painful-swallowing
+  minStage: 2
+  interval: 80
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-bacterial-painful-swallowing-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialSwollenThroat
+  name: pathogen-symptom-ambient-bacterial-swollen-throat
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-bacterial-swollen-throat-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialUnpleasantTaste
+  name: pathogen-symptom-ambient-bacterial-unpleasant-taste
+  minStage: 2
+  interval: 95
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-bacterial-unpleasant-taste-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialMildFatigue
+  name: pathogen-symptom-ambient-bacterial-mild-fatigue
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:Emote
+    emote: Yawn
+    showInChat: true
+    force: true
+
+- type: pathogenSymptom
+  id: AmbientBacterialVoiceCracking
+  name: pathogen-symptom-ambient-bacterial-voice-cracking
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-ambient-bacterial-voice-cracking-visible
+
+- type: pathogenSymptom
+  id: AmbientFungalRash
+  name: pathogen-symptom-ambient-fungal-rash
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-fungal-rash-popup
+
+- type: pathogenSymptom
+  id: AmbientFungalDrySkin
+  name: pathogen-symptom-ambient-fungal-dry-skin
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-fungal-dry-skin-popup
+
+- type: pathogenSymptom
+  id: AmbientFungalMildSweating
+  name: pathogen-symptom-ambient-fungal-mild-sweating
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-fungal-mild-sweating-popup
+
+- type: pathogenSymptom
+  id: AmbientFungalSporeSneezing
+  name: pathogen-symptom-ambient-fungal-spore-sneezing
+  minStage: 2
+  interval: 80
+  effects:
+  - !type:Emote
+    emote: Sneeze
+    showInChat: true
+    force: true
+
+- type: pathogenSymptom
+  id: AmbientFungalEyeIrritation
+  name: pathogen-symptom-ambient-fungal-eye-irritation
+  minStage: 2
+  interval: 80
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-fungal-eye-irritation-popup
+
+- type: pathogenSymptom
+  id: AmbientFungalCrawlingSkin
+  name: pathogen-symptom-ambient-fungal-crawling-skin
+  minStage: 2
+  interval: 95
+  effects:
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-fungal-crawling-skin-popup
+
+# --- Ambient fixed stage-three signatures ---
+
+- type: pathogenSymptom
+  id: AmbientViralShivering
+  name: pathogen-symptom-ambient-viral-shivering
+  minStage: 3
+  interval: 45
+  intervalVariance: 0.2
+  effects:
+  - !type:Jitter
+    time: 1
+    amplitude: 2
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-viral-shivering-popup
+
+- type: pathogenSymptom
+  id: AmbientBacterialCoughingFit
+  name: pathogen-symptom-ambient-bacterial-coughing-fit
+  minStage: 3
+  interval: 45
+  intervalVariance: 0.2
+  effects:
+  - !type:Emote
+    emote: Cough
+    showInChat: true
+    force: true
+  - !type:MovementSpeedModifier
+    effectProto: PathogenThroatSlowdownStatusEffect
+    walkSpeedModifier: 0.7
+    sprintSpeedModifier: 0.7
+    time: 2
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-ambient-bacterial-coughing-fit-popup
+
+- type: pathogenSymptom
+  id: AmbientFungalEyeBlur
+  name: pathogen-symptom-ambient-fungal-eye-blur
+  minStage: 3
+  interval: 48
+  intervalVariance: 0.2
+  effects:
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-ambient-fungal-eye-blur-visible
+  - !type:ModifyStatusEffect
+    effectProto: PathogenMildBlurStatusEffect
+    time: 1.5
+    type: Update
+
+# --- Emergent ---
+# Station-neglect symptoms create real medical and operational problems without becoming
+# antagonist-grade. Stage two is mechanically disruptive but deals no damage. Each stage
+# three pair combines one capped damage symptom with one dangerous gameplay interruption.
+# None of these alter transmission; spread stays tied to pathogen type.
+
+# Station Flu: stage two pool
+
+- type: pathogenSymptom
+  id: EmergentViralFeverChills
+  name: pathogen-symptom-emergent-viral-fever-chills
+  minStage: 2
+  interval: 80
+  effects:
+  - !type:Jitter
+    time: 4
+    amplitude: 5
+  - !type:MovementSpeedModifier
+    effectProto: PathogenEmergentSlowdownStatusEffect
+    walkSpeedModifier: 0.9
+    sprintSpeedModifier: 0.9
+    time: 4
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-viral-fever-chills-visible
+
+- type: pathogenSymptom
+  id: EmergentViralMuscleWeakness
+  name: pathogen-symptom-emergent-viral-muscle-weakness
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:MovementSpeedModifier
+    effectProto: PathogenEmergentSlowdownStatusEffect
+    walkSpeedModifier: 0.8
+    sprintSpeedModifier: 0.8
+    time: 4
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-viral-muscle-weakness-popup
+
+- type: pathogenSymptom
+  id: EmergentViralLightHeadedness
+  name: pathogen-symptom-emergent-viral-light-headedness
+  minStage: 2
+  interval: 95
+  effects:
+  - !type:ModifyStatusEffect
+    effectProto: StatusEffectWoozy
+    time: 4
+    type: Update
+  - !type:ModifyStatusEffect
+    effectProto: PathogenMildBlurStatusEffect
+    time: 4
+    type: Update
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-viral-light-headedness-popup
+
+# Station Flu: fixed stage three pair
+
+- type: pathogenSymptom
+  id: EmergentViralHighFever
+  name: pathogen-symptom-emergent-viral-high-fever
+  minStage: 3
+  interval: 120
+  intervalVariance: 0.2
+  effects:
+  - !type:PathogenCappedDamage
+    damageType: Heat
+    amount: 3
+    maximum: 15
+  - !type:ModifyStatusEffect
+    effectProto: PathogenMildBlurStatusEffect
+    time: 4
+    type: Update
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-viral-high-fever-popup
+
+- type: pathogenSymptom
+  id: EmergentViralFaintingSpell
+  name: pathogen-symptom-emergent-viral-fainting-spell
+  minStage: 3
+  interval: 130
+  intervalVariance: 0.2
+  effects:
+  - !type:ModifyKnockdown
+    time: 2
+    type: Update
+    drop: true
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-viral-fainting-spell-visible
+
+# Grey Lung: stage two pool
+
+- type: pathogenSymptom
+  id: EmergentBacterialCoughingFit
+  name: pathogen-symptom-emergent-bacterial-coughing-fit
+  minStage: 2
+  interval: 75
+  effects:
+  - !type:Emote
+    emote: Cough
+    showInChat: true
+    force: true
+  - !type:MovementSpeedModifier
+    effectProto: PathogenEmergentSlowdownStatusEffect
+    walkSpeedModifier: 0.7
+    sprintSpeedModifier: 0.7
+    time: 4
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-bacterial-coughing-fit-popup
+
+- type: pathogenSymptom
+  id: EmergentBacterialBreathlessness
+  name: pathogen-symptom-emergent-bacterial-breathlessness
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:Emote
+    emote: Gasp
+    showInChat: true
+    force: true
+  - !type:MovementSpeedModifier
+    effectProto: PathogenEmergentSlowdownStatusEffect
+    walkSpeedModifier: 1
+    sprintSpeedModifier: 0.5
+    time: 4
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-bacterial-breathlessness-popup
+
+- type: pathogenSymptom
+  id: EmergentBacterialSevereHoarseness
+  name: pathogen-symptom-emergent-bacterial-severe-hoarseness
+  minStage: 2
+  interval: 100
+  effects:
+  - !type:ModifyStatusEffect
+    effectProto: StatusEffectStutter
+    time: 4
+    type: Update
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-bacterial-severe-hoarseness-visible
+
+# Grey Lung: fixed stage three pair
+
+- type: pathogenSymptom
+  id: EmergentBacterialHypoxicAttack
+  name: pathogen-symptom-emergent-bacterial-hypoxic-attack
+  minStage: 3
+  interval: 120
+  intervalVariance: 0.2
+  effects:
+  - !type:PathogenCappedDamage
+    damageType: Asphyxiation
+    amount: 5
+    maximum: 20
+  - !type:ModifyStatusEffect
+    effectProto: PathogenMildBlurStatusEffect
+    time: 4
+    type: Update
+  - !type:Emote
+    emote: Gasp
+    showInChat: true
+    force: true
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-bacterial-hypoxic-attack-popup
+
+- type: pathogenSymptom
+  id: EmergentBacterialRespiratoryCollapse
+  name: pathogen-symptom-emergent-bacterial-respiratory-collapse
+  minStage: 3
+  interval: 130
+  intervalVariance: 0.2
+  effects:
+  - !type:Emote
+    emote: Gasp
+    showInChat: true
+    force: true
+  - !type:ModifyKnockdown
+    time: 3
+    type: Update
+    drop: true
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-bacterial-respiratory-collapse-visible
+
+# Mycosis: stage two pool
+
+- type: pathogenSymptom
+  id: EmergentFungalEyeInflammation
+  name: pathogen-symptom-emergent-fungal-eye-inflammation
+  minStage: 2
+  interval: 85
+  effects:
+  - !type:ModifyStatusEffect
+    effectProto: PathogenMildBlurStatusEffect
+    time: 4
+    type: Update
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-fungal-eye-inflammation-visible
+
+- type: pathogenSymptom
+  id: EmergentFungalCramps
+  name: pathogen-symptom-emergent-fungal-cramps
+  minStage: 2
+  interval: 90
+  effects:
+  - !type:Jitter
+    time: 2
+    amplitude: 7
+  - !type:MovementSpeedModifier
+    effectProto: PathogenEmergentSlowdownStatusEffect
+    walkSpeedModifier: 0.8
+    sprintSpeedModifier: 0.8
+    time: 2
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-fungal-cramps-popup
+
+- type: pathogenSymptom
+  id: EmergentFungalNumbFingers
+  name: pathogen-symptom-emergent-fungal-numb-fingers
+  minStage: 2
+  interval: 100
+  effects:
+  - !type:PathogenDropActiveItem
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-fungal-numb-fingers-popup
+
+# Mycosis: fixed stage three pair
+
+- type: pathogenSymptom
+  id: EmergentFungalToxicMycosis
+  name: pathogen-symptom-emergent-fungal-toxic-mycosis
+  minStage: 3
+  interval: 120
+  intervalVariance: 0.2
+  effects:
+  - !type:PathogenCappedDamage
+    damageType: Poison
+    amount: 3
+    maximum: 15
+  - !type:Vomit
+    probability: 0.25
+  - !type:PopupMessage
+    type: Local
+    messages:
+    - pathogen-symptom-emergent-fungal-toxic-mycosis-popup
+
+- type: pathogenSymptom
+  id: EmergentFungalOcularSporeFlare
+  name: pathogen-symptom-emergent-fungal-ocular-spore-flare
+  minStage: 3
+  interval: 130
+  intervalVariance: 0.2
+  effects:
+  - !type:ModifyStatusEffect
+    effectProto: StatusEffectTemporaryBlindness
+    time: 3
+    type: Update
+  - !type:PopupMessage
+    type: Pvs
+    messages:
+    - pathogen-symptom-emergent-fungal-ocular-spore-flare-visible

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -542,6 +542,9 @@
   id: OmniCyberEyes
 
 - type: Tag
+  id: OrganicTrash
+
+- type: Tag
   id: OvenMachineBoard
 
 - type: Tag
@@ -555,6 +558,9 @@
 
 - type: Tag
   id: PatchPack
+
+- type: Tag
+  id: PathogenRottenFood
 
 - type: Tag
   id: PersonnelStorage


### PR DESCRIPTION
## Short description
First part of a Virology system. This one adds the foundations only: pathogen data, symptoms, six archetypes, the infection lifecycle, station contamination measurement, and admin tooling.

There is no seeding and no transmission in this PR, so no crew member catches anything. Contamination  is only measured to test, but doesn't effect anything yet.

What is here:

- Pathogen types, tiers, components and prototypes
- 6 archetypes (3 ambient, 3 emergent) built from a symptom pool, rolled per round rather
  than authored, so a strain has to be diagnosed rather than memorised
- Infection lifecycle: incubation, stages, symptom expression, recovery, immunity
- Contamination measurement from rot, puddles, organic waste and dead plants
- Admin verbs (cure, immunise) and a `virology` commands
- `virotest` developer command for exercising the passive mechanics without waiting

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/c4801539-da8c-4db2-8f0c-3130445f496c

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Glaud
- add: Added the foundations of the virology system.

