### PR TITLE
Remove the frezon trigger from artifacts

### DIFF
--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -132,17 +132,15 @@
     reagents:
     - NitrousOxide
 
-# Starlight-start
-#- type: xenoArchTrigger
-#  id: TriggerFrezon # Removing this because it just makes the node uncompletable in the majority of cases
-#  tip: xenoarch-trigger-tip-frezon
-#  components:
-#  - type: XATGas
-#    targetGas: Frezon
-#  - type: XATReactive
-#    reagents:
-#    - Frezon
-# Starlight-end
+- type: xenoArchTrigger
+  id: TriggerFrezon
+  tip: xenoarch-trigger-tip-frezon
+  components:
+  - type: XATGas
+    targetGas: Frezon
+  - type: XATReactive
+    reagents:
+    - Frezon
 
 - type: xenoArchTrigger
   id: TriggerRadiation

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -11,7 +11,7 @@
     TriggerN2O: 0.5
     TriggerTritium: 0.1
     TriggerAmmonia: 0.1
-    TriggerFrezon: 0.1 # Starlight-edit: Removing this because it just makes the node uncompletable in the majority of cases
+    #TriggerFrezon: 0.1 # Starlight-edit: Removing this because it just makes the node uncompletable in the majority of cases
     TriggerRadiation: 1
     TriggerPressureHigh: 0.5
     TriggerPressureLow: 1

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -132,15 +132,17 @@
     reagents:
     - NitrousOxide
 
-- type: xenoArchTrigger
-  id: TriggerFrezon
-  tip: xenoarch-trigger-tip-frezon
-  components:
-  - type: XATGas
-    targetGas: Frezon
-  - type: XATReactive
-    reagents:
-    - Frezon
+# Starlight-start
+#- type: xenoArchTrigger
+#  id: TriggerFrezon # Removing this because it just makes the node uncompletable in the majority of cases
+#  tip: xenoarch-trigger-tip-frezon
+#  components:
+#  - type: XATGas
+#    targetGas: Frezon
+#  - type: XATReactive
+#    reagents:
+#    - Frezon
+# Starlight-end
 
 - type: xenoArchTrigger
   id: TriggerRadiation

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -11,7 +11,7 @@
     TriggerN2O: 0.5
     TriggerTritium: 0.1
     TriggerAmmonia: 0.1
-    TriggerFrezon: 0.1
+    TriggerFrezon: 0.1 # Starlight-edit: Removing this because it just makes the node uncompletable in the majority of cases
     TriggerRadiation: 1
     TriggerPressureHigh: 0.5
     TriggerPressureLow: 1

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Materials/misc.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Materials/misc.yml
@@ -7,8 +7,8 @@
     - type: XenoArtifact
       priceMultiplier: 1.5
       nodeCount:
-        min: 23
-        max: 24
+        min: 22
+        max: 23
     - type: Sprite
       sprite: _Starlight/Objects/Materials/abyss.rsi
       state: abyss_core


### PR DESCRIPTION
## Short description
This removes the frezon trigger from the artifact trigger pool. It also lowers the min/max amount of abyssium core nodes to reflect the reduction in number of triggers.

## Why we need to add this
Science can basically never do this unless they get lucky enough to have an artifact that produces frezon. Even if atmos does have frezon, it's probably better to just sell it and buy a new artifact than to bother using it on the frezon trigger. All the trigger does is cause frustration when one of the starting artifacts is useless because of a frezon trigger, which often forces science to spend its limited early budget on a new artifact.

## Media (Video/Screenshots)

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: VBlankFF
- remove: Removed the frezon trigger from artifacts.
- tweak: Lowered the min-max nodes of abyssal cores from 23-24 to 22-23.
