### PR TITLE
Add artist credits to music vinyl descriptions

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
@@ -165,6 +165,12 @@
   name: "vinyl: Space Jazz"
   description: A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod #SL  Addition
   components:
+  - type: Sprite
+    state: default
+    layers:
+    - state: default
+    - state: label
+      color: "#67659e"
   - type: Vinyl
     song:
       path: /Audio/_Goobstation/RadioStation/Vinyls/music/KevinMacleod/SpaceJazz.ogg

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
@@ -3,7 +3,7 @@
   parent: BaseVinylDisc
   id: VinylAirportLounge
   name: "vinyl: Airport Lounge"
-  description: A long, relaxing song reminiscent of elevator music.
+  description: A long, relaxing song reminiscent of elevator music. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -19,7 +19,7 @@
   parent: BaseVinylDisc
   id: VinylBoogiePart
   name: "vinyl: Boogie Part"
-  description: A funky jazz song that makes you want to boogie.
+  description: A funky jazz song that makes you want to boogie. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -35,7 +35,7 @@
   parent: BaseVinylDisc
   id: VinylBurnTheWorldWaltz
   name: "vinyl: Burn The World Waltz"
-  description: Heavy metal and brimstone.
+  description: Heavy metal and brimstone. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -51,7 +51,7 @@
   parent: BaseVinylDisc
   id: VinylCorncob
   name: "vinyl: Corncob"
-  description: A fast pace country tune.
+  description: A fast pace country tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -67,7 +67,7 @@
   parent: BaseVinylDisc
   id: VinylDeadlyRoulette
   name: "vinyl: Deadly Roulette"
-  description: A slow pace basey tune.
+  description: A slow pace basey tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -83,7 +83,7 @@
   parent: BaseVinylDisc
   id: VinylFeralAngelWaltz
   name: "vinyl: Feral Angel Waltz"
-  description: A slow pace rock waltz.
+  description: A slow pace rock waltz. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -99,7 +99,7 @@
   parent: BaseVinylDisc
   id: VinylJingleBells
   name: "vinyl: Jingle Bells"
-  description: The classic festive tune.
+  description: The classic festive tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -115,7 +115,7 @@
   parent: BaseVinylDisc
   id: VinylLateNightRadio
   name: "vinyl: Late Night Radio"
-  description: A slow pace jazzy tune.
+  description: A slow pace jazzy tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -131,7 +131,7 @@
   parent: BaseVinylDisc
   id: VinylMesmerizingGalaxyLoop
   name: "vinyl: Mesmerizing Galaxy Loop"
-  description: A hypnotic eletronic tune.
+  description: A hypnotic eletronic tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -147,7 +147,7 @@
   parent: BaseVinylDisc
   id: VinylNightInVenice
   name: "vinyl: Night In Venice"
-  description: A slow pace jazzy tune with a romantic vibe.
+  description: A slow pace jazzy tune with a romantic vibe. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -163,7 +163,7 @@
   parent: BaseVinylAI
   id: VinylSpaceJazz
   name: "vinyl: Space Jazz"
-  description: A slow pace jazzy tune reminiscent of elevator music.
+  description: A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -173,7 +173,7 @@
   parent: BaseVinylDisc
   id: VinylVibingOverVenus
   name: "vinyl: Vibing Over Venus"
-  description: A slow pace jazzy tune.
+  description: A slow pace jazzy tune. By: Kevin MacLeod #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -191,7 +191,7 @@
   parent: BaseVinylDisc
   id: VinylChristmasSong
   name: "vinyl: Christmas Song"
-  description: A festive tune about giving your heart away to someone special.
+  description: A festive tune about giving your heart away to someone special. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -209,7 +209,7 @@
   parent: BaseVinylDisc
   id: VinylAlsoSprachZarathustra
   name: "vinyl: Also Sprach Zarathustra"
-  description: A classical piece that slowly builds to an climactic crescendo.
+  description: A classical piece that slowly builds to an climactic crescendo. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -225,7 +225,7 @@
   parent: BaseVinylDisc
   id: VinylRussianDance
   name: "vinyl: Russian Dance"
-  description: A classical piece with a fast pace and a lively rhythm.
+  description: A classical piece with a fast pace and a lively rhythm. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -241,7 +241,7 @@
   parent: BaseVinylDisc
   id: VinylTheFlowerDuet
   name: "vinyl: The Flower Duet"
-  description: A classical opera duet.
+  description: A classical opera duet. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -257,7 +257,7 @@
   parent: BaseVinylDisc
   id: VinylWinterVivaldi
   name: "vinyl: Vivaldi's Winter"
-  description: A classical tune from Vivaldi, representing the winter season.
+  description: A classical tune from Vivaldi, representing the winter season. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -273,7 +273,7 @@
   parent: BaseVinylDisc
   id: VinylCelloSuite
   name: "vinyl: Cello Suite"
