### PR TITLE
Adjust weights on RR vs Teach a Lesson traitor antag objectives

### DIFF
--- a/Resources/Prototypes/Objectives/objectiveGroups.yml
+++ b/Resources/Prototypes/Objectives/objectiveGroups.yml
@@ -57,10 +57,10 @@
 - type: weightedRandom
   id: TraitorObjectiveGroupKill
   weights:
-    KillRandomPersonObjective: 1
-    KillRandomHeadObjective: 0.25
-    TeachRandomPersonObjective: 1 #Starlight Teach them a lesson
-    TeachRandomHeadObjective: 0.25 # Starlight Teach them a lesson
+    KillRandomPersonObjective: 0.75 # Starlight-start
+    KillRandomHeadObjective: 0.19
+    TeachRandomPersonObjective: 1.25
+    TeachRandomHeadObjective: 0.31 # Starlight-end Teach them a lesson and adjust weights
 
 - type: weightedRandom
   id: TraitorObjectiveGroupState


### PR DESCRIPTION
## Short description
I propose we adjust the weights on round removal kill objectives vs teach a lesson kill objectives, to slightly lower the former (50% chance to ~38%) and raise the latter (50% chance to ~62%) while maintaining the 80%/20% crew to head split. 

## Why we need to add this
In general, round removal kills are less fun for everyone involved. There is less chance medical will have anything to do on a gibbed body, it is an extra level of stress/complication for the antags which places additional guard rails on which strategies that are viable and how TC can be spent, and the person who is being killed will not want to be round removed just because an antag ripped out their brain and ate it raw (which is already very questionable for MRP). Meanwhile, teach a lesson does not remove a player from the game and instead creates new rp/gameplay experiences between sec->victim and med->victim. The bar for completion is also lower, so people will be more tempted to go for special or flashy kill methods, while having more resources at their disposal to do so. This increase in chaos should also increase the amount of crew that is affected by traitors (leading to more antag to crew interactions not involving being a hit target) to makeup for the decrease in RR. There was some conversation [in a discord channel in favour of this](https://discord.com/channels/1272545509562777621/1524872608322158662/1540028205778472982), IE someone pointed out that other antags (pclone, terminator) also increase the amounts of RR. 

## Media (Video/Screenshots)
Na

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Common
- tweak: Increase rate of "Teach A Lesson" objectives and decreased rate of RR objectives relatively.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
