### PR TITLE
Syndicate Bomb Tweak

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -126,7 +126,7 @@
     - type: Explosive
       explosionType: HardBomb
       totalIntensity: 4000.0
-      intensitySlope: 10
+      intensitySlope: 1 # Starlight: Changed from 10 to 1 to make the explosion more spread out
       maxIntensity: 75
     - type: StaticPrice
       price: 10000 # Good luck!


### PR DESCRIPTION
## Short description
Changing the syndicate bomb to make a larger less concentrated explosion.

## Why we need to add this
A suggestion came up about how syndicate bombs were sorta underwhelming with the fact that they dont cause large explosions and instead feel like a concentrated bomb for specific areas. This goes against what the uplink description says about it being a "large explosion". This change is to make it more align with the large explosion its meant to be. https://discord.com/channels/1272545509562777621/1540933818062606376

## Media (Video/Screenshots)
<img width="681" height="628" alt="image" src="https://github.com/user-attachments/assets/caf4842b-1ca9-47b9-80e6-dbbed35aace9" />
The blue tiles are the original size of the syndicate bomb.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: The syndicate bomb is less concentrated with its explosion, focusing more on making a large explosion than entirely deleting an area.
