### PR TITLE
Intellicard fixes, unified naming conventions and name transfers with posi/mmi to borgs as well as making transfers possible

### DIFF
--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.Ui.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.Ui.cs
@@ -58,7 +58,11 @@ public abstract partial class SharedBorgSystem
             return;
 
         _adminLog.Add(LogType.Action, LogImpact.High, $"{args.Actor} set borg \"{chassis.Owner}\"'s name to: {name}");
-        _metaData.SetEntityName(chassis, name, metaData, false);
+        _metaData.SetEntityName(chassis, name, metaData);
+        // Starlight-start: Keep the Borg brain synchronized with the chassis name.
+        if (chassis.Comp.BrainEntity is { } brain)
+            _metaData.SetEntityName(brain, name);
+        // Starlight-end
     }
 
     private void OnRemoveModuleBuiMessage(Entity<BorgChassisComponent> chassis, ref BorgRemoveModuleBuiMessage args)

--- a/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
+++ b/Content.Shared/Silicons/Borgs/SharedBorgSystem.cs
@@ -36,6 +36,8 @@ using Content.Shared.Radio.Components;
 using Content.Shared._Starlight.Silicons.Borgs;
 using Content.Shared.Actions.Components;
 // Starlight begin
+using Content.Shared.NameModifier.EntitySystems;
+using Robust.Shared.Prototypes;
 using Content.Shared._Starlight.TextToSpeech;
 using Content.Shared.Tag;
 // Starlight end
@@ -70,6 +72,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
     [Dependency] private SharedHandheldLightSystem _handheldLight = default!;
     [Dependency] private SharedAccessSystem _access = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private NameModifierSystem _nameModifier = default!; // Starlight
     [Dependency] private TagSystem _tag = default!; // Starlight
 
     /// <inheritdoc/>
@@ -137,6 +140,30 @@ public abstract partial class SharedBorgSystem : EntitySystem
     private void OnMapInit(Entity<BorgChassisComponent> chassis, ref MapInitEvent args)
     {
         _movementSpeedModifier.RefreshMovementSpeedModifiers(chassis.Owner);
+
+        // Starlight: If the borg has a brain, synchronize the name of the brain with the chassis.
+        if (chassis.Comp.BrainEntity is { } brain)
+            SynchronizeBrainName(chassis, brain);
+    }
+
+    // Starlight: function to synchronize the name of the brain with the chassis, and the other way around.
+    private void SynchronizeBrainName(Entity<BorgChassisComponent> chassis, EntityUid brain)
+    {
+        var brainName = _nameModifier.GetBaseName(brain);
+        var chassisName = _nameModifier.GetBaseName(chassis.Owner);
+
+        if (brainName.Equals(chassisName, StringComparison.InvariantCulture))
+            return;
+
+        if (MetaData(brain).EntityPrototype is { } brainPrototype &&
+            brainName.Equals(Loc.GetString(brainPrototype.Name), StringComparison.InvariantCulture))
+        {
+            _metaData.SetEntityName(brain, chassisName);
+        }
+        else
+        {
+            _metaData.SetEntityName(chassis, brainName);
+        }
     }
 
     private void OnItemSlotInsertAttempt(Entity<BorgChassisComponent> chassis, ref ItemSlotInsertAttemptEvent args)
@@ -181,6 +208,7 @@ public abstract partial class SharedBorgSystem : EntitySystem
             return;
 
         //#region Starlight
+        SynchronizeBrainName(chassis, args.Entity);
         if (TryComp(args.Entity, out BorgBrainComponent? brain) && _mind.TryGetMind(args.Entity, out var mindId, out var mind))
         {
             //re-target the station-AI's shunt target to the chassis insteaf of the brain

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -45,6 +45,7 @@ using Content.Shared.Silicons.Laws.Components;
 using Content.Shared.DeviceLinking;
 using System.Numerics;
 using Content.Shared._Starlight;
+using Content.Shared.NameModifier.EntitySystems;
 #endregion Starlight
 
 namespace Content.Shared.Silicons.StationAi;
@@ -79,6 +80,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private SharedDeviceLinkSystem _deviceLinkSystem = default!; // Starlight
     [Dependency] private StarlightEntitySystem _entitySystem = default!; // Starlight
+    [Dependency] private NameModifierSystem _nameModifier = default!; // Starlight-edit
 
     // StationAiHeld is added to anything inside of an AI core.
     // StationAiHolder indicates it can hold an AI positronic brain (e.g. holocard / core).
@@ -332,15 +334,16 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         }
         // Starlight-end
 
