### PR TITLE
Fixes small mistake in the cultist metrics

### DIFF
--- a/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/CosmicCultRuleSystem.cs
@@ -571,6 +571,7 @@ public sealed partial class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRule
         args.AddLine(Loc.GetString("cosmiccult-roundend-monument-stage", ("stage", component.CurrentTier)));
 
         _cultistCounter.WithLabels(component.WinType.ToString()).Inc();
+        _convertsGauage.Set(0);
     }
 
     public void IncrementCultObjectiveEntropy(Entity<CosmicCultComponent> ent)


### PR DESCRIPTION
## Short description
Properly resets the converts counter at the end of the round

## Why we need to add this
Cuz i forgot to properly reset...

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
