### PR TITLE
Fix vomiting to remove chemicals from stomach as intended

### DIFF
--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class VomitSystem : EntitySystem
         foreach (var stomach in stomachList)
         {
             if (_solutionContainer.ResolveSolution(stomach.Owner, StomachSystem.DefaultSolutionName, ref stomach.Comp1.Solution, out var sol))
-                _solutionContainer.TryTransferSolution(stomach.Comp1.Solution.Value, args.Sol, sol.AvailableVolume);
+                args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto);
         }
 
         args.Handled = true;

--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -71,7 +71,10 @@ public sealed partial class VomitSystem : EntitySystem
         foreach (var stomach in stomachList)
         {
             if (_solutionContainer.ResolveSolution(stomach.Owner, StomachSystem.DefaultSolutionName, ref stomach.Comp1.Solution, out var sol))
-                args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto);
+            {
+                // _solutionContainer.TryTransferSolution(stomach.Comp1.Solution.Value, args.Sol, sol.AvailableVolume); // Starlight
+                args.Sol.AddSolution(_solutionContainer.SplitSolution(stomach.Comp1.Solution.Value, sol.Volume), _proto); // Starlight
+            }
         }
 
         args.Handled = true;

--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -71,7 +71,7 @@ public sealed partial class VomitSystem : EntitySystem
         foreach (var stomach in stomachList)
         {
             if (_solutionContainer.ResolveSolution(stomach.Owner, StomachSystem.DefaultSolutionName, ref stomach.Comp1.Solution, out var sol))
-                // _solutionContainer.TryTransferSolution(stomach.Comp1.Solution.Value, args.Sol, sol.AvailableVolume); // Starlight
+                // args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto); // Starlight
                 args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto); // Starlight
         }
 

--- a/Content.Shared/Medical/VomitSystem.cs
+++ b/Content.Shared/Medical/VomitSystem.cs
@@ -71,7 +71,8 @@ public sealed partial class VomitSystem : EntitySystem
         foreach (var stomach in stomachList)
         {
             if (_solutionContainer.ResolveSolution(stomach.Owner, StomachSystem.DefaultSolutionName, ref stomach.Comp1.Solution, out var sol))
-                args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto);
+                // _solutionContainer.TryTransferSolution(stomach.Comp1.Solution.Value, args.Sol, sol.AvailableVolume); // Starlight
+                args.Sol.AddSolution(sol.SplitSolution(sol.Volume), _proto); // Starlight
         }
 
         args.Handled = true;


### PR DESCRIPTION
## Short description
Vomiting is intended to remove chemicals from the stomach, however this is not currently functional. It's unclear when this broke (it might've been from #5678).

## Why we need to add this
The most pressing reason this needs to be fixed is because without it ipecac is effectively useless as a medicine. #5678 changes how chemicals enter the bloodstream from the stomach, and as a result of these changes, if someone is poisoned via a pill (like a maints pill), the only way to remove the poison is to purge the stomach by inducing vomiting, which vomiting currently does not do even though it's supposed to empty the stomach.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A because it's hard to actually view this without being able to view the chemicals currently in the stomach, but this is functionality I've added to the health analyzer in another PR, and I can confirm that this works as intended.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: Rhapsody (Pepta Vismahl)
- fix: Fixed vomiting not removing chemicals from the player's stomach.