### PR TITLE
(Novo Lobster) Very subtle volume Increase to snow storm ambience

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
@@ -94,4 +94,4 @@
       path: /Audio/Effects/Weather/snowstorm.ogg
       params:
         loop: true
-        volume: -12 # quiet ambience rather than in-your-face wind
+        volume: -9.5 # quiet ambience rather than in-your-face wind

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
@@ -94,4 +94,4 @@
       path: /Audio/Effects/Weather/snowstorm.ogg
       params:
         loop: true
-        volume: -9.9 # quiet ambience rather than in-your-face wind
+        volume: -10 # quiet ambience rather than in-your-face wind

--- a/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
+++ b/Resources/Prototypes/_Starlight/Entities/StatusEffects/weather.yml
@@ -94,4 +94,4 @@
       path: /Audio/Effects/Weather/snowstorm.ogg
       params:
         loop: true
-        volume: -9.5 # quiet ambience rather than in-your-face wind
+        volume: -9.9 # quiet ambience rather than in-your-face wind


### PR DESCRIPTION
## Short description
Slightly boost the ambience volume of Novo Lobster's snow storm so it's actually audible.
<!-- What do you propose to change with your PR? -->

## Why we need to add this
Relative to everything else happening in the game, it's way too quiet. This intends to boost it very subtly.

Up until now I didn't know that Novo Lobster had an ambience because it's very hard to hear.
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Way
- tweak: (Novo Lobster) Snow Storm ambience is slightly louder.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