-  description: A classical cello solo.
+  description: A classical cello solo. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -289,7 +289,7 @@
   parent: BaseVinylDisc
   id: VinylRideOfTheValkyries
   name: "vinyl: Ride Of The Valkyries"
-  description: A classical piece best paired with the charging of cavalry.
+  description: A classical piece best paired with the charging of cavalry. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -305,7 +305,7 @@
   parent: BaseVinylDisc
   id: VinylRomeoAndJuliet
   name: "vinyl: Romeo And Juliet"
-  description: A classical romantic piece.
+  description: A classical romantic piece. By: PM Music #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -323,7 +323,7 @@
   parent: BaseVinylDevil
   id: VinylMaxi
   name: "vinyl: Maxi"
-  description: An exciting rock/metal song.
+  description: An exciting rock/metal song. By: Goonstation #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -333,7 +333,7 @@
   parent: BaseVinylDevil
   id: VinylXtra
   name: "vinyl: Xtra"
-  description: An exciting rock/metal song.
+  description: An exciting rock/metal song. By: Goonstation #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -343,7 +343,7 @@
   parent: BaseVinylDevil
   id: VinylGiga
   name: "vinyl: Giga"
-  description: An exciting rock/metal song.
+  description: An exciting rock/metal song. By: Goonstation #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -353,7 +353,7 @@
   parent: BaseVinylDisc
   id: VinylEveryoneIsSoAlive
   name: "vinyl: Everyone Is So Alive"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -369,7 +369,7 @@
   parent: BaseVinylDisc
   id: VinylHighTechnologicBeat
   name: "vinyl: High Technologic Beat"
-  description: A fast pace electronic dance beat.
+  description: A fast pace electronic dance beat. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -385,7 +385,7 @@
   parent: BaseVinylDisc
   id: VinylAfterParty
   name: "vinyl: After Party"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -401,7 +401,7 @@
   parent: BaseVinylDisc
   id: VinylItFeelsGoodToBeAliveToo
   name: "vinyl: It Feels Good To Be Alive Too"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -417,7 +417,7 @@
   parent: BaseVinylDisc
   id: VinylFunkadelic
   name: "vinyl: Funkadelic"
-  description: A slow pace funky electronic tune.
+  description: A slow pace funky electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -433,7 +433,7 @@
   parent: BaseVinylDisc
   id: VinylLunch
   name: "vinyl: Lunch"
-  description: A fast pace groovy electronic tune.
+  description: A fast pace groovy electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -449,7 +449,7 @@
   parent: BaseVinylDisc
   id: VinylGroovy
   name: "vinyl: Groovy"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -468,7 +468,7 @@
   parent: BaseVinylDisc
   id: VinylAnonymous
   name: "vinyl: Anonymous"
-  description: A fast pace hypnotic electronic tune.
+  description: A fast pace hypnotic electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -487,7 +487,7 @@
   parent: BaseVinylDisc
   id: VinylDistantStar
   name: "vinyl: Distant Star"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -506,7 +506,7 @@
   parent: BaseVinylDisc
   id: VinylEphedrineOverdose
   name: "vinyl: Ephedrine Overdose"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -522,7 +522,7 @@
   parent: BaseVinylDisc
   id: VinylGetThatAntag
   name: "vinyl: Get That Antag!"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -538,7 +538,7 @@
   parent: BaseVinylDisc
   id: VinylGreytideSong
   name: "vinyl: Greytide Song"
-  description: A hip tune by DJ Tider.
+  description: A hip tune by DJ Tider. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -554,7 +554,7 @@
   parent: BaseVinylDisc
   id: VinylNukiesTrap
   name: "vinyl: Nukies Trap Remix"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -570,7 +570,7 @@
   parent: BaseVinylDisc
   id: VinylRunningOut
   name: "vinyl: Running Out"
-  description: A dramatic fast pace electronic tune.
+  description: A dramatic fast pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -586,7 +586,7 @@
   parent: BaseVinylDisc
   id: VinylSponsoredBySyndicate
   name: "vinyl: Sponsored By Syndicate"
-  description: A fast pace rock tune.
+  description: A fast pace rock tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -602,7 +602,7 @@
   parent: BaseVinylDisc
   id: VinylTraitorousIntent
   name: "vinyl: Traitorous Intent"
-  description: A eerie low pace electronic tune.
+  description: A eerie low pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -618,7 +618,7 @@
   parent: BaseVinylDisc
   id: VinylViolet
   name: "vinyl: Violet"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -638,7 +638,7 @@
   parent: BaseVinylDisc
   id: VinylWaystations
   name: "vinyl: Waystations"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -654,7 +654,7 @@
   parent: BaseVinylDisc
   id: VinylUpbeatOne
   name: "vinyl: Upbeat 1"
