### PR TITLE
Door-Health-rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Airlocks/base_structureairlocks.yml
@@ -155,7 +155,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 300 #SL
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -34,7 +34,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 500
+          damage: 250
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Firelocks/firelock.yml
@@ -34,7 +34,7 @@
       thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 250
+          damage: 250 #SL
         behaviors:
         - !type:DoActsBehavior
           acts: ["Destruction"]

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -236,7 +236,7 @@
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 400
+        damage: 300
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Windoors/base_structurewindoors.yml
@@ -230,13 +230,13 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 600
+        damage: 500 #SL
       behaviors: #excess damage (nuke?). avoid computational cost of spawning entities.
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
     - trigger:
         !type:DamageTrigger
-        damage: 300
+        damage: 300 #SL
       behaviors:
       - !type:SpawnEntitiesBehavior
         spawn:

--- a/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/turnstile.yml
@@ -51,7 +51,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 150 #SL
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]


### PR DESCRIPTION
## Short description
Seeing that Turnstile has 500 HP for 3 Steel made me look at the code.
And having firelocks have 500 health aswell made me an bit confused.

so an SOLID STEEL WALL shouldnt have less health than turnstile.

## Why we need to add this

Rebalance of some structures which had just silly numbers.
Reference i took is that an solid wall has 200 HP before breaking into an girder.
And for Turnstile, it costs 3 Steel aint no way in hell that thing has more then 200.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: SirLutz
- tweak: Turnstile HP reduced from 500-> 150.
- tweak: Airlocks HP reduced from 500 -> 300.
- tweak: Firelocks HP reduced from 500 -> 250.
- tweak: Reinf. Windoors HP reduced from 400 -> 300.