-        // Otherwise try to take from them
-        if (targetHolder != null && slot != null && _slots.CanEject(target, args.User, targetHolder.Slot)) // Starlight-edit
+        // Starlight-start: Otherwise try to take from them
+        if (targetHolder != null && slot != null && _slots.CanEject(target, args.User, targetHolder.Slot))
         {
-            if (!_slots.TryInsert(uid, slot, targetHolder.Slot.Item!.Value, args.User, excludeUserAudio: true)) // Starlight-edit
+            var held = targetHolder.Slot.Item!.Value;
+            _metadata.SetEntityName(held, _nameModifier.GetBaseName(held), raiseEvents: false);
+            if (!_slots.TryInsert(uid, slot, held, args.User, excludeUserAudio: true))
                 return;
-
             args.Handled = true;
         }
-        // Starlight-start: borgs can be downloaded/uploaded
+        // Starlight: borgs can be downloaded/uploaded
         else if (targetHolder != null && isBorg && !borgHaveMind && targetHolder.Slot.Item is { } aiEntity)
         {
             if (!_mind.TryGetMind(aiEntity, out var mindId, out var mind))
@@ -348,7 +351,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
                 return;
             }
 
-            _metadata.SetEntityName(uid, MetaData(aiEntity).EntityName); // Starlight-edit
+            _metadata.SetEntityName(uid, _nameModifier.GetBaseName(aiEntity));
             _mind.TransferTo(mindId, uid, ghostCheckOverride: true, mind: mind);
             Del(aiEntity);
             args.Handled = true;
@@ -357,13 +360,21 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         else if (targetHolder != null && isBorg && borgHaveMind && targetHolder.Slot.ContainerSlot != null)
         {
             var brain = SpawnInContainerOrDrop(DefaultAi, target, targetHolder.Slot.ContainerSlot.ID);
-            if (!_mind.TryGetMind(borgMind, out var mindId, out var mind)) // Starlight-edit
-                return; // Starlight-edit
-            _metadata.SetEntityName(brain, MetaData(borgMind).EntityName); // Starlight-edit
-            _metadata.SetEntityName(target, MetaData(borgMind).EntityName); // Starlight-edit
-            _mind.TransferTo(mindId, brain, ghostCheckOverride: true, mind: mind); // Starlight-edit
+            if (!_mind.TryGetMind(borgMind, out var mindId, out var mind))
+                return;
+            _metadata.SetEntityName(brain, _nameModifier.GetBaseName(borgMind));
+            _metadata.SetEntityName(target, _nameModifier.GetBaseName(borgMind));
+            _mind.TransferTo(mindId, brain, ghostCheckOverride: true, mind: mind);
+            ResetNameToPrototype(uid);
         }
         // Starlight-end
+    }
+
+    // Starlight: wipe the name of the entity to the prototype name, used for entities when they are downloaded/uploaded
+    private void ResetNameToPrototype(EntityUid entity)
+    {
+        if (MetaData(entity).EntityPrototype is { } prototype)
+            _metadata.SetEntityName(entity, Loc.GetString(prototype.Name));
     }
 
     private void OnHolderInteract(Entity<StationAiHolderComponent> ent, ref AfterInteractEvent args)
@@ -396,14 +407,15 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         var isShunted = TryComp<StationAIShuntComponent>(borgTarget, out var shunt) && shunt.Return != null;
         var borgHaveMind = TryComp<MindContainerComponent>(borgMindTarget, out var mindContainer) && mindContainer.HasMind; // Starlight-edit
 
-        // Starlight-end
-
-        if (targetHolder == null && !isBorg) // Starlight-edit
+        if (targetHolder == null && !isBorg)
         {
-            _popup.PopupClient(Loc.GetString("intellicard-core-empty"), args.User, args.User, PopupType.Medium);
+            var message = cardHasAi ? "intellicard-cannot-transfer-to" : "intellicard-core-empty";
+            _popup.PopupClient(Loc.GetString(message), args.User, args.User, PopupType.Medium);
             args.Handled = true;
             return;
         }