-  description: A groovy upbeat tune.
+  description: A groovy upbeat tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -670,7 +670,7 @@
   parent: BaseVinylDisc
   id: VinylUpbeatTwo
   name: "vinyl: Upbeat 2"
-  description: A groovy upbeat tune.
+  description: A groovy upbeat tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -686,7 +686,7 @@
   parent: BaseVinylDisc
   id: VinylPlanets
   name: "vinyl: Planets"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -702,7 +702,7 @@
   parent: BaseVinylDisc
   id: VinylChillOne
   name: "vinyl: Chill 1"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -718,7 +718,7 @@
   parent: BaseVinylDisc
   id: VinylChillTwo
   name: "vinyl: Chill 2"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -734,7 +734,7 @@
   parent: BaseVinylDisc
   id: VinylChillThree
   name: "vinyl: Chill 3"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -750,7 +750,7 @@
   parent: BaseVinylDisc
   id: VinylChillFour
   name: "vinyl: Chill 4"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -766,7 +766,7 @@
   parent: BaseVinylDisc
   id: VinylBeaches
   name: "vinyl: Beaches"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: aquariofury, Not Tom  #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -782,7 +782,7 @@
   parent: BaseVinylDisc
   id: VinylDanceOnASpaceVolcano
   name: "vinyl: Dance On A Space Volcano"
-  description: A funky fast pace electronic dance tune.
+  description: A funky fast pace electronic dance tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -798,7 +798,7 @@
   parent: BaseVinylFloaty
   id: VinylFloaty
   name: "vinyl: Floaty"
-  description: A slow pace hypnotic tune.
+  description: A slow pace hypnotic tune. By: aquariofury, Not Tom #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -808,7 +808,7 @@
   parent: BaseVinylDisc
   id: VinylGraveyard
   name: "vinyl: Graveyard"
-  description: A slow pace eerie tune.
+  description: A slow pace eerie tune. By: aquariofury, Not Tom #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -824,7 +824,7 @@
   parent: BaseVinylDisc
   id: VinylRiverdancer
   name: "vinyl: Riverdancer"
-  description: A slow pace funky electronic tune.
+  description: A slow pace funky electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -840,7 +840,7 @@
   parent: BaseVinylDisc
   id: VinylSpaceGardener
   name: "vinyl: Space Gardener"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: tamakari #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -856,7 +856,7 @@
   parent: BaseVinylDisc
   id: VinylKeyLime
   name: "vinyl: Key Lime"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -872,7 +872,7 @@
   parent: BaseVinylAI
   id: VinylLayEggIsTrue
   name: "vinyl: Lay Egg Is True"
-  description: A face pace electronic tune.
+  description: A face pace electronic tune. By: WyrdDoe #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -882,7 +882,7 @@
   parent: BaseVinylDisc
   id: VinylMonkeyRiot
   name: "vinyl: Monkey Riot"
-  description: A fast pace high-energy electronic tune.
+  description: A fast pace high-energy electronic tune. By: WyrdDoe #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -898,7 +898,7 @@
   parent: BaseVinylDisc
   id: VinylOhNoEvilStar
   name: "vinyl: Oh No Evil Star"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -914,7 +914,7 @@
   parent: BaseVinylDisc
   id: VinylRepose
   name: "vinyl: Repose"
-  description: A slow pace funky tune.
+  description: A slow pace funky tune. By: aquariofury, Not Tom #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -930,7 +930,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureThree
   name: "vinyl: Adventure 3"
-  description: A fast pace adventurous tune.
+  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -946,7 +946,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureFour
   name: "vinyl: Adventure 4"
-  description: A fast pace adventurous tune.
+  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -962,7 +962,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureFive
   name: "vinyl: Adventure 5"
-  description: A fast pace adventurous tune.
+  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -978,7 +978,7 @@
   parent: BaseVinylDisc
   id: VinylAtlas
   name: "vinyl: Atlas"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -994,7 +994,7 @@
   parent: BaseVinylDisc
   id: VinylAtmosphere
   name: "vinyl: Atmosphere"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1010,7 +1010,7 @@
   parent: BaseVinylDisc
   id: VinylBanjoOne
   name: "vinyl: Banjo 1"
-  description: A slow pace calming tune.
+  description: A slow pace calming tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1026,7 +1026,7 @@
   parent: BaseVinylDisc
   id: VinylBiodome
   name: "vinyl: Biodome"
-  description: A slow pace eerie tune.
+  description: A slow pace eerie tune. By: aquariofury, Not Tom #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1042,7 +1042,7 @@
   parent: BaseVinylDisc
   id: VinylBlackWingInterface
   name: "vinyl: Black Wing Interface"
-  description: A slow pace electronic tune.
+  description: A slow pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1058,7 +1058,7 @@
   parent: BaseVinylDisc
   id: VinylBumblebee
   name: "vinyl: Bumblebee"
