### PR TITLE
Hristov anti-materiel buffs, makes shields take structural damage

### DIFF
--- a/Resources/Prototypes/Damage/containers.yml
+++ b/Resources/Prototypes/Damage/containers.yml
@@ -38,6 +38,7 @@
     - Brute
   supportedTypes:
     - Heat
+    - Structural # Starlight
 
 - type: damageContainer
   id: Box

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -87,6 +87,7 @@
         Brute: -60 # 20 of each Brute Type - 20% of a basic shield HP
       types:
         Heat: -20
+        Structural: -20
     fuelCost: 10 # 1/2 of a Welder for a full repair
     doAfterDelay: 5
     allowSelfRepair: false

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -19,6 +19,10 @@
           Slash: 0.9
           Piercing: 0.9
           Heat: 0.9
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.8
@@ -30,6 +34,7 @@
           Slash: 1
           Piercing: 1
           Heat: 1
+          Structural: 10 # Starlight
     - type: Damageable
       damageContainer: Shield
     - type: ExaminableDamage
@@ -105,6 +110,10 @@
         coefficients:
           Blunt: 0.7
           Slash: 0.7
+        #region Starlight
+        flatReductions:
+          Structural: 20
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.5
@@ -112,6 +121,7 @@
         flatReductions:
           Blunt: 1
           Slash: 1
+          Structural: 20 # Starlight
 
 - type: entity
   name: laser shield
@@ -127,11 +137,16 @@
       passiveBlockModifier:
         coefficients:
           Heat: 0.7
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Heat: 0.5
         flatReductions:
           Heat: 1
+          Structural: 10 # Starlight
 
 - type: entity
   name: ballistic shield
@@ -147,11 +162,16 @@
       passiveBlockModifier:
         coefficients:
           Piercing: 0.7
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Piercing: 0.5
         flatReductions:
           Piercing: 1
+          Structural: 10 # Starlight
 
 #Craftable shields
 
@@ -172,6 +192,10 @@
           Slash: 0.95
           Piercing: 0.95
           Heat: 2
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.85
@@ -182,6 +206,7 @@
           Blunt: 1
           Slash: 1
           Piercing: 1
+          Structural: 10 # Starlight
     - type: Construction
       graph: WoodenBuckler
       node: woodenBuckler
@@ -286,6 +311,10 @@
           Slash: 0.95
           Piercing: 0.95
           Heat: 0.9
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.85
@@ -297,6 +326,7 @@
           Slash: 0.5
           Piercing: 0.5
           Heat: 1
+          Structural: 10 # Starlight
     - type: MeleeWeapon
       damage:
         types:
@@ -349,6 +379,10 @@
           Blunt: 0.95
           Slash: 0.95
           Piercing: 0.95
+        #region Starlight
+        flatReductions:
+          Structural: 10
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.85
@@ -358,6 +392,7 @@
           Blunt: 0.5
           Slash: 0.5
           Piercing: 0.5
+          Structural: 10 # Starlight
     - type: Construction
       graph: WebObjects
       node: shield
@@ -405,6 +440,10 @@
           Slash: 0.8
           Piercing: 0.8
           Heat: 1.5
+        #region Starlight
+        flatReductions:
+          Structural: 20
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 0.7
@@ -415,6 +454,7 @@
           Blunt: 1
           Slash: 1
           Piercing: 1
+          Structural: 20 # Starlight
       #Have it break into brass when clock cult is in
 
 - type: entity
@@ -438,6 +478,10 @@
           Slash: 1.2
           Piercing: 1.2
           Heat: .7
+        #region Starlight
+        flatReductions:
+          Structural: 5
+        #endregion Starlight
       activeBlockModifier:
         coefficients:
           Blunt: 1.2
@@ -446,6 +490,7 @@
           Heat: .6
         flatReductions:
           Heat: 1
+          Structural: 5 # Starlight
       blockSound: !type:SoundPathSpecifier
         path: /Audio/Effects/glass_step.ogg
     - type: Destructible
@@ -547,12 +592,14 @@
           Slash: 0.9
           Piercing: 0.85
           Heat: 0.6
+          Structural: 0.0 # Starlight - it's energy, it doesn't have structural integrity
       activeBlockModifier:
         coefficients:
           Blunt: 1.2
           Slash: 0.85
           Piercing: 0.5
           Heat: 0.4
+          Structural: 0.0 # Starlight
         flatReductions:
           Heat: 1
           Piercing: 1

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -23,6 +23,8 @@
           Slash: 0.5 #Encourages long swordfights, which I really, really want to see.
           Piercing: 0.8
           Heat: 0.85
