### PR TITLE
(Hotel & Manor) Random Radio Spawns Added

### DIFF
--- a/Resources/Maps/_Starlight/Stations/Hotel.yml
+++ b/Resources/Maps/_Starlight/Stations/Hotel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 08/17/2026 14:16:46
-  entityCount: 22535
+  time: 08/19/2026 00:56:02
+  entityCount: 22548
 maps:
 - 1
 grids:
@@ -8129,7 +8129,7 @@ entities:
       pos: 8.5,6.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -263742.97
+      secondsUntilStateChange: -264502.1
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -9837,7 +9837,7 @@ entities:
       pos: 2.5,-7.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -225867.02
+      secondsUntilStateChange: -226626.14
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -10003,7 +10003,7 @@ entities:
       pos: -38.5,10.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -277918.44
+      secondsUntilStateChange: -278677.56
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -10019,7 +10019,7 @@ entities:
       pos: -36.5,-10.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -277817.5
+      secondsUntilStateChange: -278576.62
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -70289,11 +70289,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -12.42361,-15.404704
-  - uid: 11109
-    components:
-    - type: Transform
-      parent: 2
-      pos: 36.533817,-10.173307
 - proto: FoodBreadBaguette
   entities:
   - uid: 11110
@@ -115167,6 +115162,68 @@ entities:
     - type: Transform
       parent: 2
       pos: 13.5,22.5
+- proto: RandomSpawnStationRadioReceiver
+  entities:
+  - uid: 11109
+    components:
+    - type: Transform
+      parent: 2
+      pos: 54.5,11.5
+  - uid: 14926
+    components:
+    - type: Transform
+      parent: 2
+      pos: 16.5,-10.5
+  - uid: 22536
+    components:
+    - type: Transform
+      parent: 2
+      pos: -17.5,-17.5
+  - uid: 22537
+    components:
+    - type: Transform
+      parent: 2
+      pos: -9.5,7.5
+  - uid: 22538
+    components:
+    - type: Transform
+      parent: 2
+      pos: -15.5,14.5
+  - uid: 22540
+    components:
+    - type: Transform
+      parent: 2
+      pos: -23.5,-30.5
+  - uid: 22541
+    components:
+    - type: Transform
+      parent: 2
+      pos: 16.5,-44.5
+  - uid: 22542
+    components:
+    - type: Transform
+      parent: 2
+      pos: 44.5,-50.5
+  - uid: 22544
+    components:
+    - type: Transform
+      parent: 2
+      pos: -32.5,0.5
+  - uid: 22546
+    components:
+    - type: Transform
+      parent: 2
+      pos: -27.5,-3.5
+  - uid: 22547
+    components:
+    - type: Transform
+      parent: 2
+      pos: 45.5,-18.5
+  - uid: 22548
+    components:
+    - type: Transform
+      parent: 2
+      pos: 62.5,12.5
 - proto: RandomVending
   entities:
   - uid: 17459
@@ -122096,17 +122153,7 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: 54.5,11.5
-  - uid: 14926
-    components:
-    - type: Transform
-      parent: 2
-      pos: 16.5,-10.5
-  - uid: 17053
-    components:
-    - type: Transform
-      parent: 2
-      pos: -17.5,-17.5
+      pos: 36.5,-10.5
   - uid: 22457
     components:
     - type: Transform
@@ -123964,6 +124011,11 @@ entities:
       pos: -33.432343,16.572697
 - proto: Table
   entities:
+  - uid: 17053
+    components:
+    - type: Transform
+      parent: 2
+      pos: -9.5,7.5
   - uid: 18822
     components:
     - type: Transform
@@ -124539,6 +124591,11 @@ entities:
     - type: Transform
       parent: 2
       pos: 9.5,25.5
+  - uid: 22539
+    components:
+    - type: Transform
+      parent: 2
+      pos: -23.5,-30.5
 - proto: TableCarpet
   entities:
   - uid: 18933
@@ -124696,6 +124753,16 @@ entities:
       parent: 2
       rot: 1.5707963267948966 rad
       pos: -4.5,-31.5
