### PR TITLE
can now put jugs in Chem_bag

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chemistry/chem_bag.yml
@@ -15,7 +15,7 @@
   - type: Item
     size: Ginormous
   - type: Storage
-    maxItemSize: Normal # allow up to 5 large beakers / 10 beakers / 10 pill canisters
+    maxItemSize: Normal # allow up to 5 large beakers / 10 beakers / 10 pill canisters / 4 Jugs
     grid:
     - 0,0,4,3
     quickInsert: true
@@ -26,6 +26,7 @@
         - Pill
         - Patch
       tags:
+        - ChemDispensable
         - Document
         - PillCanister
         - Bottle


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
With this PR you will now be able to put jugs in the chemistry_bag
## Why we need to add this
Being able to put Jugs in chemistry bags will function as a Quality of Life change. Jugs are a tool Chemist use to do their job alongside Beakers, Vials, Syringes etc the addition of jugs to the bag makes sense given the fact that its a chemistry tool alongside making things slightly easier for Chemist by giving them an extra container to put their jugs in.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
<img width="650" height="209" alt="Screenshot 2026-08-23 211106" src="https://github.com/user-attachments/assets/b34feb21-5645-41f0-941a-d7b55bf9e583" />
<img width="1774" height="1156" alt="Screenshot 2026-08-23 211201" src="https://github.com/user-attachments/assets/6789be1b-8bbe-4090-9fbe-7b9849085cc1" />


-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X ] I do not require assistance to complete the PR.
- [X ] Before posting/requesting review of a PR, I have verified that the changes work.
- [X ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X ] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
🆑 Adonalsium



:cl: STARLIGHT TEAM
- tweak: modified Chemistry bags so that jugs can now fit in them.
-->