-  description: A incredibly fast pace violin solo.
+  description: A incredibly fast pace violin solo. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1074,7 +1074,7 @@
   parent: BaseVinylDisc
   id: VinylCloudSkyManGuy
   name: "vinyl: Cloud Sky Man Guy"
-  description: A upbeat electronic tune.
+  description: A upbeat electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1090,7 +1090,7 @@
   parent: BaseVinylTTD
   id: VinylJourney
   name: "vinyl: Journey"
-  description: A upbeat electronic tune.
+  description: A upbeat electronic tune. By: OpenTTD #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -1100,7 +1100,7 @@
   parent: BaseVinylForgotten
   id: VinylPeakAsshole
   name: "forgotten vinyl"
-  description: A song that we have all heard. Just not this bad...
+  description: A song that we have all heard. Just not this bad... By: LuciferMkshelter #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -1112,7 +1112,7 @@
   parent: BaseVinylSlippery
   id: VinylButtris
   name: "vinyl: Buttris"
-  description: An iconic videogame song remixed by the clown.
+  description: An iconic videogame song remixed by the clown. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     layers:
@@ -1127,7 +1127,7 @@
   parent: BaseVinylSlippery
   id: VinylWeAreNumberTwo
   name: "vinyl: We Are Number Two"
-  description: A recognisable song from a famous TV show, remixed by the clown.
+  description: A recognisable song from a famous TV show, remixed by the clown. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1143,7 +1143,7 @@
   parent: BaseVinylSlippery
   id: VinylUguu
   name: "vinyl: Uguu"
-  description: Some will say this song doesn't contain music. Others... their masterpiece.
+  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1159,7 +1159,7 @@
   parent: BaseVinylSlippery
   id: VinylPoo
   name: "vinyl: Poo"
-  description: Take a chance on... poo?
+  description: Take a chance on... poo? By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1175,7 +1175,7 @@
   parent: BaseVinylSlippery
   id: VinylDiscoPoo
   name: "vinyl: Disco Poo"
-  description: Some will say this song doesn't contain music. Others... their masterpiece.
+  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1191,7 +1191,7 @@
   parent: BaseVinylSlippery
   id: VinylCoreOfPoo
   name: "vinyl: Core Of Poo"
-  description: Some will say this song doesn't contain music. Others... their masterpiece.
+  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1207,7 +1207,7 @@
   parent: BaseVinylSlippery
   id: VinylFartElise
   name: "vinyl: Fart Elise"
-  description: A classical piece remixed by the clown.
+  description: A classical piece remixed by the clown. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1223,7 +1223,7 @@
   parent: BaseVinylSlippery
   id: VinylHonkmas
   name: "vinyl: Honkmas"
-  description: A festive tune made by the clown. With love.
+  description: A festive tune made by the clown. With love. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1239,7 +1239,7 @@
   parent: BaseVinylSlippery
   id: VinylEggshell
   name: "vinyl: Eggshell"
-  description: Eggs. Eggs. Eggs. Eggs. Eggs.
+  description: Eggs. Eggs. Eggs. Eggs. Eggs. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1255,7 +1255,7 @@
   parent: BaseVinylSlippery
   id: VinylWarriorsHonk
   name: "vinyl: Warriors Honk"
-  description: A fast pace electronic tune.
+  description: A fast pace electronic tune. By: Goonstation #SL  Addition
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
@@ -165,12 +165,14 @@
   name: "vinyl: Space Jazz"
   description: "A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod" #SL  Addition
   components:
+  # Starlight-start 
   - type: Sprite
     state: default
     layers:
     - state: default
     - state: label
       color: "#67659e"
+  # Starlight-end
   - type: Vinyl
     song:
       path: /Audio/_Goobstation/RadioStation/Vinyls/music/KevinMacleod/SpaceJazz.ogg

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
@@ -3,7 +3,7 @@
   parent: BaseVinylDisc
   id: VinylAirportLounge
   name: "vinyl: Airport Lounge"
-  description: A long, relaxing song reminiscent of elevator music. By: Kevin MacLeod #SL  Addition
+  description: "A long, relaxing song reminiscent of elevator music. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -19,7 +19,7 @@
   parent: BaseVinylDisc
   id: VinylBoogiePart
   name: "vinyl: Boogie Part"
-  description: A funky jazz song that makes you want to boogie. By: Kevin MacLeod #SL  Addition
+  description: "A funky jazz song that makes you want to boogie. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -35,7 +35,7 @@
   parent: BaseVinylDisc
   id: VinylBurnTheWorldWaltz
   name: "vinyl: Burn The World Waltz"
-  description: Heavy metal and brimstone. By: Kevin MacLeod #SL  Addition
+  description: "Heavy metal and brimstone. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -51,7 +51,7 @@
   parent: BaseVinylDisc
   id: VinylCorncob
   name: "vinyl: Corncob"
