### PR TITLE
Anti-Anomaly Zone Markers

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Markers/anti_anomaly_zone.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/anti_anomaly_zone.yml
@@ -1,0 +1,51 @@
+- type: entity
+  name: anti anomaly zone
+  description: Anomalies will not be able to appear within a 10 block radius of this point.
+  id: AntiAnomalyZone
+  suffix: "range 10"
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    sprite: Structures/Specific/Anomalies/ice_anom.rsi
+    layers:
+      - state: anom
+      - sprite: Markers/cross.rsi
+        state: pink
+  - type: AntiAnomalyZone
+    zoneRadius: 10
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone20
+  suffix: "range 20"
+  description: Anomalies will not be able to appear within a 20 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 20
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone30
+  suffix: "range 30"
+  description: Anomalies will not be able to appear within a 30 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 30
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone40
+  suffix: "range 40"
+  description: Anomalies will not be able to appear within a 40 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 40
+
+- type: entity
+  parent: AntiAnomalyZone
+  id: AntiAnomalyZone50
+  suffix: "range 50"
+  description: Anomalies will not be able to appear within a 50 block radius of this point.
+  components:
+  - type: AntiAnomalyZone
+    zoneRadius: 50


### PR DESCRIPTION
## Short description
Readds "Anti-Anomaly Zone Markers". These markers were removed by Wizden in https://github.com/space-wizards/space-station-14/pull/24634 but the code to create Anti-Anomaly Zones was left intact and functional, just unused.

Anti-Anomaly Zone Markers are mapping tools that prevent Anomalies from generating within a specified range (10, 20, 30, 40, or 50 tiles radius).

## Why we need to add this
Extremely useful mapping tool to control where Anomalies can generate. Some maps like Kiloton and Sepulturum have very large asteroid areas. If an Anomaly generates in these areas, it's basically a dead end that never gets found by players.

Depending on what mapping standards are decided, the smaller range versions of these _could_ also be mapped at Arrivals, Supermatter, and Main Engine rooms to prevent unavoidable Singuloose/Tesloose/Delam, but this would be up to @CawsForConcern 

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Re-added Anti-Anomaly Zone Markers for Mapping. These markers prevent Anomalies from generating within a radius of them. Primary use case would be the large asteroid areas of Kiloton and Sepulturum where an Anomaly would literally never be found by players.