+  - uid: 22543
+    components:
+    - type: Transform
+      parent: 2
+      pos: -32.5,0.5
+  - uid: 22545
+    components:
+    - type: Transform
+      parent: 2
+      pos: -27.5,-3.5
 - proto: TablePlasmaGlass
   entities:
   - uid: 18962

--- a/Resources/Maps/_Starlight/Stations/Manor.yml
+++ b/Resources/Maps/_Starlight/Stations/Manor.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: 283.0.0
+  engineVersion: 288.0.1
   forkId: ""
   forkVersion: ""
-  time: 08/11/2026 14:56:37
-  entityCount: 35296
+  time: 08/19/2026 01:39:24
+  entityCount: 35312
 maps:
 - 1
 grids:
@@ -127,6 +127,8 @@ entities:
     - type: GridTree
     - type: Broadphase
     - type: OccluderTree
+    - type: ChunkContainer
+      chunkEntities: []
   - uid: 2
     components:
     - type: MetaData
@@ -10934,6 +10936,10 @@ entities:
       id: StarlightManor
     - type: ImplicitRoof
     - type: ExplosionAirtightGrid
+    - type: ChunkContainer
+      chunkEntities: []
+    - type: TileHistory
+      chunkHistory: {}
   - uid: 5
     components:
     - type: MetaData
@@ -12944,7 +12950,7 @@ entities:
       pos: 1.5,-2.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -188594.61
+      secondsUntilStateChange: -189852.62
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -13077,7 +13083,7 @@ entities:
       pos: -52.5,58.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -215366.58
+      secondsUntilStateChange: -216624.6
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -15243,7 +15249,7 @@ entities:
       pos: 18.5,53.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -389255.62
+      secondsUntilStateChange: -390513.66
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -15782,7 +15788,7 @@ entities:
       pos: -61.5,49.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -245126.44
+      secondsUntilStateChange: -246384.45
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
@@ -76243,33 +76249,28 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,49.5
+      pos: -5.5,50.5
   - uid: 12379
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,51.5
+      pos: -4.5,49.5
   - uid: 12380
     components:
     - type: Transform
       parent: 2
-      pos: -4.5,49.5
+      pos: -5.5,52.5
   - uid: 12381
     components:
     - type: Transform
       parent: 2
-      pos: -4.5,49.5
+      pos: -5.5,49.5
   - uid: 12382
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,50.5
-  - uid: 12383
-    components:
-    - type: Transform
-      parent: 2
       pos: -4.5,50.5
-  - uid: 12384
+  - uid: 12383
     components:
     - type: Transform
       parent: 2
@@ -76278,12 +76279,12 @@ entities:
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,48.5
+      pos: -5.5,51.5
   - uid: 12386
     components:
     - type: Transform
       parent: 2
-      pos: -5.5,52.5
+      pos: -5.5,48.5
   - uid: 12387
     components:
     - type: Transform
@@ -104494,7 +104495,7 @@ entities:
       pos: -71.5,55.5
     - type: Door
       state: Opening
-      secondsUntilStateChange: -79841.836
+      secondsUntilStateChange: -81099.85
   - uid: 17218
     components:
     - type: Transform
@@ -106680,7 +106681,7 @@ entities:
       pos: 66.5,41.5
     - type: Door
       state: Closing
-      secondsUntilStateChange: -142018.02
+      secondsUntilStateChange: -143276.03
     - type: Firelock
       emergencyCloseCooldown: 11124.3888776
   - uid: 17415
@@ -108170,7 +108171,7 @@ entities:
       pos: -27.5,81.5
     - type: Door
       state: Closing
-      secondsUntilStateChange: -130128.01
+      secondsUntilStateChange: -131386.03
   - uid: 17628
     components:
     - type: Transform
@@ -111126,16 +111127,6 @@ entities:
     - type: Transform
       parent: 2
       pos: -45.47355,23.69711
-  - uid: 18027
-    components:
-    - type: Transform
-      parent: 2
-      pos: -30.647339,-25.508987
-  - uid: 18028
-    components:
-    - type: Transform
-      parent: 2
-      pos: -30.647339,-25.227737
   - uid: 18029
     components:
     - type: Transform