-  description: A fast pace country tune. By: Kevin MacLeod #SL  Addition
+  description: "A fast pace country tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -67,7 +67,7 @@
   parent: BaseVinylDisc
   id: VinylDeadlyRoulette
   name: "vinyl: Deadly Roulette"
-  description: A slow pace basey tune. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace basey tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -83,7 +83,7 @@
   parent: BaseVinylDisc
   id: VinylFeralAngelWaltz
   name: "vinyl: Feral Angel Waltz"
-  description: A slow pace rock waltz. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace rock waltz. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -99,7 +99,7 @@
   parent: BaseVinylDisc
   id: VinylJingleBells
   name: "vinyl: Jingle Bells"
-  description: The classic festive tune. By: Kevin MacLeod #SL  Addition
+  description: "The classic festive tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -115,7 +115,7 @@
   parent: BaseVinylDisc
   id: VinylLateNightRadio
   name: "vinyl: Late Night Radio"
-  description: A slow pace jazzy tune. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace jazzy tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -131,7 +131,7 @@
   parent: BaseVinylDisc
   id: VinylMesmerizingGalaxyLoop
   name: "vinyl: Mesmerizing Galaxy Loop"
-  description: A hypnotic eletronic tune. By: Kevin MacLeod #SL  Addition
+  description: "A hypnotic eletronic tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -147,7 +147,7 @@
   parent: BaseVinylDisc
   id: VinylNightInVenice
   name: "vinyl: Night In Venice"
-  description: A slow pace jazzy tune with a romantic vibe. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace jazzy tune with a romantic vibe. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -163,7 +163,7 @@
   parent: BaseVinylAI
   id: VinylSpaceJazz
   name: "vinyl: Space Jazz"
-  description: A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -179,7 +179,7 @@
   parent: BaseVinylDisc
   id: VinylVibingOverVenus
   name: "vinyl: Vibing Over Venus"
-  description: A slow pace jazzy tune. By: Kevin MacLeod #SL  Addition
+  description: "A slow pace jazzy tune. By: Kevin MacLeod" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -197,7 +197,7 @@
   parent: BaseVinylDisc
   id: VinylChristmasSong
   name: "vinyl: Christmas Song"
-  description: A festive tune about giving your heart away to someone special. By: Goonstation #SL  Addition
+  description: "A festive tune about giving your heart away to someone special. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -215,7 +215,7 @@
   parent: BaseVinylDisc
   id: VinylAlsoSprachZarathustra
   name: "vinyl: Also Sprach Zarathustra"
-  description: A classical piece that slowly builds to an climactic crescendo. By: PM Music #SL  Addition
+  description: "A classical piece that slowly builds to an climactic crescendo. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -231,7 +231,7 @@
   parent: BaseVinylDisc
   id: VinylRussianDance
   name: "vinyl: Russian Dance"
-  description: A classical piece with a fast pace and a lively rhythm. By: PM Music #SL  Addition
+  description: "A classical piece with a fast pace and a lively rhythm. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -247,7 +247,7 @@
   parent: BaseVinylDisc
   id: VinylTheFlowerDuet
   name: "vinyl: The Flower Duet"
-  description: A classical opera duet. By: PM Music #SL  Addition
+  description: "A classical opera duet. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -263,7 +263,7 @@
   parent: BaseVinylDisc
   id: VinylWinterVivaldi
   name: "vinyl: Vivaldi's Winter"
-  description: A classical tune from Vivaldi, representing the winter season. By: PM Music #SL  Addition
+  description: "A classical tune from Vivaldi, representing the winter season. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -279,7 +279,7 @@
   parent: BaseVinylDisc
   id: VinylCelloSuite
   name: "vinyl: Cello Suite"
-  description: A classical cello solo. By: PM Music #SL  Addition
+  description: "A classical cello solo. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -295,7 +295,7 @@
   parent: BaseVinylDisc
   id: VinylRideOfTheValkyries
   name: "vinyl: Ride Of The Valkyries"
-  description: A classical piece best paired with the charging of cavalry. By: PM Music #SL  Addition
+  description: "A classical piece best paired with the charging of cavalry. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -311,7 +311,7 @@
   parent: BaseVinylDisc
   id: VinylRomeoAndJuliet
   name: "vinyl: Romeo And Juliet"
-  description: A classical romantic piece. By: PM Music #SL  Addition
+  description: "A classical romantic piece. By: PM Music" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -329,7 +329,7 @@
   parent: BaseVinylDevil
   id: VinylMaxi
   name: "vinyl: Maxi"
-  description: An exciting rock/metal song. By: Goonstation #SL  Addition
+  description: "An exciting rock/metal song. By: Goonstation" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -339,7 +339,7 @@
   parent: BaseVinylDevil
   id: VinylXtra
   name: "vinyl: Xtra"
