### PR TITLE
increased slightly the prying speed of NT_cane, and added prying sound.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/cane_nt.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Melee/cane_nt.yml
@@ -85,7 +85,9 @@
     malus: 0.300
   - type: MobilityAid
   - type: Prying
-    speedModifier: 0.25
+    useSoundOnDoafter: /Audio/_Starlight/Machines/airlock_pry.ogg
+    playSoundOnDoafter: true
+    speedModifier: 0.5
   - type: ESSparkOnItemToggle
     count: 1
     sparkPrototype: SLEffectSparksBaton


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->

Buffing the Crowbar speed of the Fancy Cane (CaneNT) and adding a correct prying sound while opening airlock.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

First, to add a proper sound for prying. nothing much to say about it. second, we can already pry door with the fancy cane, but still almost as slow of prying with hands. In my mind, i don't really see the representative of a mega corporation walking around with a tool belt or crowbar, and we all know how much a crowbar is important in Space station 14, you can't separate yourself from it.
The cane is not intended to pry as fast a regular crowbar, but as a "robust cane made to repelling assailant", i expect it to be able to pry almost as fast a crowbar does.
After doing a suggestion on the starlight discord, people was interested by the idea, with no complaint at the moment i open the PR.

regular crowbar pry in approximately 2 second, CaneNT after change approximately 3 second. CaneNT before change was approximately 6.30 second. Bare hands prying time is 15 second in comparison. 

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
before
<img width="465" height="39" alt="image" src="https://github.com/user-attachments/assets/90f260fb-4865-4f2d-8961-fe54bd917c95" />

after
<img width="660" height="84" alt="image" src="https://github.com/user-attachments/assets/37025fad-a3fb-4009-ab0c-826893f404e0" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: ANATHELARCTEK
- tweak: prying with NTR cane is quicker, but still slower than crowbar.
- add: prying sound now play while prying with NTR cane.
