### PR TITLE
Fix ItemSwitchState typo

### DIFF
--- a/Content.Shared/_Starlight/ItemSwitch/Components/ItemSwitchComponent.cs
+++ b/Content.Shared/_Starlight/ItemSwitch/Components/ItemSwitchComponent.cs
@@ -65,7 +65,7 @@ public sealed partial class ItemSwitchState : BoundUserInterfaceMessage
     public bool RemoveComponents = true;
 
     [DataField]
-    public bool Hiden = false;
+    public bool Hidden = false;
 
     [DataField]
     public SpriteSpecifier? Sprite;

--- a/Content.Shared/_Starlight/ItemSwitch/Components/ItemSwitchComponent.cs
+++ b/Content.Shared/_Starlight/ItemSwitch/Components/ItemSwitchComponent.cs
@@ -64,6 +64,10 @@ public sealed partial class ItemSwitchState : BoundUserInterfaceMessage
     [DataField]
     public bool RemoveComponents = true;
 
+    /// <summary>
+    /// If true, this state is hidden from the activation verb menu and unreachable via normal cycling.
+    /// It can only be entered by direct <c>Switch</c> calls.
+    /// </summary>
     [DataField]
     public bool Hidden = false;
 

--- a/Content.Shared/_Starlight/ItemSwitch/SharedItemSwitchSystem.cs
+++ b/Content.Shared/_Starlight/ItemSwitch/SharedItemSwitchSystem.cs
@@ -52,7 +52,7 @@ public abstract partial class SharedItemSwitchSystem : EntitySystem
         if (args.Handled || !ent.Comp.OnUse || ent.Comp.States.Count == 0) return;
         args.Handled = true;
 
-        if (ent.Comp.States.TryGetValue(Next(ent), out var state) && state.Hiden)
+        if (ent.Comp.States.TryGetValue(Next(ent), out var state) && state.Hidden)
             return;
 
         Switch((ent, ent.Comp), Next(ent), args.User, predicted: ent.Comp.Predictable);
@@ -67,7 +67,7 @@ public abstract partial class SharedItemSwitchSystem : EntitySystem
 
         foreach (var state in ent.Comp.States)
         {
-            if (state.Value.Hiden)
+            if (state.Value.Hidden)
                 continue;
             args.Verbs.Add(new ActivationVerb()
             {
@@ -89,7 +89,7 @@ public abstract partial class SharedItemSwitchSystem : EntitySystem
 
         args.Handled = true;
 
-        if (ent.Comp.States.TryGetValue(Next(ent), out var state) && state.Hiden)
+        if (ent.Comp.States.TryGetValue(Next(ent), out var state) && state.Hidden)
             return;
 
         Switch((ent.Owner, ent.Comp), Next(ent), args.User, predicted: ent.Comp.Predictable);

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/OuterClothing/armor.yml
@@ -44,7 +44,7 @@
       states:
         Stealth: !type:ItemSwitchState
           verb: Stealth
-          hiden: true
+          hidden: true
           sprite:
             sprite: _Starlight/Clothing/OuterClothing/Armor/abductor.rsi
             state: icon
@@ -66,7 +66,7 @@
 
         Combat: !type:ItemSwitchState
           verb: Combat
-          hiden: true
+          hidden: true
           sprite:
             sprite: _Starlight/Clothing/OuterClothing/Armor/abductor.rsi
             state: combat-icon
@@ -364,13 +364,13 @@
       states:
         inactive: !type:ItemSwitchState
           verb: Inactive
-          hiden: true
+          hidden: true
           sprite:
             sprite: _Starlight/Clothing/OuterClothing/Armor/reactive.rsi
             state: icon
         active: !type:ItemSwitchState
           verb: Active
-          hiden: true
+          hidden: true
           sprite:
             sprite: _Starlight/Clothing/OuterClothing/Armor/reactive.rsi
             state: active-icon


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Rename ```ItemSwitchState.Hiden``` to ```ItemSwitchState.Hidden``` to fix typo introduced in abductor vest work (4637ae8742). The YAML key changes from ```hiden``` to ```hidden```. Any downstream fork prototype using hiden: will need updating.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

Fix typo.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->

:cl: OMEGA
- fix: Typo in ItemSwitch.