### PR TITLE
returned silicon emotes to pAIs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -115,6 +115,7 @@
   - type: Tag
     tags:
     - SiliconEmotes
+    - SiliconEmotesFH #Starlight - Return silicon noises to pAIs
   # Starlight Start
     - CanPilot
   - type: Blindable


### PR DESCRIPTION
## Short description
Returns silicon emotes to pAIs

## Why we need to add this
Justice for pAIs! Too long have we been denied our beeps and buzzes!
In all honesty, this was probably an oversight :sweat_smile: 

## Media (Video/Screenshots)
<img width="448" height="395" alt="image" src="https://github.com/user-attachments/assets/da3f0be6-de90-47d7-b6fa-a8b12fe8b853" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Fixed faulty audio unit for pAIs, enabling them to beep and buzz again.