+
+        // Starlight-end
 
         if (cardHasAi && (coreHasAi || borgHaveMind)) // Starlight-edit
         {
@@ -477,7 +489,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         UpdateAppearance((ent.Owner, ent.Comp));
 
         if (ent.Comp.RenameOnInsert)
-            _metadata.SetEntityName(ent.Owner, MetaData(args.Entity).EntityName);
+            _metadata.SetEntityName(ent.Owner, _nameModifier.GetBaseName(args.Entity));
     }
 
     private void OnHolderConRemove(Entity<StationAiHolderComponent> ent, ref EntRemovedFromContainerMessage args)

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -284,15 +284,24 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         if (args.Args.Target == null) // Starlight-edit
             return;
 
-        if (!TryComp(args.Args.Target.Value, out StationAiHolderComponent? targetHolder)) // Starlight-edit
+        var target = args.Args.Target.Value;
+        if (TryComp<BorgChassisComponent>(target, out var chassis) && chassis.BrainEntity is { } chassisBrain)
+            target = chassisBrain;
+
+        if (!TryComp(target, out StationAiHolderComponent? targetHolder) &&
+            !HasComp<BorgBrainComponent>(target)) // Starlight-edit
             return;
 
         // Starlight-start
 
         var isBorg = HasComp<BorgBrainComponent>(uid);
-        var borgHaveMind = TryComp<MindContainerComponent>(uid, out var mindContainer) && _mind.GetMind(uid, mindContainer) != null;
-        var isBorgTarget = HasComp<BorgBrainComponent>(args.Args.Target.Value);
-        var borgHaveMindTarget = TryComp<MindContainerComponent>(args.Args.Target.Value, out var targetMindContainer) && _mind.GetMind(args.Args.Target.Value, targetMindContainer) != null;
+        var borgMind = uid; // Starlight-edit
+        if (isBorg && _containers.TryGetContainingContainer(uid, out var borgContainer) &&
+            TryComp<BorgChassisComponent>(borgContainer.Owner, out _)) // Starlight-edit
+            borgMind = borgContainer.Owner; // Starlight-edit
+        var borgHaveMind = TryComp<MindContainerComponent>(borgMind, out var mindContainer) && _mind.GetMind(borgMind, mindContainer) != null; // Starlight-edit
+        var isBorgTarget = HasComp<BorgBrainComponent>(target);
+        var borgHaveMindTarget = TryComp<MindContainerComponent>(target, out var targetMindContainer) && _mind.GetMind(target, targetMindContainer) != null;
 
         // basically if the AI is off shunting we wanna force them BACK. simplest way to do that is to fake the event to send them back.
         var slot = component?.Slot;
@@ -301,39 +310,58 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         // Starlight-end
 
         // Try to insert our thing into them
-        if (slot != null && _slots.CanEject(uid, args.User, slot)) // Starlight-edit
+        if (targetHolder != null && slot != null && _slots.CanEject(uid, args.User, slot)) // Starlight-edit
         {
-            if (!_slots.TryInsert(args.Args.Target.Value, targetHolder.Slot, slot.Item!.Value, args.User, excludeUserAudio: true)) // Starlight-edit
-            {
+            if (!_slots.TryInsert(target, targetHolder.Slot, slot.Item!.Value, args.User, excludeUserAudio: true)) // Starlight-edit
                 return;
-            }
 
             args.Handled = true;
             return;
         }
         // Starlight-start: borgs can be downloaded/uploaded
-        else if (isBorgTarget && borgHaveMindTarget && slot?.ContainerSlot is { } containerSlot && containerSlot.ContainedEntity != null)
+        else if (isBorgTarget && !borgHaveMindTarget && slot?.ContainerSlot is { } containerSlot &&
+                 containerSlot.ContainedEntity is { } aiEntity)
         {
-            _mind.ControlMob(args.Args.Target.Value, uid);
-            Del(containerSlot.ContainedEntity);
+            if (!_mind.TryGetMind(aiEntity, out var mindId, out var mind))
+                return;
+
+            _mind.TransferTo(mindId, target, ghostCheckOverride: true, mind: mind);
+            Del(aiEntity);
+            args.Handled = true;
+            return;
         }
         // Starlight-end
 
         // Otherwise try to take from them
