### PR TITLE
Add specific Mime and Clown access and apply to their lockers and vends

### DIFF
--- a/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
@@ -23,6 +23,8 @@ id-card-access-level-brigmedic = Brigmedic
 id-card-access-level-cadet = Cadet
 
 # Service
+id-card-access-level-clown = Clown
+id-card-access-level-mime = Mime
 
 # Medical
 id-card-access-level-surgery = Surgery

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -42,6 +42,6 @@
   - Theatre
   - Chapel
   - Lawyer
-  - Clown
-  - Mime
+  - Clown # Starlight
+  - Mime # Starlight
   - Journalism # Goobstation

--- a/Resources/Prototypes/Access/service.yml
+++ b/Resources/Prototypes/Access/service.yml
@@ -42,4 +42,6 @@
   - Theatre
   - Chapel
   - Lawyer
+  - Clown
+  - Mime
   - Journalism # Goobstation

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -599,7 +599,7 @@
   components:
   - type: Appearance
   - type: AccessReader
-    access: [["Theatre"]]
+    access: [["Clown"]] # Starlight
   - type: EntityStorageVisuals
     stateBaseClosed: clown
     stateDoorOpen: clown_open
@@ -614,7 +614,7 @@
   components:
   - type: Appearance
   - type: AccessReader
-    access: [["Theatre"]]
+    access: [["Mime"]] # Starlight
   - type: EntityStorageVisuals
     stateBaseClosed: mime
     stateDoorOpen: mime_open

--- a/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/clown.yml
@@ -10,6 +10,7 @@
   - Theatre
   - Maintenance
   - Service # Starlight
+  - Clown # Starlight
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/mime.yml
@@ -13,6 +13,7 @@
   - Theatre
   - Maintenance
   - Service # Starlight
+  - Mime # Starlight
   special:
   - !type:AddComponentSpecial
     components:

--- a/Resources/Prototypes/_Starlight/Access/service.yml
+++ b/Resources/Prototypes/_Starlight/Access/service.yml
@@ -1,0 +1,7 @@
+- type: accessLevel
+  id: Clown
+  name: id-card-access-level-clown
+
+- type: accessLevel
+  id: Mime
+  name: id-card-access-level-mime

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/vending_machines.yml
@@ -168,7 +168,7 @@
   description: Get your honk fix here! Surprise the station with HohohonkersVend — the ultimate machine for hilarious pranks. Hack it, and you'll unlock something special!
   components:
   - type: AccessReader
-    access: [["Theatre"]]
+    access: [["Clown"]]
   - type: Store
     name: vendor-clown-dispenser
     categories:
@@ -185,7 +185,7 @@
   description: All the gear a mime could need. Go put the captain in an invisible box!
   components:
   - type: AccessReader
-    access: [["Theatre"]]
+    access: [["Mime"]]
   - type: Store
     name: vendor-mime-dispenser
     categories:


### PR DESCRIPTION
## Short description
This PR will add a new access role specific to both Mime and Clown. It also replaces the current access role of theatre on their respective vends/lockers. 

## Why we need to add this
These roles are quite prop-heavy, amd  over a shift it's common for the Clown/Mime to end up obtaining more items than they have inventory space for. At the moment, they have no safe place to store these items and lighten the load on their inventory space. The other issue is that their vends are currently open to all theatre roles, such as musician and performer. This enables them to purchase the aforementioned props, many of which are limited in quantity. This can end up being quite impactful on the Clown/Mime's enjoyment or shift experience. This PR will help both the issue of not having storage, and the issue of the shared vend access. Letting these roles have a safe place to store items or props for different points in the shift allows for some additional adaptability. At the same time, the Clown/Mime will no longer feel a need to rush to purchase the valuable items from their vend before someone else with the theatre role can walk in. 

## Media (Video/Screenshots)
Clown
<img width="481" height="294" alt="image" src="https://github.com/user-attachments/assets/ace559a9-02d7-4dca-bb1a-5dec0693ba6d" />
<img width="510" height="365" alt="image" src="https://github.com/user-attachments/assets/3015de53-9edd-40e1-83c5-537307f32ebe" />
<img width="472" height="274" alt="image" src="https://github.com/user-attachments/assets/c7643c15-c3e3-4280-aa59-fc9942adcd14" />

Mime
<img width="379" height="245" alt="image" src="https://github.com/user-attachments/assets/3dd83007-2ea0-4325-980a-56e952430a9f" />
<img width="452" height="342" alt="image" src="https://github.com/user-attachments/assets/0b4b0287-aaaa-4b68-a24f-b290f56abf97" />
<img width="452" height="261" alt="image" src="https://github.com/user-attachments/assets/035ea1d4-a20b-47f1-bfb8-62b5bd77e911" />

I do not have recording software installed so I have not captured footage of me testing, but the permissions work as expected. Each can open/operate their own machine, without being able to use the others. If this is a blocker, I can figure out how to download and setup some recording software, however I tried to be thorough with my screenshots. 
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Common
- add: Specific accesses added for Clown and Mime. 
- tweak: Change access on Clown Vend and Locker from theatre to Clown. 
- tweak: Change access on Mime Vend and Locker from theatre to Mime. 

<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
