### PR TITLE
Digestive Chems Fix

### DIFF
--- a/Content.Shared/_Starlight/Medical/Body/Components/MetabolizerComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Components/MetabolizerComponent.cs
@@ -55,8 +55,7 @@ public sealed partial class MetabolizerComponent : Component
         {
             SolutionName = "stomach",
             SolutionOnBody = false,
-            TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName,
-            TransferEfficacy = 0.5
+            TransferSolutionName = BloodstreamComponent.DefaultBloodSolutionName
         },
         ["Bloodstream"] = new()
         {
@@ -134,7 +133,7 @@ public sealed partial class MetabolismSolutionEntry
     /// Reagents transferred by this metabolizer will transfer at this rate if they don't have a metabolism
     /// </summary>
     [DataField]
-    public FixedPoint2 TransferRate = 0.25;
+    public FixedPoint2 TransferRate = 1.0;
 
     /// <summary>
     /// The percentage of transferred reagents that actually make it to the next step in metabolism if they don't have explicit metabolites


### PR DESCRIPTION
## Short description
Makes Digestion no longer destroy half the chems and changes transfer rates to be more punishing.

## Why we need to add this
Oral application of chemicals really shouldn't just randomly destroy half of them, and the needlessly slow transfer rates currently make it outright impossible to overdose from drinking chems. I should not be able to drink an entire jug of dermaline and just *be fine*, purging your stomach like that is *why* ipecac and similar emetives exist.
This change sets the transfer rates at twice the metabolic rate, so oral application of chems makes overdoses more lenient, but possible, returning the use of emetics as an emergency measure, rather than being entirely useless (because ODs are impossible). This would also return the previous application method balance of Pills being slow to work, but portable and easy to portion out for distribution, while injections start working immediately, at the cost of being more intensive to manage.

## Media (Video/Screenshots)
<img width="373" height="598" alt="image" src="https://github.com/user-attachments/assets/5967bb92-8f7e-4630-bac6-15eabbdafd76" />
You can overdose on ingested chems again!

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- tweak: The digestive system no longer destroys half the chemicals passing through it.
- tweak: You can now overdose again from drinking too much.