-        if (slot != null && _slots.CanEject(args.Args.Target.Value, args.User, targetHolder.Slot)) // Starlight-edit
+        if (targetHolder != null && slot != null && _slots.CanEject(target, args.User, targetHolder.Slot)) // Starlight-edit
         {
             if (!_slots.TryInsert(uid, slot, targetHolder.Slot.Item!.Value, args.User, excludeUserAudio: true)) // Starlight-edit
-            {
                 return;
-            }
 
             args.Handled = true;
         }
         // Starlight-start: borgs can be downloaded/uploaded
-        else if (isBorg && borgHaveMind && targetHolder.Slot.ContainerSlot != null)
+        else if (targetHolder != null && isBorg && !borgHaveMind && targetHolder.Slot.Item is { } aiEntity)
         {
-            var brain = SpawnInContainerOrDrop(DefaultAi, args.Args.Target.Value, targetHolder.Slot.ContainerSlot.ID);
-            _mind.ControlMob(uid, brain);
+            if (!_mind.TryGetMind(aiEntity, out var mindId, out var mind))
+            {
+                return;
+            }
+
+            _metadata.SetEntityName(uid, MetaData(aiEntity).EntityName); // Starlight-edit
+            _mind.TransferTo(mindId, uid, ghostCheckOverride: true, mind: mind);
+            Del(aiEntity);
+            args.Handled = true;
+            return;
+        }
+        else if (targetHolder != null && isBorg && borgHaveMind && targetHolder.Slot.ContainerSlot != null)
+        {
+            var brain = SpawnInContainerOrDrop(DefaultAi, target, targetHolder.Slot.ContainerSlot.ID);
+            if (!_mind.TryGetMind(borgMind, out var mindId, out var mind)) // Starlight-edit
+                return; // Starlight-edit
+            _metadata.SetEntityName(brain, MetaData(borgMind).EntityName); // Starlight-edit
+            _metadata.SetEntityName(target, MetaData(borgMind).EntityName); // Starlight-edit
+            _mind.TransferTo(mindId, brain, ghostCheckOverride: true, mind: mind); // Starlight-edit
         }
         // Starlight-end
     }
@@ -359,11 +387,23 @@ public abstract partial class SharedStationAiSystem : EntitySystem
 
         // Starlight-start: Downloadable borgs
 
-        var isBorg = HasComp<BorgBrainComponent>(args.Target.Value);
-        var isShunted = TryComp<StationAIShuntComponent>(args.Target.Value, out var shunt) && shunt.Return != null;
-        var borgHaveMind = TryComp<MindContainerComponent>(args.Target.Value, out var mindContainer) && mindContainer.HasMind;
+        var borgTarget = args.Target.Value;
+        var borgMindTarget = borgTarget; // Starlight-edit
+        if (TryComp<BorgChassisComponent>(borgTarget, out var chassis) && chassis.BrainEntity is { } chassisBrain)
+            borgTarget = chassisBrain;
+
+        var isBorg = HasComp<BorgBrainComponent>(borgTarget);
+        var isShunted = TryComp<StationAIShuntComponent>(borgTarget, out var shunt) && shunt.Return != null;
+        var borgHaveMind = TryComp<MindContainerComponent>(borgMindTarget, out var mindContainer) && mindContainer.HasMind; // Starlight-edit
 
         // Starlight-end
