### PR TITLE
Removes Command access from Internal Affairs Agents

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/iaa.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Representatives/iaa.yml
@@ -23,10 +23,10 @@
   - IAA
   - Brig
   - Maintenance
-#  - Lawyer # Lawyer is now for Lawyers, not IAAs.
+# - Lawyer # Lawyer is now for Lawyers, not IAAs.
   - GenpopEnter
   - GenpopLeave
-  - Command
+# - Command # IAAs are not members of Command.
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Removes `Command` access from IAAs.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This is paired with #5743 - IAAs on Live have Command access, which allows them to:
- make announcements in the Bridge
- set Alert levels

IAAs are **not** members of Commands (and do not even have `Debrief` access!) and should not have access to either of these. Their mapping guidelines have always strictly prohibited mapping any IAA offices behind Command access.

IAAs don't need this access. It should be removed and it should not be added again. They have their own dedicated office spaces on maps where they can operate out of for paperwork, holocalls, and shelter in during emergencies. Failing that, they still have `Brig` access to shelter in Security. There's no need for them to get access to Command areas.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="411" height="148" alt="image" src="https://github.com/user-attachments/assets/f0d826a7-52bb-4227-8724-f9accc0f4df2" />

fig. 1 - Access list.

<img width="446" height="379" alt="image" src="https://github.com/user-attachments/assets/841ac1fc-58c2-477d-95d5-bb4c93781812" />

fig. 2 - No longer able to set alert levels.

<img width="659" height="374" alt="image" src="https://github.com/user-attachments/assets/57620894-cae6-453e-be3b-20548b780025" />

fig. 3 - No longer able to make announcements.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- remove: Internal Affairs Agents no longer have Command access.