### PR TITLE
Stir Stir No Shittery

### DIFF
--- a/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
@@ -130,7 +130,7 @@ ghost-role-information-kiki-name = Kiki
 ghost-role-information-kiki-description = An honorable member of the kobold society in charge of botany and helping the botanists in any way she can.
 
 ghost-role-information-stirstir-name = Stir Stir
-ghost-role-information-stirstir-description = A disreputable monkey who should not be trusted. A real cell stuffer.
+ghost-role-information-stirstir-description = A disreputable monkey who should not be trusted. A real cell stuffer. Check the Guidebook for more information.
 
 ghost-role-information-icesculpture-name = Ice sculpture
 ghost-role-information-icesculpture-description = A sculpture of ice given sentience by magic, obey your master!

--- a/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Starlight/guidebook/guides.ftl
@@ -92,6 +92,7 @@ guide-entry-sl-security-sop-enemy-of-corporation = Enemies of the Corporation
 guide-entry-sl-security-sop-hostage-situations = Hostage Situations
 
 guide-entry-rules-supernatural-entities = Supernatural Entities
+guide-entry-stirstir = Stir Stir
 
 guide-entry-sl-legal-sop-intro = Legal
 

--- a/Resources/Prototypes/Guidebook/security.yml
+++ b/Resources/Prototypes/Guidebook/security.yml
@@ -7,6 +7,7 @@
   - Defusal
   - CriminalRecords
   - SpaceLaw
+  - StirStir #SL Edit
 
 - type: guideEntry
   id: Forensics

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -126,6 +126,9 @@
     attributes:
       proper: true
       gender: male
+  - type: GuideHelp
+    guides:
+    - StirStir
 
 ## ADMIN MICE
 

--- a/Resources/Prototypes/_Starlight/Guidebook/security.yml
+++ b/Resources/Prototypes/_Starlight/Guidebook/security.yml
@@ -2,3 +2,8 @@
   id: SupernaturalEntities
   name: guide-entry-rules-supernatural-entities
   text: "/ServerInfo/Guidebook/ServerRules/SpaceLaw/SupernaturalEntities.xml"
+
+- type: guideEntry
+  id: StirStir
+  name: guide-entry-stirstir
+  text: "/ServerInfo/_Starlight/Guidebook/Mobs/StirStir.xml"

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Fun/prisoner.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Fun/prisoner.yml
@@ -16,9 +16,9 @@
   description: job-description-stirstir
   playTimeTracker: JobStirStir
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 0.25h
+    - !type:RoleTimeRequirement
+      role: JobSecurityOfficer
+      time: 7200 # 2 hrs
   startingGear: PrisonerGear
   setPreference: false
   icon: "JobIconPrisoner"

--- a/Resources/ServerInfo/Guidebook/Jobs.xml
+++ b/Resources/ServerInfo/Guidebook/Jobs.xml
@@ -9,7 +9,7 @@ SS14 has a large number of jobs, divided into seven major departments:
 It primarily functions as folks who entertain, clean, and serve the rest of the crew, with the exception of assistants who have no particular job beyond getting lost in maintenance.
 
 ## Cargo
