### PR TITLE
Labelable Wallmounts

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/hand_labeler.yml
@@ -28,6 +28,7 @@
       whitelist:
         components:
           - Item
+          - WallMount # Starlight Edit
         tags:
           - Structure
           - Labelable # Starlight


### PR DESCRIPTION
## Short description
Adds WallMount component to the Hand Labeler whitelist, so all wallmounts can explicitly be labeled always. Air Alarms, Posters, Signs, Fire Alarms, Neon Signs, and anything we add in the future.

## Why we need to add this
It's good practice to label Air Alarms for Atmos/Engie, but it's made even more tedious and shit for mappers by needing to use right-click verbs for it. Plus, players should be able to edit them mid-round if they rebuild a room or add a new alarm to an area.

This method just future-proofs it for the rest of time so any wallmounted machine we might add, can be labeled. IE if we port a version of the in-dev Wizden smart-airlock control panels that suck all the air out of a room before unbolting the exterior airlock into space.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- tweak: All wallmounts can now be labeled with a hand labeler, such as Air Alarms, Neon Signs, Signs, Fire Alarms, etc.

