### PR TITLE
Electrolyzer Fix

### DIFF
--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerComponent.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerComponent.cs
@@ -12,7 +12,7 @@ public sealed partial class ElectrolyzerComponent : Component
     public float CurrentFuel { get; set; } = 0f;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)] /// Starlight: Changed value
-    public float PlasmaFuelConversion { get; set; } = 400000f;
+    public float PlasmaFuelConversion { get; set; } = 1000000f;
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public bool IsPowered { get; set; } = false;

--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -220,7 +220,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
             mixture.AdjustMoles(Gas.BZ, -BZRate);
             mixture.AdjustMoles(Gas.Oxygen, BZRate * 0.2f);
             mixture.AdjustMoles(Gas.Halon, BZRate * 2f);
-            var energyReleased = BZRate * Atmospherics.HalonProductionEnergy;
+            var energyReleased = BZRate * (Atmospherics.HalonProductionEnergy / heatScale);
 
             var newHeatCapacity = _atmosphereSystem.GetHeatCapacity(mixture, true);
             if (newHeatCapacity > Atmospherics.MinimumHeatCapacity)

--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -143,7 +143,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
                 }
 
                 var missingCharge = battery.MaxCharge - charge;
-                powerConsumer.DrawRate = Math.Min(50_000f, Math.Max(0f, missingCharge / args.dt));
+                powerConsumer.DrawRate = Math.Min(50_000f, Math.Max(0f, missingCharge));
                 _battery.ChangeCharge((uid, battery), powerConsumer.ReceivedPower * args.dt);
                 charge = _battery.GetCharge((uid, battery));
         }
@@ -175,8 +175,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
             }
         }
 
-
-        var rate = (charge/battery.MaxCharge) / args.dt;
+        var rate = (charge/battery.MaxCharge);
         var initH2O = mixture.GetMoles(Gas.WaterVapor);
         var initHyperNob = mixture.GetMoles(Gas.HyperNoblium);
         var initBZ = mixture.GetMoles(Gas.BZ);
@@ -186,11 +185,12 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
         var H2OLoad = 0; ///Starlight: Dummy values, load is now combined rather than highest wins.
         var HyperNobLoad = 0;
         var BZLoad = 0;
+        var heatScale = _atmosphereSystem.HeatScale;
 
         if (initH2O > 0.05f)
         {
             var temperatureEfficiency = Math.Min(mixture.Temperature / 1123.15f, 1f); ///Starlight: For some reason combustibles have variable oxy consumption? This keeps it balanced.
-            var h2oRate = Math.Min(Math.Min(2.5f * rate, initH2O / 2f), (2f * charge / electrolyzer.Efficiency)/Atmospherics.FireHydrogenEnergyReleased);
+            var h2oRate = Math.Min(Math.Min(2.5f * rate, initH2O / 2f), (2f * charge / electrolyzer.Efficiency)/(Atmospherics.FireHydrogenEnergyReleased / heatScale));
 
             var h2oRemoved = h2oRate * 2f;
             var oxyProduced = h2oRate * temperatureEfficiency;
@@ -200,7 +200,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
             mixture.AdjustMoles(Gas.Oxygen, oxyProduced);
             mixture.AdjustMoles(Gas.Hydrogen, hydrogenProduced);
 
-            H2OLoad = (int) (Atmospherics.FireHydrogenEnergyReleased * hydrogenProduced); ///Starlight: Load is determined by the energy made by re-igniting the hydrogen. Efficiency of device prevents free power.
+            H2OLoad = (int) ((Atmospherics.FireHydrogenEnergyReleased / heatScale) * hydrogenProduced); ///Starlight: Load is determined by the energy made by re-igniting the hydrogen. Efficiency of device prevents free power.
         }
 
         if (initHyperNob > 0.01f && temperature < 150f)
@@ -233,7 +233,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
         if (finalHeatCapacity > Atmospherics.MinimumHeatCapacity && finalHeatCapacity != oldHeatCapacity)
             mixture.Temperature = Math.Max(mixture.Temperature * oldHeatCapacity / finalHeatCapacity, Atmospherics.TCMB);
 
-        var powerUsed = (500f + H2OLoad + HyperNobLoad + BZLoad); ///Starlight: Gotta consume power
+        var powerUsed = (50f + H2OLoad + HyperNobLoad + BZLoad); ///Starlight: Gotta consume power
 
         var fuelMultiplier = 1f;
 
@@ -246,7 +246,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
 
         _battery.ChangeCharge((uid, battery),-powerUsed * fuelMultiplier / electrolyzer.Efficiency);
 
-        electrolyzer.CurrentFuel = Math.Max(0f, electrolyzer.CurrentFuel - powerUsed);
+        electrolyzer.CurrentFuel = Math.Max(0f, electrolyzer.CurrentFuel - (powerUsed * 0.01f));
 
         if (electrolyzer.Passive == true)
         {

--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -175,7 +175,7 @@ public sealed partial class ElectrolyzerSystem : EntitySystem
             }
         }
 
-        var rate = (charge/battery.MaxCharge);
+        var rate = (charge/battery.MaxCharge) * args.dt;
         var initH2O = mixture.GetMoles(Gas.WaterVapor);
         var initHyperNob = mixture.GetMoles(Gas.HyperNoblium);
         var initBZ = mixture.GetMoles(Gas.BZ);

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -121,7 +121,7 @@
     - SingularityTeslaEngine
   # Starlight-start
   - type: Electrolyzer
-    efficiency: .5
+    efficiency: .25
     passive: true
   - type: AtmosDevice
   # Starlight-end
@@ -228,7 +228,7 @@
   - type: TeslaCoil
     chargeFromLightning: 5000000
   - type: Electrolyzer
-    efficiency: 0.25
+    efficiency: 0.05
     passive: true
   - type: AtmosDevice
   # Starlight-end

--- a/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
+++ b/Resources/Prototypes/Entities/Structures/Power/Generation/Tesla/coil.yml
@@ -121,7 +121,7 @@
     - SingularityTeslaEngine
   # Starlight-start
   - type: Electrolyzer
-    efficiency: .25
+    efficiency: .10
     passive: true
   - type: AtmosDevice
   # Starlight-end
@@ -228,7 +228,7 @@
   - type: TeslaCoil
     chargeFromLightning: 5000000
   - type: Electrolyzer
-    efficiency: 0.05
+    efficiency: 0.01
     passive: true
   - type: AtmosDevice
   # Starlight-end


### PR DESCRIPTION
## Short description

Tweaks internal values of the electrolyzer that were set incorrectly with the previous update. Coil efficiency tweaks to offset heatscale changes. Plasma efficiency massively improved.

## Why we need to add this

Made water electrolysis excessively energy consuming due to failing to account for heatscale. 
Plasma sheets were made excessively weak due to the new logic used for calculating load.

## Media (Video/Screenshots)
<img width="921" height="572" alt="image" src="https://github.com/user-attachments/assets/dda95f3d-ed57-49c1-9d87-fe981aaa668d" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

Changelog

:cl: OJG
- tweak: Increased base electrolyzer fuel value of plasma sheets.
- tweak: Adjust electrolyzer values to ensure plasma sheets last long than 2 seconds.
- tweak: Lowered tesla-coil and grounding rod electrolyzing efficiency.
- fix: Made electrolyzer account for heatscale factor.