-[color=#b18644]Cargo[/color] consists of the cargo technicians, salvage specialists, and the quartermaster. As a department, it responsible resource distribution and trade, capable of buying and selling things on the galactic market.
+[color=#b18644]Cargo[/color] consists of the cargo technicians, mail technicians, salvage specialists, mining specialists, and the quartermaster. As a department, it responsible resource distribution and trade, capable of buying and selling things on the galactic market.
 
 For the most part, this means they scrounge around the station and assorted wrecks to find materials to sell and redistribute, and purchase materials other departments request.
 
@@ -29,14 +29,19 @@ Scientists should seek out new artifacts to study, as well as solicit department
 Engineering is readily equipped to go safely into space, and as such they should always attempt to repair uninhabitable parts of the station.
 
 ## Security
-[color=#cb0000]Security[/color] consists of the security cadets, lawyers, detective, security officers, warden, and the head of security. As a department it is responsible for dealing with troublemakers and non-humanoid threats like giant rats and carp.
+[color=#cb0000]Security[/color] consists of the security cadets, security officers, brig medics, duty officers, detective, warden, and the head of security. As a department it is responsible for dealing with troublemakers and non-humanoid threats like giant rats and carp.
 
 As a result of this, and the need to walk a fine line, security sometimes is overwhelmed by angry crew (don't kill the clown), and it is important for its members to try and stay on their best behavior.
 
 ## Command
 [color=#1b67a5]Command[/color] consists of every department head. It is responsible for keeping the station and its departments running efficiently.
 
-Command members should always be relatively competent in their respective departments and attempt to delegate responsibility and direct work.
+Command members should always be relatively competent in their respective departments and attempt to delegate responsibility and direct work. You report directly to Central Command.
+
+## NanoTrasen
+[color=#478eff]NanoTrasen[/color] consists of the nanotrasen representative, magistrate, internal affairs agents, nanotrasen career trainers, and station ai. It is responsible for maintaining oversight and offering guidance to Command.
+
+While NanoTrasen owns the research stations the crew works on, they have been pulled away on more important business for over 50 years, leaving the manning and daily operations to a contractor known as Central Command. The job of NanoTrasen personnel on stations is to ensure they actually do their jobs, properly, and do not attempt to seize control for themselves.
 
 # Getting Your Job Changed
 The [color=#9fed58]Head of Personnel[/color] is the person in charge of changing ID accesses and handing out encryption keys. Head over to their office and let them know what job you'd like to work instead.

--- a/Resources/ServerInfo/Guidebook/Security/Security.xml
+++ b/Resources/ServerInfo/Guidebook/Security/Security.xml
@@ -5,7 +5,7 @@ Ensuring the safety of both station and crew is number one for [color=#cb0000]Se
 They face [textlink="Syndicate Agents" link="Traitors"], [textlink="Nuclear Operatives" link="NuclearOperatives"], [textlink="Zombies" link="Zombies"] and unruly staff.
 
 ## Personnel
-[color=#cb0000]Security[/color]'s staff is made up of Security Cadets, Security Officers, and the Detective. [color=#cb0000]Security[/color] is run by the Warden and Head of Security.
+[color=#cb0000]Security[/color]'s staff is made up of Security Cadets, Security Officers, Brig Medics, Duty Officers, and the Detective. [color=#cb0000]Security[/color] is run by the Warden and Head of Security.
 
   <Box>
     <GuideEntityEmbed Entity="ToyFigurineSecurity" Caption="Secoff"/>

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/StirStir.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/StirStir.xml
@@ -1,0 +1,23 @@
+<Document>
+  # Stir Stir
+
+  <Box>
+    <GuideEntityEmbed Entity="PosterContrabandWantedStirStir" Caption=""/>
+  </Box>
+
+  ## Who is Stir Stir?
+  Stir Stir is the more troublesome cousin of the slightly less disreputable Bar Monkey, [color=yellow]Pun Pun[/color]. Often called a cell stuffer, due to how frequently he finds himself behind bars. Despite everything, the charges never seem to stick for long.
+
+  Stir Stir can almost always be found locked up in [color=yellow]Genpop[/color] in [color=red]Security[/color] at the start of every shift.
+
+  ## Roleplaying As & With Stir Stir
+  Stir Stir might be behind bars, but he is [color=red]not an Antagonist[/color]. Leeway may be given by Staff for breakout attempts, but murder and constant griefing is not allowed. You require [color=yellow] 2 hours of Security Officer play time[/color] to play as Stir Stir for a reason, so you know how annoying it would be if you acted poorly.
+
+  The circumstances of Stir Stir's incarceration are intentionally ambiguous, and are left up to the Roleplayers to decide every round. Depending on what is decided as Stir Stir's crime, [color=red]Security[/color] can decide to allow [color=yellow]parole[/color] by involving the [color=yellow]Magistrate or Lawyers[/color] in the process for procedure and Roleplay.
+
+  ## Antagonists and Stir Stir
+  Stir Stir is designed as a Roleplay-first role for players, but like all Smart Monkeys and Kobolds, you can role [color=red]Antagonist Roles[/color] as him. Your objectives will be difficult as you start behind bars.
+
+  His imprisonment may also be to his benefit. Stir Stir has a spotty past and there are plenty of reasons for the [color=red]Syndicate[/color] to want him, dead or alive. Perhaps breaking out isn't always the best idea.
+
+</Document>


### PR DESCRIPTION
## Short description
Updates Stir Stir to reduce shittery. Stir Stir now has some guidance on how he should behave, and Security has some guidance on how to treat him. Stir Stir also now needs 2 hours of Security Officer playtime instead of 15 minutes of Security Department.
- Stir Stir is not an antagonist (unless he rolls an antag role), and should not be griefing or RDM'ing, though attempting to escape is allowed
- Stir Stir's crime is ambiguous on purpose, to allow Roleplayers to pick what it is each round
- Security can allow Stir Stir to go through the process and be pardoned for good behavior, preferably with the involvement of Lawyers and Magistrate for Roleplay

The Ghost Role description for Stir Stir directly points users to read the Guidebook, but examining Stir Stir and clicking the (?) icon will also open the page, and it is under the Security tab in the Guidebook to make it more likely Security players see it also.

Also updates a few random guidebook pages to include Starlight jobs. I noticed these issues while looking for where Stir Stir needed linked.

## Why we need to add this
The primary two complaints Stir Stir has raised are that Stir Stir is usually a shittery who makes Sec's life annoying, and that Security doesn't know what to do with them as they have no documented crime. This clears up the confusion by giving some framework to use both as Stir Stir and and Security to inform the Roleplay, and raising the bar to mitigate shittery. The idea being if someone has to actually play Security to unlock Stir Stir, they are maybe less likely to be a dickhead as Stir Stir because they know what it's like to be on the receiving end.

## Media (Video/Screenshots)
<img width="896" height="699" alt="image" src="https://github.com/user-attachments/assets/6e05f6b6-82b8-4859-8b6f-a81116eeec14" />

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added a Guidebook entry for Stir Stir adding more information on how to play as Stir Stir, interact with him as Security, and basic information to help RP as/with him. Their crime is vague on purpose, so RPers can decide in round. He can be paroled for good behavior, try to involve Lawyers and Magi, and he is NOT an Antag (unless he rolls an antag role).
- tweak: Changed Stir Stir's playtime requirement from 15 minutes of Security Department to 2 hours of Security Officer. Maybe people will hesitate to be a shitter as Stir Stir if they've been on the receiving end as a Secoff before.
