### PR TITLE
More dev fixes

### DIFF
--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -48,7 +48,9 @@
   - SalvageLead
   - Mail
   - Debrief
-  - Shuttle # Starlight end
+  - Shuttle
+  - Clown
+  - Mime # Starlight end
 
 
 - type: accessGroup

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3118,8 +3118,8 @@
 
 - type: entity
   abstract: true
-  parent: [SimpleMobBaseAntag, StripableInventoryBase] # Starlight, so smart corgis can still roll antag
-  id: MobCorgiBase
+  parent: [SimpleMobBase, StripableInventoryBase]
+  id: MobCorgiBaseTemplate # Starlight, to let smart corgis roll antag but not other corgi types
   name: corgi
   description: Finally, a space corgi!
   components:
@@ -4145,7 +4145,7 @@
         Base: reindeer_doe_dead
 
 - type: entity
-  parent: MobCorgiBase #starlight Nubody will not pass.
+  parent: MobCorgiBaseAntag # Starlight Nubody will not pass + allows them to be antags
   id: MobCorgiSmart
   name: smart corgi
   description: An unusually smart dog.

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3118,7 +3118,7 @@
 
 - type: entity
   abstract: true
-  parent: [SimpleMobBase, StripableInventoryBase]
+  parent: [SimpleMobBaseAntag, StripableInventoryBase] # Starlight, so they don't inherit antag immune
   id: MobCorgiBaseTemplate # Starlight, to let smart corgis roll antag but not other corgi types
   name: corgi
   description: Finally, a space corgi!

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -75,6 +75,7 @@
     enabled: false
   - type: ActiveInputMover # Starlight
   - type: Speech # Starlight, only adds speech bubble while typing
+  - type: AntagImmune # Starlight
 
 # proto for player ghosts specifically
 - type: entity
@@ -97,6 +98,7 @@
     uis:
       enum.RadarConsoleUiKey.Key:
         toggleAction: ActionObserverShowRadar # Starlight-end
+
 - type: entity
   parent: BaseMentalAction
   id: ActionGhostBoo

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/turret_controls.yml
@@ -139,6 +139,11 @@
     - Surgery
     - IAA
     - Mail
+    - Debrief
+    - Shuttle
+    - Journalism
+    - Clown
+    - Mime
     # Starlight end
   - type: DeviceList
     isAllowList: true

--- a/Resources/Prototypes/Roles/Antags/ninja.yml
+++ b/Resources/Prototypes/Roles/Antags/ninja.yml
@@ -66,7 +66,7 @@
     outerClothing: ClothingOuterSuitSpaceNinja
     shoes: ClothingShoesSpaceNinja
     id: NinjaPDA
-    ears: ClothingHeadsetAssistantNinja # Starlight
+    ears: ClothingHeadsetNinja
     pocket1: SpiderCharge
     pocket2: PinpointerStation
     belt: EnergyKatana

--- a/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/service_worker.yml
@@ -17,9 +17,11 @@
   - Kitchen
   - Hydroponics # Starlight
   extendedAccess:
-  - Theatre # Starlight
-  - Journalism # Starlight
-#  - Hydroponics # Starlight
+  - Theatre # Starlight start
+  - Journalism
+#  - Hydroponics
+  - Clown
+  - Mime # Starlight end
 
 - type: startingGear
   id: ServiceWorkerGear

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -54,15 +54,17 @@
   - Atmospherics
   - Medical
   - Journalism # Goobstation
-  - Robotics # Starlight
-  - Brigmedic # Starlight
-  - Surgery # Starlight
-  - Paramedic # Starlight
-  - Mining # Starlight
-  - SalvageLead # Starlight
-  - Mail # Starlight
-  - Debrief # Starlight
-  - Shuttle # Starlight
+  - Robotics # Starlight start
+  - Brigmedic
+  - Surgery
+  - Paramedic
+  - Mining
+  - SalvageLead
+  - Mail
+  - Debrief
+  - Shuttle
+  - Clown
+  - Mime # Starlight end
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -12,7 +12,9 @@
   access:
   - Service
   - Maintenance
-  - Journalism # Starlight
+  - Journalism # Starlight start
+  extendedAccess:
+  - Theatre # Starlight end
 
 - type: startingGear
   id: ReporterGear

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Crew/radiohost.yml
@@ -10,6 +10,8 @@
   - Maintenance
   - Journalism
   - Service
+  extendedAccess: # Starlight
+  - Theatre # Starlight
 
 - type: startingGear
   id: RadioHostGear

--- a/Resources/Prototypes/_Starlight/Access/misc.yml
+++ b/Resources/Prototypes/_Starlight/Access/misc.yml
@@ -37,6 +37,8 @@
     - Mail
     - Shuttle
     - Journalism
+    - Clown
+    - Mime
 
 - type: accessLevel
   id: Debug1

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/animals.yml
@@ -10,6 +10,7 @@
     - Dog
     - Canilunzt
     - GalacticCommon
+
 - type: entity
   parent: MobCorgiSmartNoGalcom
   id: MobCorgiSmartGhostrole

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/pets.yml
@@ -270,6 +270,7 @@
   - type: AutoImplant
     implants:
     - RedspaceImplant
+  - type: AntagImmune
 
 - type: entity
   parent: MobAdminMouse

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/simplemob.yml
@@ -21,3 +21,15 @@
   parent: SimpleSpaceMobBaseTemplate
   id: SimpleSpaceMobBaseAntag
   abstract: true
+
+- type: entity
+  parent: MobCorgiBaseTemplate
+  id: MobCorgiBase
+  abstract: true
+  components:
+  - type: AntagImmune
+
+- type: entity
+  parent: MobCorgiBaseTemplate
+  id: MobCorgiBaseAntag
+  abstract: true

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Civilian/performer.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Civilian/performer.yml
@@ -18,6 +18,9 @@
   - Bar
   - Kitchen
   - Hydroponics
+  - Journalism
+  - Clown
+  - Mime
 
 - type: startingGear
   id: PerformerGear

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/blueshield.yml
@@ -57,6 +57,8 @@
     - SalvageLead
     - Debrief
     - Journalism
+    - Clown
+    - Mime
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/nanotrasenrepresentative.yml
@@ -53,6 +53,8 @@
     - Paramedic
     - Debrief
     - Journalism
+    - Clown
+    - Mime
   special:
     - !type:AddImplantSpecial
       implants: [MindShieldImplant]


### PR DESCRIPTION
## Short description
Captain, HoP, BSO, NTR, and everyone in the various AllAccess groups now get Clown and Mime access. Some members of service get it on skeleton crew too.

Ninja now actually spawns with their headset.

Added Clown, Mime, and Journalism access to things that were missing it (mainly turret controls).

## Why we need to add this
Fixes are fixes.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Reporters and Radio Hosts now get Theatre access on skeleton crew.
- fix: Some members of Service will get Clown and Mime access on skeleton crew.
- fix: Non-smart Corgis, Admin/Mentor Mice, and ghosts will no longer roll antag.
- fix: Ninja now actually spawns with their headset.
- fix: Captain, HoP, BSO, NT Rep, and others in the all access group now have Clown and Mime access.
