### PR TITLE
Make things that shouldn't roll antag not roll antag

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -1342,7 +1342,7 @@
 - type: entity
   name: genetic ancestor
   id: MobBaseAncestor
-  parent: [SimpleMobBase, StripableInventoryBase] # Starlight Edit: Removed BaseMobAnimal
+  parent: [SimpleMobBaseAntag, StripableInventoryBase] # Starlight Edit: Removed BaseMobAnimal + inherits Antag so they can roll antags
   description: The genetic bipedal ancestor of... Uh... Something. Yeah, there's definitely something on the station that descended from whatever this is.
   abstract: true
   components:
@@ -3118,7 +3118,7 @@
 
 - type: entity
   abstract: true
-  parent: [SimpleMobBase, StripableInventoryBase]
+  parent: [SimpleMobBaseAntag, StripableInventoryBase] # Starlight, so smart corgis can still roll antag
   id: MobCorgiBase
   name: corgi
   description: Finally, a space corgi!

--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -42,7 +42,7 @@
   - MobBloodstream
   - MobFlammable
   # - BaseMobAnimal # Starlight Edit: Reverted NuBody
-  id: SimpleSpaceMobBase # Mob without barotrauma, freezing and asphyxiation (for space carps!?)
+  id: SimpleSpaceMobBaseTemplate # Mob without barotrauma, freezing and asphyxiation (for space carps!?) + Starlight, changed to template so we can allow some things to roll antags
   suffix: AI
   components:
   - type: NpcFactionMember
@@ -74,7 +74,7 @@
   - MobRespirator
   - MobAtmosStandard
   - SimpleSpaceMobBase
-  id: SimpleMobBase # for air breathers
+  id: SimpleMobBaseTemplate # Starlight, changed so we can inherit this among antag-rolling and non-antag rolling animals
   suffix: AI
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -75,6 +75,7 @@
     enabled: false
   - type: ActiveInputMover # Starlight
   - type: Speech # Starlight, only adds speech bubble while typing
+  - type: AntagImmune # Starlight
 
 # proto for player ghosts specifically
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/simplemob.yml
@@ -1,0 +1,23 @@
+- type: entity
+  parent: SimpleMobBaseTemplate
+  id: SimpleMobBase
+  abstract: true
+  components:
+  - type: AntagImmune
+
+- type: entity
+  parent: SimpleMobBaseTemplate
+  id: SimpleMobBaseAntag
+  abstract: true
+
+- type: entity
+  parent: SimpleSpaceMobBaseTemplate
+  id: SimpleSpaceMobBase
+  abstract: true
+  components:
+  - type: AntagImmune
+
+- type: entity
+  parent: SimpleSpaceMobBaseTemplate
+  id: SimpleSpaceMobBaseAntag
+  abstract: true

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/terror_spiders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/terror_spiders.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: terror spider
-  parent: [ SimpleSpaceMobBase, MobRespirator ]
+  parent: [ SimpleSpaceMobBaseAntag, MobRespirator ]
   id: MobTerrorSpider
   description: a deadly hybrid of a giant spider and xenomorph.
   abstract: true


### PR DESCRIPTION
## Short description
No more mothroaches rolling antag.

## Why we need to add this
C'mon, really...

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Mobs that shouldn't roll antag will no longer roll antag.
