### PR TITLE
Uranium Rod De-research

### DIFF
--- a/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
@@ -10,7 +10,7 @@
   id: ReactorPartsBasic
   recipes:
   - CerenkiteReactorFuelRod
-  - UraniumReactorFuelRod
+  - UraniumReactorFuelRod # Starlight
   - BohrumReactorControlRod
   - SteelReactorControlRod
   - BrassReactorControlRod

--- a/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
@@ -27,7 +27,6 @@
 - type: latheRecipePack
   id: ReactorFuelRods
   recipes:
-  - UraniumReactorFuelRod
   - PlutoniumReactorFuelRod
   - BananiumReactorFuelRod
   - PlasmaReactorFuelRod

--- a/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
+++ b/Resources/Prototypes/_FarHorizons/Recipes/Lathes/Packs/engineering.yml
@@ -10,6 +10,7 @@
   id: ReactorPartsBasic
   recipes:
   - CerenkiteReactorFuelRod
+  - UraniumReactorFuelRod
   - BohrumReactorControlRod
   - SteelReactorControlRod
   - BrassReactorControlRod

--- a/Resources/Prototypes/_FarHorizons/Research/industrial.yml
+++ b/Resources/Prototypes/_FarHorizons/Research/industrial.yml
@@ -11,7 +11,6 @@
   - NuclearFabricatorMachineCircuitboard
   - NuclearReactorMonitorComputerCircuitboard
   - GasTurbineMonitorComputerCircuitboard
-  - UraniumReactorFuelRod
   - PlasmaReactorFuelRod
   - UraniumGlassReactorFuelRod
   - SilverReactorControlRod


### PR DESCRIPTION
## Short description
Makes the uranium rod a non-research item.

## Why we need to add this
Uranium fuel is the classic nuclear fuel with the least technical challenges to use. It doesn't make sense to require research if the cerenkite rod exists as a zero research item.
Additionally, if there is no plasma to make cerenkite but engi has uranium, they are no longer shit out of luck because sci exploded.

## Media (Video/Screenshots)
<img width="736" height="496" alt="image" src="https://github.com/user-attachments/assets/38e38854-abd6-48b5-8dec-5fb19d56ec01" />
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: OJG
- tweak: The uranium fuel rod no longer requires research to produce.

