### PR TITLE
Allow borgs to pick up music discs

### DIFF
--- a/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/borg_modules.ftl
@@ -18,3 +18,4 @@ borg-slot-knives-empty = Knives
 borg-slot-pkaupgrade-empty = PKA Upgrades
 borg-slot-goliath-empty = Goliath Plates
 borg-slot-rollerbeds-empty = Body Bags and RollerBeds
+borg-slot-music-media-empty = Vinyls and CDs

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1300,6 +1300,16 @@
         whitelist:
           components:
           - Instrument
+    # Starlight start
+    - hand:
+        emptyLabel: borg-slot-music-media-empty
+        emptyRepresentative: VinylAirportLounge
+        whitelist:
+          tags:
+          - VinylSleeveFit
+          - VinylSleeve
+          - CD
+    # Starlight end
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: musical-module }
 


### PR DESCRIPTION
## Short description
Allow borgs to pick up music discs

## Why we need to add this
DJ borgster in the house

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

https://github.com/user-attachments/assets/0edb2172-ce65-4269-a4df-7ee35a3fde68



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- add: Service borgs now have a Vinyl and CD slot.