### PR TITLE
Make the Standing Mic an Instrument

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Furniture/standing_mic.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Furniture/standing_mic.yml
@@ -28,6 +28,15 @@
         density: 100
         mask:
         - TableMask
+  - type: Instrument
+    program: 52
+  - type: SwappableInstrument
+    instrumentList:
+      "Aah": {52: 0}
+      "Ooh": {53: 0}
+      "Kweh": {4: 100} # Defined in space-station-14.sf2
+      "Waa": {5: 100} # Defined in space-station-14.sf2
+      "Wah": {6: 100} # Defined in space-station-14.sf2
   - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Metallic


### PR DESCRIPTION
## Short description
This PR makes the standing mic a playable instrument.

## Why we need to add this
It is usable in the same way the handheld microphone is. It should be usable as an instrument.

## Checks

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [ ] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Orhu
- tweak: The standing mic can now be used as an instrument.
