### PR TITLE
Reverts lighting changes from WizDen #44843

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -36,7 +36,7 @@
     energy: 0.8
     radius: 10
     softness: 1
-    offset: "0, 0.495"
+    offset: "0, -0.5" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -324,7 +324,7 @@
     enabled: false
   - type: PointLight
     enabled: false
-    offset: "0, 0.495"
+    offset: "0, -0.5" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
   - type: ContainerContainer
     containers:
       light_bulb: !type:ContainerSlot

--- a/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
+++ b/Resources/Prototypes/Entities/Structures/Lighting/base_lighting.yml
@@ -36,7 +36,7 @@
     energy: 0.8
     radius: 10
     softness: 1
-    offset: "0, -0.5" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
+    offset: "0, -0.495" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
   - type: Damageable
     damageContainer: Inorganic
     damageModifierSet: Metallic
@@ -324,7 +324,7 @@
     enabled: false
   - type: PointLight
     enabled: false
-    offset: "0, -0.5" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
+    offset: "0, -0.495" # Starlight - reverts Upstream #44843, which made wall mounted lights look extremely sharp
   - type: ContainerContainer
     containers:
       light_bulb: !type:ContainerSlot


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
https://github.com/space-wizards/space-station-14/pull/44843 changed the offset of `PointLight`s for all of the base lighting from `-0.5` to `0.495`, with the description stating that the light offsets were wrong.

That change made the origin point for lights physically correct (aligned with the sprites), but it hasn't left much consideration for how that change actually looks in-game. See the Media section for how much of a difference this offset makes for lighting.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
The change to the light offset makes for some _extremely_ sharp shadows around walls that just look wrong.

All of our maps are designed and lit around the old offset of `-0.5`. It's not unheard of video games to use physically incorrect offsets for lights in order to get something that looks "more correct". There's no bounce lighting in SS14, so a lot of areas that should be lit don't get lit - reverting the light offset helps alleviate that.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="1142" height="913" alt="image" src="https://github.com/user-attachments/assets/deb8aa1b-0c2b-4537-85eb-841e5d4a90ba" />

fig. 1 - (Upstream) Lighting. You can see the whole desk looks dark even though there's six lights here! Two of them are in positions that should light the desk, but don't.

<img width="1111" height="972" alt="space mall sample" src="https://github.com/user-attachments/assets/de2a4d05-e549-412b-ba47-2f941b1fb7b7" />

fig. 2 - Comparison of Upstream, Live (before upstream), and this PR's changes.

<img width="555" height="486" alt="space mall sample 2" src="https://github.com/user-attachments/assets/1afc0faa-7c86-4b27-927f-3dfc91e17b48" />

fig. 3 - Another comparison of Upstream, Live (before upstream), and this PR's changes. The end result is still a bit different because Upstream made diagonal walls occlude lights properly, which does look quite nice.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Fixed an issue where wall-mounted lights looked like they were 'cut off' by sharp corners - lighting should be approximately restored to how it was before.