@@ -178588,6 +178579,78 @@ entities:
       parent: 2
       rot: -1.5707963267948966 rad
       pos: -5.5,15.5
+- proto: RandomSpawnStationRadioReceiver
+  entities:
+  - uid: 12384
+    components:
+    - type: Transform
+      parent: 2
+      pos: 19.5,69.5
+  - uid: 18028
+    components:
+    - type: Transform
+      parent: 2
+      pos: -30.5,-25.5
+  - uid: 35297
+    components:
+    - type: Transform
+      parent: 2
+      pos: 29.5,1.5
+  - uid: 35298
+    components:
+    - type: Transform
+      parent: 2
+      pos: 47.5,21.5
+  - uid: 35299
+    components:
+    - type: Transform
+      parent: 2
+      pos: 32.5,63.5
+  - uid: 35300
+    components:
+    - type: Transform
+      parent: 2
+      pos: -24.5,66.5
+  - uid: 35302
+    components:
+    - type: Transform
+      parent: 2
+      pos: -29.5,30.5
+  - uid: 35303
+    components:
+    - type: Transform
+      parent: 2
+      pos: -59.5,26.5
+  - uid: 35304
+    components:
+    - type: Transform
+      parent: 2
+      pos: -83.5,52.5
+  - uid: 35306
+    components:
+    - type: Transform
+      parent: 2
+      pos: -17.5,-18.5
+  - uid: 35307
+    components:
+    - type: Transform
+      parent: 2
+      pos: -21.5,-2.5
+  - uid: 35308
+    components:
+    - type: Transform
+      parent: 2
+      pos: -42.5,59.5
+  - uid: 35310
+    components:
+    - type: Transform
+      parent: 2
+      pos: -29.5,73.5
+  - uid: 35312
+    components:
+    - type: Transform
+      parent: 2
+      pos: 11.5,27.5
 - proto: RandomVendingDrinks
   entities:
   - uid: 27725
@@ -188056,6 +188119,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -6.5,17.5
+  - uid: 35301
+    components:
+    - type: Transform
+      parent: 2
+      pos: -37.5,49.5
 - proto: StationRadioRig
   entities:
   - uid: 25282
@@ -190579,6 +190647,11 @@ entities:
       pos: 41.98885,68.59696
 - proto: Table
   entities:
+  - uid: 18027
+    components:
+    - type: Transform
+      parent: 2
+      pos: -17.5,-18.5
   - uid: 29602
     components:
     - type: Transform
@@ -191209,6 +191282,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -70.5,66.5
+  - uid: 35305
+    components:
+    - type: Transform
+      parent: 2
+      pos: -23.5,-18.5
 - proto: TableCarpet
   entities:
   - uid: 29727
@@ -192650,6 +192728,12 @@ entities:
     - type: Transform
       parent: 2
       pos: -107.5,48.5
+  - uid: 35309
+    components:
+    - type: Transform
+      parent: 2
+      rot: 1.5707963267948966 rad
+      pos: -29.5,73.5
 - proto: TableReinforcedGlass
   entities:
   - uid: 29994
@@ -193689,6 +193773,11 @@ entities:
     - type: Transform
       parent: 2
       pos: -86.5,69.5
+  - uid: 35311
+    components:
+    - type: Transform
+      parent: 2
+      pos: 11.5,27.5
 - proto: TapeDeck
   entities:
   - uid: 29618


### PR DESCRIPTION
## Short description
Quick addition of the Random Radio Spawners I made in #5705

Almost every department has atleast 1 or 2 spots where a radio can end up spawning, at a 45% chance rate.
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Same reasoning as in #5705 , Less linear radio placement in spots.
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<img width="4640" height="4576" alt="Hotel-0" src="https://github.com/user-attachments/assets/43861fff-37c5-4239-bd65-de15d2465f54" />
<img width="7232" height="4864" alt="Manor-0" src="https://github.com/user-attachments/assets/4a3a8781-6323-49c0-816c-2bae1cf9235b" />

<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Way
- add: (Hotel) Added random station radio spawners.
- add: (Hotel) One radio in GenPop, not random.
- add: (Manor) Added random station radio spawners.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
