### PR TITLE
Changing carp damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -195,6 +195,10 @@
     - type: Flammable
       damage:
         types: {}
+    - type: MeleeWeapon
+      damage:
+        types:
+          Slash: 12
     - type: Damageable
       damageModifierSet: DragonCarpResistances
     - type: Prying

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -191,14 +191,13 @@
     - type: Temperature
     - type: TemperatureDamage
       heatDamageThreshold: 1200
-   #Starlight
-    - type: Flammable
+    - type: Flammable # Starlight Start
       damage:
         types: {}
     - type: MeleeWeapon
       damage:
         types:
-          Slash: 12
+          Slash: 12 # Starlight End
     - type: Damageable
       damageModifierSet: DragonCarpResistances
     - type: Prying


### PR DESCRIPTION
## Short description
Im proposing to merge all carp damage together, so instead of 7 slash and 5 blunt, it would be 12 slash total.

## Why we need to add this
This was to satisfy the suggestion for carps dealing structural damage and allowing them to break walls and stuff. Adding structural damage to the carp instead of doing this merging of damage would not suffice due to walls requiring around 20 structural to even be damaged, along with it being odd balancing considering mechs take structural. Merging the damages allows it to do damage to walls without changing much other balancing regarding carp. https://discord.com/channels/1272545509562777621/1538392038947422328

## Media (Video/Screenshots)
<img width="730" height="169" alt="image" src="https://github.com/user-attachments/assets/19d930fa-e12b-4528-9929-310e6be51587" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Changed the space dragons carp to do full slashing damage to allow them to break walls.