+        flatReductions:
+          Structural: 10
       activeBlockModifier:
         coefficients:
           Blunt: 0.5
@@ -34,6 +36,7 @@
           Slash: 1
           Piercing: 1
           Heat: 1
+          Structural: 10
     - type: MeleeWeapon
       damage:
         types:
@@ -102,12 +105,16 @@
           Slash: 0.7
           Piercing: 0.7
           Heat: 0.85
+        flatReductions:
+          Structural: 20
       activeBlockModifier:
         coefficients: #Insanely high resist because normal shields suck when raising. This is a WALL.
           Blunt: 0.1
           Slash: 0.1
           Piercing: 0.1
           Heat: 0.75 # Achilles Heel
+        flatReductions:
+          Structural: 20
     - type: MeleeWeapon
       attackRate: 0.50 # Large and heavy but god help you if someone hits you with this thing.
       damage:
@@ -168,12 +175,16 @@
           Slash: 0.6
           Piercing: 0.7
           Heat: 0.9
+        flatReductions:
+          Structural: 10
       activeBlockModifier:
         coefficients:
           Blunt: 0.6
           Slash: 0.5
           Piercing: 0.6
           Heat: 0.8
+        flatReductions:
+          Structural: 10
     - type: MeleeWeapon
       damage:
         types:
@@ -279,12 +290,16 @@
           Slash: 0.7
           Piercing: 0.9
           Heat: 0.95
+        flatReductions:
+          Structural: 10
       activeBlockModifier:
         coefficients:
           Blunt: 0.7
           Slash: 0.6
           Piercing: 0.8
           Heat: 0.85
+        flatReductions:
+          Structural: 10
     - type: MeleeWeapon
       damage:
         types:
@@ -391,12 +406,14 @@
           Slash: 0.15
           Piercing: 0.10
           Heat: 0.15
+          Structural: 0.0 # it's energy, it doesn't have structural integrity
       activeBlockModifier: # You shouldn't be able to wield it, but if for some reason you end up doing it, no more immortality.
         coefficients:
           Blunt: 0.4
           Slash: 0.35
           Piercing: 0.25
           Heat: 0.35
+          Structural: 0.0
       passiveBlockFraction: 0.2
       activeBlockFraction: 0.3
     - type: Appearance
@@ -532,12 +549,14 @@
           Slash: 0.8
           Piercing: 0.85
           Heat: 0.6
+          Structural: 0.0 # it's energy, it doesn't have structural integrity
       activeBlockModifier:
         coefficients:
           Blunt: 0.95
           Slash: 0.75
           Piercing: 0.5
           Heat: 0.4
+          Structural: 0.0
         flatReductions:
           Heat: 1
           Piercing: 1
@@ -573,12 +592,14 @@
           Slash: 0.9
           Piercing: 0.85
           Heat: 0.6
+          Structural: 0.0 # it's energy, it doesn't have structural integrity
       activeBlockModifier:
         coefficients:
           Blunt: 1.0
           Slash: 0.85
           Piercing: 0.5
           Heat: 0.4
+          Structural: 0.0
         flatReductions:
           Heat: 1
           Piercing: 1
@@ -622,6 +643,8 @@
           Blunt: 0.75 # It costs biomass to use, and makes you a target. A bit worse than the Paladin Shield.
           Piercing: 0.85
           Slash: 0.75
+        flatReductions:
+          Structural: 10
       activeBlockModifier:
         coefficients:
           Blunt: 0.6
@@ -631,6 +654,7 @@
           Blunt: 1
           Piercing: 0.5
           Slash: 1
+          Structural: 10
     - type: MeleeWeapon
       damage:
         types:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Shields/shields.yml
@@ -76,6 +76,7 @@
           Brute: -60 # 20 of each Brute Type - 20% of a basic shield HP
         types:
           Heat: -20
+          Structural: -20
       fuelCost: 10 # 1/2 of a Welder for a full repair
       doAfterDelay: 5
       allowSelfRepair: false

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -42,7 +42,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
-    armorPenetration: 0.35
+    armorPenetration: 0.69 # AP
     damage:
       types:
         Piercing: 75


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR explores:
- making shields take Structural damage
- making the Hristov do anti-materiel things with its anti-materiel rounds

It also gives the Hristov a flat buff by making its ammo AP without changing its base damage. I didn't feel like making it worse against unarmoured targets is that interesting, so I did not drop the base damage by the customary 30% for AP ammo.