-  description: An exciting rock/metal song. By: Goonstation #SL  Addition
+  description: "An exciting rock/metal song. By: Goonstation" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -349,7 +349,7 @@
   parent: BaseVinylDevil
   id: VinylGiga
   name: "vinyl: Giga"
-  description: An exciting rock/metal song. By: Goonstation #SL  Addition
+  description: "An exciting rock/metal song. By: Goonstation" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -359,7 +359,7 @@
   parent: BaseVinylDisc
   id: VinylEveryoneIsSoAlive
   name: "vinyl: Everyone Is So Alive"
-  description: A slow pace electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -375,7 +375,7 @@
   parent: BaseVinylDisc
   id: VinylHighTechnologicBeat
   name: "vinyl: High Technologic Beat"
-  description: A fast pace electronic dance beat. By: Goonstation #SL  Addition
+  description: "A fast pace electronic dance beat. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -391,7 +391,7 @@
   parent: BaseVinylDisc
   id: VinylAfterParty
   name: "vinyl: After Party"
-  description: A slow pace electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -407,7 +407,7 @@
   parent: BaseVinylDisc
   id: VinylItFeelsGoodToBeAliveToo
   name: "vinyl: It Feels Good To Be Alive Too"
-  description: A fast pace electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -423,7 +423,7 @@
   parent: BaseVinylDisc
   id: VinylFunkadelic
   name: "vinyl: Funkadelic"
-  description: A slow pace funky electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace funky electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -439,7 +439,7 @@
   parent: BaseVinylDisc
   id: VinylLunch
   name: "vinyl: Lunch"
-  description: A fast pace groovy electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace groovy electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -455,7 +455,7 @@
   parent: BaseVinylDisc
   id: VinylGroovy
   name: "vinyl: Groovy"
-  description: A fast pace electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -474,7 +474,7 @@
   parent: BaseVinylDisc
   id: VinylAnonymous
   name: "vinyl: Anonymous"
-  description: A fast pace hypnotic electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace hypnotic electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -493,7 +493,7 @@
   parent: BaseVinylDisc
   id: VinylDistantStar
   name: "vinyl: Distant Star"
-  description: A fast pace electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -512,7 +512,7 @@
   parent: BaseVinylDisc
   id: VinylEphedrineOverdose
   name: "vinyl: Ephedrine Overdose"
-  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A fast pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -528,7 +528,7 @@
   parent: BaseVinylDisc
   id: VinylGetThatAntag
   name: "vinyl: Get That Antag!"
-  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A fast pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -544,7 +544,7 @@
   parent: BaseVinylDisc
   id: VinylGreytideSong
   name: "vinyl: Greytide Song"
-  description: A hip tune by DJ Tider. By: mrjajkes #SL  Addition
+  description: "A hip tune by DJ Tider. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -560,7 +560,7 @@
   parent: BaseVinylDisc
   id: VinylNukiesTrap
   name: "vinyl: Nukies Trap Remix"
-  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A fast pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -576,7 +576,7 @@
   parent: BaseVinylDisc
   id: VinylRunningOut
   name: "vinyl: Running Out"
-  description: A dramatic fast pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A dramatic fast pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -592,7 +592,7 @@
   parent: BaseVinylDisc
   id: VinylSponsoredBySyndicate
   name: "vinyl: Sponsored By Syndicate"
-  description: A fast pace rock tune. By: mrjajkes #SL  Addition
+  description: "A fast pace rock tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -608,7 +608,7 @@
   parent: BaseVinylDisc
   id: VinylTraitorousIntent
   name: "vinyl: Traitorous Intent"
-  description: A eerie low pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A eerie low pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -624,7 +624,7 @@
   parent: BaseVinylDisc
   id: VinylViolet
   name: "vinyl: Violet"
-  description: A fast pace electronic tune. By: mrjajkes #SL  Addition
+  description: "A fast pace electronic tune. By: mrjajkes" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -644,7 +644,7 @@
   parent: BaseVinylDisc
   id: VinylWaystations
   name: "vinyl: Waystations"
-  description: A slow pace electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -660,7 +660,7 @@
   parent: BaseVinylDisc
   id: VinylUpbeatOne
   name: "vinyl: Upbeat 1"
-  description: A groovy upbeat tune. By: Goonstation #SL  Addition
+  description: "A groovy upbeat tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -676,7 +676,7 @@
   parent: BaseVinylDisc
   id: VinylUpbeatTwo
   name: "vinyl: Upbeat 2"
-  description: A groovy upbeat tune. By: Goonstation #SL  Addition
+  description: "A groovy upbeat tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -692,7 +692,7 @@
   parent: BaseVinylDisc
   id: VinylPlanets
   name: "vinyl: Planets"