+
+        if (targetHolder == null && !isBorg) // Starlight-edit
+        {
+            _popup.PopupClient(Loc.GetString("intellicard-core-empty"), args.User, args.User, PopupType.Medium);
+            args.Handled = true;
+            return;
+        }
 
         if (cardHasAi && (coreHasAi || borgHaveMind)) // Starlight-edit
         {
@@ -399,7 +439,11 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         }
         // Starlight-end
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, cardHasAi ? intelliComp.UploadTime : intelliComp.DownloadTime, new IntellicardDoAfterEvent(), args.Target, ent.Owner)
+        var doAfterTarget = args.Target.Value;
+        if (TryComp<BorgChassisComponent>(doAfterTarget, out var doAfterChassis) && doAfterChassis.BrainEntity is { } doAfterBrain)
+            doAfterTarget = doAfterBrain;
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, cardHasAi ? intelliComp.UploadTime : intelliComp.DownloadTime, new IntellicardDoAfterEvent(), doAfterTarget, ent.Owner)
         {
             BreakOnDamage = true,
             BreakOnMove = true,

--- a/Resources/Locale/en-US/intellicard/intellicard.ftl
+++ b/Resources/Locale/en-US/intellicard/intellicard.ftl
@@ -1,4 +1,5 @@
 # General
 intellicard-core-occupied = Target is already occupied by another digital consciousness.
 intellicard-core-empty = Target has no digital consciousness to download.
+intellicard-cannot-transfer-to = Target cannot receive a digital consciousness.
 intellicard-shunted = This borg brain can't be downloaded! It's occupied by AI!

--- a/Resources/Locale/en-US/name-identifier.ftl
+++ b/Resources/Locale/en-US/name-identifier.ftl
@@ -6,4 +6,5 @@ name-identifier-format-positronic-brain = PB-{$number}
 name-identifier-format-silicon = Si-{$number}
 name-identifier-format-xenoborg = Xi-{$number}
 name-identifier-format-station-ai = AI-{$number}
+name-identifier-format-intellicard = IC-{$number}
 name-identifier-format-telepad = TELE-{$number}

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -174,6 +174,8 @@
           Rebooting: { state: dead }
           Dead: { state: dead }
   - type: Intellicard
+  - type: NameIdentifier #Starlight: Added to give intellicards unique identifiers
+    group: Intellicard
   - type: ForceQuickDraw #Starlight don't pull the posi-brain out when the intelecard is in a pocket and hotkey used to bring it to a player hand
 
 - type: entity
@@ -357,6 +359,8 @@
   parent: PlayerStationAiEmpty
   suffix: Job spawn
   components:
+  - type: NameIdentifier
+    group: StationAi
   - type: ContainerSpawnPoint
     containerId: station_ai_mind_slot
     job: StationAi

--- a/Resources/Prototypes/name_identifier_groups.yml
+++ b/Resources/Prototypes/name_identifier_groups.yml
@@ -42,6 +42,12 @@
   maxValue: 999
 
 - type: nameIdentifierGroup
+  id: Intellicard #Starlight: Adding Intellicard name identifier
+  format: name-identifier-format-intellicard
+  minValue: 100
+  maxValue: 999
+
+- type: nameIdentifierGroup
   id: XenoArtifactNode
   minValue: 0
   maxValue: 999


### PR DESCRIPTION
## Short description
Fixing dead-end error that makes it impossible to move an AI to anything else than an intellicard.
Unify naming convention of AI core and Intellicard with silicon ID-generation.
Letting (posi/mmi)brains be base for naming of silicons like borgs.

## Why we need to add this
This is mostly a fix and cleanup.
Balancing impact would be:
- The fixed possibility to transfer intelligences from but also to posi/mmi

## Media (Video/Screenshots)
<img width="713" height="556" alt="image" src="https://github.com/user-attachments/assets/7b389fcc-584f-4380-9ceb-23214db611ae" />
<img width="364" height="183" alt="image" src="https://github.com/user-attachments/assets/6dffec50-e43f-4a5c-a8e7-090e838c194f" />
<img width="202" height="71" alt="image" src="https://github.com/user-attachments/assets/41e81179-01e7-4146-aebf-0e177794877e" />
<img width="471" height="258" alt="image" src="https://github.com/user-attachments/assets/9326ef29-4840-48ba-9e93-fa2caa8c98c7" />
<img width="508" height="353" alt="image" src="https://github.com/user-attachments/assets/6f51736e-3bae-4245-b56c-ce6aa36fcc05" />
<img width="460" height="264" alt="image" src="https://github.com/user-attachments/assets/9afa1019-ef59-4485-9e5e-2370b5a61b48" />

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Borg chassis names now synchronize with inserted brains
- tweak: Entity naming (Intellicard/AI core) was unified and fixed
- tweak: Entitys that have their intelligence removed by intellicard, reset to default names
- fix: Intellicard entities can now be transfered to borg/borg brains/MMI as intended