I'm super open to tweaking the numbers below if the concept of this PR is interesting enough to be considered to be merged. Stuff like the flat reductions for structural damage were mostly chosen out of a desire to not make cheap weapons like the baseball bat good against shields.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- "Give hristov armor pen (and possible damage buff)": https://discord.com/channels/1272545509562777621/1539575454787436594
- "Please buff the Histrov": https://discord.com/channels/1272545509562777621/1517337220724428932
- "Make hristov great again": https://discord.com/channels/1272545509562777621/1462471997022929010

**People wanna see this gun be cool,** but just making it a oneshot "kills everything" death cannon wouldn't be interesting.

So I thought leaning into the "anti materiel" part would be cool. This thing utterly shwacks shields now. That's not to say shields are worthless - you still get the protection of the shield on that first shot, but your shield will be utterly destroyed after it tanks that shot.

I made an exception for energy shields, though. They're made of energy, not structural materials and it's an anti-materiel rifle, after all, not an anti-energy rifle. Stuff like EMPs should probably remain the go-to way to defeat energy-based weapons and armour.

### Why this buff?
Aside from seeing people want to see the Hristov buffed, I ran into something interesting with the Hristov when shooting at target dummies with shields: shields are comically good at defeating the Hristov.

Making shields take structural damage makes it so that the Hristov is _really_ good against them, and I think that's a fun niche to fulfill.

This does incidentally buff other weapons that do structural damage, but the difference is not that dramatic outside of weapons that do a _lot_ of structural damage, like the fireaxe (50) and breaching hammer (135). Outside of those high-structural damage weapons, you'll probably be crit long before your shield breaks.

| Armour Pen | Target Armour | Resulting Damage
| -- | -- | -- |
| 35% (default) | $0$% Naked | 75 piercing |
| 35% (default) | $33.5$% Standard | 58.4 piercing |
| 35% (default) | $48.7$% Hardsuit | 50.2 piercing |
| 35% (default) | $33.5$% Standard + Shield | 29.19 piercing |
| 35% (default) | $48.7$% Hardsuit + Shield | 25.09 piercing |

| Armour Pen | Target Armour | Resulting Damage
| -- | -- | -- |
| 69% (AP buff) | $0$% Naked | 75 piercing |
| 69% (AP buff) | $33.5$% Security Standard | 66.96 piercing |
| 69% (AP buff) | $48.7$% Security Hardsuit | 62.67 piercing |
| 69% (AP buff) | $33.5$% Standard + Shield | 33.48 piercing |
| 69% (AP buff) | $48.7$% Hardsuit + Shield | 31.33 piercing |

I used the following setups for armour:
- **Naked**: 0% effective pierce armour
- **Security Standard**: armor vest (30%) + sec gas mask (5%) for $33.5$% effective pierce armour
- **Security Hardsuit**: sec hardsuit (40%) + sec hardsuit helmet (10%) + sec  gas mask (5%) for $48.7$% effective pierce armour
- **Ballistic Shield**: ballistic shield (50% damage block), mixed with the above two loadouts separately

Tiny footnote for people who aren't familiar with SS14 armour: it's multiplicative, not additive:
- Wearing a sec hardsuit (40%) + sec hardsuit helmet (10%) + sec gas mask (5%) does not give you $40 + 10 + 5 = 55$% armour
- It gives you $1-((1-0.40)\times(1-0.10)\times(1-0.05)) = 48.7$% armour

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="344" height="158" alt="image" src="https://github.com/user-attachments/assets/2d42eed2-ab32-4727-9a26-5dd5506cdfe2" />

fig. 1 - Example of a shield's new structural description.

<img width="365" height="174" alt="image" src="https://github.com/user-attachments/assets/ed88612a-a19d-4824-887d-bbccac8c04a9" />

fig. 2 - Hristov's new armour pen values.

<img width="351" height="217" alt="image" src="https://github.com/user-attachments/assets/894a0546-92e5-4b4d-8f02-9e47749355bd" />

fig. 3 - Energy shields don't take structural damage. It's an anti-materiel rifle, not an anti-energy rifle, after all.

<img width="350" height="426" alt="hristov" src="https://github.com/user-attachments/assets/f63ff701-a5a5-4329-aca2-7831b469ccea" />

fig. 4 - Wrecking a SecOff's shield with the Hristov.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- add: Shields now take structural damage and have varying levels of flat armour against structural damage. Baseball bats won't be cracking shields with any speed, but high-structural damage weapons like the Fire Axe Breaching Hammer will.
- tweak: The Hristov now utterly annihilates most shields in one shot.
- tweak: Made the Hristov's ammo armour piercing.