### PR TITLE
Fixes wildcard routing for disposals

### DIFF
--- a/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
+++ b/Content.Shared/Disposal/Holder/SharedDisposalHolderSystem.cs
@@ -33,7 +33,7 @@ public abstract partial class SharedDisposalHolderSystem : EntitySystem
     /// <summary>
     /// Allowed characters for tagging disposed entities.
     /// </summary>
-    public static readonly Regex TagRegex = new("^[a-zA-Z0-9, ]*$", RegexOptions.Compiled);
+    public static readonly Regex TagRegex = new("^[a-zA-Z0-9,* ]*$", RegexOptions.Compiled); // Starlight - add * for wildcards
     private const float DestinationEpsilon = 1e-3f; // Starlight
 
     public override void Initialize()

--- a/Content.Shared/Disposal/Router/DisposalRouterSystem.cs
+++ b/Content.Shared/Disposal/Router/DisposalRouterSystem.cs
@@ -40,7 +40,9 @@ public sealed partial class DisposalRouterSystem : EntitySystem
 
         var exits = _disposalTube.GetTubeConnectableDirections((ent, disposalTube));
 
-        if (exits.Length < 3 || _disposalHolder.TagsOverlap(args.Holder, ent.Comp.Tags) || ent.Comp.Tags.Contains("*")) // Starlight, wildcard support
+        if (exits.Length < 3
+            || _disposalHolder.TagsOverlap(args.Holder, ent.Comp.Tags)
+            || (ent.Comp.Tags.Contains("*") && args.Holder.Comp.Tags.Count > 0)) // Starlight, wildcard support
         {
             _disposalTube.SelectNextDirection((ent, disposalTube), exits, ref args);
             return;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
During my port of #5021, I screwed up when re-implementing wildcard routing. Currently on live, _everything_ will route through the side-exit of wildcard routers (even if it has zero tags), which breaks a bunch of mailing and disposal systems (namely on Oasis and Leth).

This PR fixes that.

Also, I didn't expand the regex used to limit input into disposal taggers/routers UI box, so you couldn't actually type `*` into the router yourself (whoops). This PR also fixes that.

## Long description
I hate describing disposal router issues with words alone so we're going to bravely hold hands and observe some Caws Academy diagrams.

This is a basic router set up.

<img width="1249" height="721" alt="image" src="https://github.com/user-attachments/assets/3959b858-97f9-4709-960e-2dfdf17721a7" />

We have:
- A bin on the left (either a disposal unit or mailing unit)
- A router in the middle (this one has its tag set to `*`
- And some disposal pipes

Let's pretend that the bin on the left is a `MailingUnitBar`. This mailing unit will add the `Bar` tag to the `DisposalHolder` container for items we stick in it. We'll pretend that the Bar is sending someone a jug of Berry juice for some reason.

<img width="1192" height="672" alt="image" src="https://github.com/user-attachments/assets/8651692f-d6c8-4979-a6a9-c0132b0ac8bf" />

When we send the item down the tubes:
- the `DisposalHolder` gets the tag `Bar` from `MailingUnitBar`
- the Router will see that this item has a tag `Bar` and go "ok you should go to my side exit"
- overall everything works as expected

<img width="1015" height="794" alt="image" src="https://github.com/user-attachments/assets/db851f8f-40c1-4443-9801-a2a3686a82ab" />

The problem is this snippet of code, though.

```csharp
if (exits.Length < 3 || _disposalHolder.TagsOverlap(args.Holder, ent.Comp.Tags) || ent.Comp.Tags.Contains("*")) // Starlight, wildcard support
```

Ignore the exits bit, it's not relevant. This code is going:
- do you have any tags that overlap with the router's tag
- **OR** does this router have the wildcard `*` symbol

It didn't check if the item actually had any tags. This means that literally anything will pass the second check on a wildcard router, making it useless. Nothing can pass straight-thru the router because everything will pass its condition to exit out its side exit.

<img width="932" height="762" alt="image" src="https://github.com/user-attachments/assets/264acd9f-3100-4abe-a506-ad3fcb975d88" />

This PR fixes that by adding a check that the item has at least one tag.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Some maps like Oasis and Leth rely on wildcard routers to separate out garbage (which has no tags) out from mail (which does have tags).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="637" height="664" alt="image" src="https://github.com/user-attachments/assets/58e21bb1-ff17-46fc-98b4-52bda2a34e60" />

fig. 1 - (BEFORE PR) Test set up. The disposal units applies no tags and should pass straight-thru the wildcard router. The mailing unit applies a tag and should route through the side exit of the router. You can see this set up fails and the disposal unit's item passes through the side exit of the wildcard router (guh).

<img width="651" height="675" alt="image" src="https://github.com/user-attachments/assets/b396a1c9-9cea-476a-ae9b-45756ee251bd" />

fig. 2 - (AFTER PR) Test set up. Same as above, but you can see that the disposal unit went straight-thru the wildcard router as expected.


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- fix: Taggers and disposal routers no longer prevent you from typing the wildcard character * into them.
- fix: Fixed an issue with wildcard routers which made it impossible for items to go straight-thru them. This should resolve mailing and disposal issues on maps like Oasis and Leth.