### PR TITLE
Fix reactor guidebook

### DIFF
--- a/Resources/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearReactor.xml
+++ b/Resources/ServerInfo/_FarHorizons/Guidebook/Engineering/NuclearReactor.xml
@@ -31,7 +31,7 @@
 
 	Handling hot Reactor Rods can cause serious burns.
 
-	If it is hotter than [color=orange][protodata="CerenkiteReactorFuelRod" comp="ReactorPart" member="GuidebookHotTemp"/]C[/color] you'll need gloves to be able to handle them. At [color=orange][protodata="CerenkiteReactorFuelRod" comp="ReactorPart" member="GuidebookBurnTemp"/]C[/color], not even gloves will protect you.
+	If it is hotter than [color=orange][protodata="CerenkiteReactorFuelRod" comp="ReactorPart" member="HotTemp"/]C[/color] you'll need gloves to be able to handle them. At [color=orange][protodata="CerenkiteReactorFuelRod" comp="ReactorPart" member="BurnTemp"/]C[/color], not even gloves will protect you.
 
 	There are four different types of Reactor Rods that can be manufactured from a variety of [textlink="materials" link="NuclearMaterials"] and placed into the Reactor grid: Fuel Rods, Control Rods, Gas Channels, and Heat Exchangers.
 


### PR DESCRIPTION
## Short description
Fix non-existent references in the nuclear reactors guidebook. 

## Why we need to add this
bug fixes, threw 1 million exceptions locally.

## Media (Video/Screenshots)
now:
<img width="487" height="48" alt="dotnet_OqbPcbUPQI" src="https://github.com/user-attachments/assets/0756320c-9597-4136-8a24-286d117242da" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- fix: missing values for the reactor guidebook temps.