-  description: A slow pace electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -708,7 +708,7 @@
   parent: BaseVinylDisc
   id: VinylChillOne
   name: "vinyl: Chill 1"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -724,7 +724,7 @@
   parent: BaseVinylDisc
   id: VinylChillTwo
   name: "vinyl: Chill 2"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -740,7 +740,7 @@
   parent: BaseVinylDisc
   id: VinylChillThree
   name: "vinyl: Chill 3"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -756,7 +756,7 @@
   parent: BaseVinylDisc
   id: VinylChillFour
   name: "vinyl: Chill 4"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -772,7 +772,7 @@
   parent: BaseVinylDisc
   id: VinylBeaches
   name: "vinyl: Beaches"
-  description: A slow pace electronic tune. By: aquariofury, Not Tom  #SL  Addition
+  description: "A slow pace electronic tune. By: aquariofury, Not Tom"  #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -788,7 +788,7 @@
   parent: BaseVinylDisc
   id: VinylDanceOnASpaceVolcano
   name: "vinyl: Dance On A Space Volcano"
-  description: A funky fast pace electronic dance tune. By: Goonstation #SL  Addition
+  description: "A funky fast pace electronic dance tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -804,7 +804,7 @@
   parent: BaseVinylFloaty
   id: VinylFloaty
   name: "vinyl: Floaty"
-  description: A slow pace hypnotic tune. By: aquariofury, Not Tom #SL  Addition
+  description: "A slow pace hypnotic tune. By: aquariofury, Not Tom" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -814,7 +814,7 @@
   parent: BaseVinylDisc
   id: VinylGraveyard
   name: "vinyl: Graveyard"
-  description: A slow pace eerie tune. By: aquariofury, Not Tom #SL  Addition
+  description: "A slow pace eerie tune. By: aquariofury, Not Tom" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -830,7 +830,7 @@
   parent: BaseVinylDisc
   id: VinylRiverdancer
   name: "vinyl: Riverdancer"
-  description: A slow pace funky electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace funky electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -846,7 +846,7 @@
   parent: BaseVinylDisc
   id: VinylSpaceGardener
   name: "vinyl: Space Gardener"
-  description: A slow pace electronic tune. By: tamakari #SL  Addition
+  description: "A slow pace electronic tune. By: tamakari" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -862,7 +862,7 @@
   parent: BaseVinylDisc
   id: VinylKeyLime
   name: "vinyl: Key Lime"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -878,7 +878,7 @@
   parent: BaseVinylAI
   id: VinylLayEggIsTrue
   name: "vinyl: Lay Egg Is True"
-  description: A face pace electronic tune. By: WyrdDoe #SL  Addition
+  description: "A face pace electronic tune. By: WyrdDoe" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -888,7 +888,7 @@
   parent: BaseVinylDisc
   id: VinylMonkeyRiot
   name: "vinyl: Monkey Riot"
-  description: A fast pace high-energy electronic tune. By: WyrdDoe #SL  Addition
+  description: "A fast pace high-energy electronic tune. By: WyrdDoe" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -904,7 +904,7 @@
   parent: BaseVinylDisc
   id: VinylOhNoEvilStar
   name: "vinyl: Oh No Evil Star"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -920,7 +920,7 @@
   parent: BaseVinylDisc
   id: VinylRepose
   name: "vinyl: Repose"
-  description: A slow pace funky tune. By: aquariofury, Not Tom #SL  Addition
+  description: "A slow pace funky tune. By: aquariofury, Not Tom" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -936,7 +936,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureThree
   name: "vinyl: Adventure 3"
-  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
+  description: "A fast pace adventurous tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -952,7 +952,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureFour
   name: "vinyl: Adventure 4"
-  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
+  description: "A fast pace adventurous tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -968,7 +968,7 @@
   parent: BaseVinylDisc
   id: VinylAdventureFive
   name: "vinyl: Adventure 5"
-  description: A fast pace adventurous tune. By: Goonstation #SL  Addition
+  description: "A fast pace adventurous tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -984,7 +984,7 @@
   parent: BaseVinylDisc
   id: VinylAtlas
   name: "vinyl: Atlas"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1000,7 +1000,7 @@
   parent: BaseVinylDisc
   id: VinylAtmosphere
   name: "vinyl: Atmosphere"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1016,7 +1016,7 @@
   parent: BaseVinylDisc
   id: VinylBanjoOne
   name: "vinyl: Banjo 1"
-  description: A slow pace calming tune. By: Goonstation #SL  Addition
+  description: "A slow pace calming tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1032,7 +1032,7 @@
   parent: BaseVinylDisc
   id: VinylBiodome
   name: "vinyl: Biodome"
-  description: A slow pace eerie tune. By: aquariofury, Not Tom #SL  Addition
+  description: "A slow pace eerie tune. By: aquariofury, Not Tom" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1048,7 +1048,7 @@
   parent: BaseVinylDisc
   id: VinylBlackWingInterface
   name: "vinyl: Black Wing Interface"
-  description: A slow pace electronic tune. By: Goonstation #SL  Addition
+  description: "A slow pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1064,7 +1064,7 @@
   parent: BaseVinylDisc
   id: VinylBumblebee
   name: "vinyl: Bumblebee"
-  description: A incredibly fast pace violin solo. By: Goonstation #SL  Addition
+  description: "A incredibly fast pace violin solo. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1080,7 +1080,7 @@
   parent: BaseVinylDisc
   id: VinylCloudSkyManGuy
   name: "vinyl: Cloud Sky Man Guy"
-  description: A upbeat electronic tune. By: Goonstation #SL  Addition
+  description: "A upbeat electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1096,7 +1096,7 @@
   parent: BaseVinylTTD
   id: VinylJourney
   name: "vinyl: Journey"
-  description: A upbeat electronic tune. By: OpenTTD #SL  Addition
+  description: "A upbeat electronic tune. By: OpenTTD" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -1106,7 +1106,7 @@
   parent: BaseVinylForgotten
   id: VinylPeakAsshole
   name: "forgotten vinyl"
-  description: A song that we have all heard. Just not this bad... By: LuciferMkshelter #SL  Addition
+  description: "A song that we have all heard. Just not this bad... By: LuciferMkshelter" #SL  Addition
   components:
   - type: Vinyl
     song:
@@ -1118,7 +1118,7 @@
   parent: BaseVinylSlippery
   id: VinylButtris
   name: "vinyl: Buttris"
-  description: An iconic videogame song remixed by the clown. By: Goonstation #SL  Addition
+  description: "An iconic videogame song remixed by the clown. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     layers:
@@ -1133,7 +1133,7 @@
   parent: BaseVinylSlippery
   id: VinylWeAreNumberTwo
   name: "vinyl: We Are Number Two"
-  description: A recognisable song from a famous TV show, remixed by the clown. By: Goonstation #SL  Addition
+  description: "A recognisable song from a famous TV show, remixed by the clown. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1149,7 +1149,7 @@
   parent: BaseVinylSlippery
   id: VinylUguu
   name: "vinyl: Uguu"
-  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
+  description: "Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1165,7 +1165,7 @@
   parent: BaseVinylSlippery
   id: VinylPoo
   name: "vinyl: Poo"
-  description: Take a chance on... poo? By: Goonstation #SL  Addition
+  description: "Take a chance on... poo? By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1181,7 +1181,7 @@
   parent: BaseVinylSlippery
   id: VinylDiscoPoo
   name: "vinyl: Disco Poo"
-  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
+  description: "Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1197,7 +1197,7 @@
   parent: BaseVinylSlippery
   id: VinylCoreOfPoo
   name: "vinyl: Core Of Poo"
-  description: Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation #SL  Addition
+  description: "Some will say this song doesn't contain music. Others... their masterpiece. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1213,7 +1213,7 @@
   parent: BaseVinylSlippery
   id: VinylFartElise
   name: "vinyl: Fart Elise"
-  description: A classical piece remixed by the clown. By: Goonstation #SL  Addition
+  description: "A classical piece remixed by the clown. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1229,7 +1229,7 @@
   parent: BaseVinylSlippery
   id: VinylHonkmas
   name: "vinyl: Honkmas"
-  description: A festive tune made by the clown. With love. By: Goonstation #SL  Addition
+  description: "A festive tune made by the clown. With love. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1245,7 +1245,7 @@
   parent: BaseVinylSlippery
   id: VinylEggshell
   name: "vinyl: Eggshell"
-  description: Eggs. Eggs. Eggs. Eggs. Eggs. By: Goonstation #SL  Addition
+  description: "Eggs. Eggs. Eggs. Eggs. Eggs. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     state: default
@@ -1261,7 +1261,7 @@
   parent: BaseVinylSlippery
   id: VinylWarriorsHonk
   name: "vinyl: Warriors Honk"
-  description: A fast pace electronic tune. By: Goonstation #SL  Addition
+  description: "A fast pace electronic tune. By: Goonstation" #SL  Addition
   components:
   - type: Sprite
     layers:

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Fun/RadioHost/vinyls.yml
@@ -165,7 +165,7 @@
   name: "vinyl: Space Jazz"
   description: "A slow pace jazzy tune reminiscent of elevator music. By: Kevin MacLeod" #SL  Addition
   components:
-  # Starlight-start 
+  # Starlight-start
   - type: Sprite
     state: default
     layers:


### PR DESCRIPTION
## Short description
Adds artist names to the music vinyls descriptions.

Some songs I could not track down the credits for, and are defaulted to being credited by Goonstation.
<!-- What do you propose to change with your PR? -->

## Why we need to add this
It's neat to have, also a way to say "this is song by so and so" or something
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Way
- add: Artist names are now in the descriptions of music vinyls.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
