### PR TITLE
Horrific Necktie Description Changes

### DIFF
--- a/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
@@ -22,8 +22,7 @@ ghost-role-information-derelict-borgi-name = Derelict Borgi
 ghost-role-information-derelict-borgi-desc = You are a regular borgi that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
 ghost-role-information-horrific-tie-name = Horrific Necktie
-ghost-role-information-horrific-tie-description = You are a horrific necktie from Disco Elysium.
-ghost-role-information-horrific-tie-rules = [bold][color=cyan]ADMIN WARNING: Do not take this role if you don't know what Disco Elysium is and how to roleplay as necktie from it.[/color][/bold]
+ghost-role-information-horrific-tie-description = You are a horrific necktie, play into your wearers hedonistic and carefree desires, a self-centered devil on their neck!
 
 ghost-role-information-space-courier-trunk-name = Space Courier Trunk pAI
 ghost-role-information-space-courier-trunk-description = You are the personal AI included inside of a space courier's trunk.

--- a/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Starlight/ghost/roles/ghost-role-component.ftl
@@ -22,7 +22,7 @@ ghost-role-information-derelict-borgi-name = Derelict Borgi
 ghost-role-information-derelict-borgi-desc = You are a regular borgi that got lost in space. After years of exposure to ion storms you find yourself near a space station.
 
 ghost-role-information-horrific-tie-name = Horrific Necktie
-ghost-role-information-horrific-tie-description = You are a horrific necktie, play into your wearers hedonistic and carefree desires, a self-centered devil on their neck!
+ghost-role-information-horrific-tie-description = You are a horrific necktie, play into your wearer's hedonistic and carefree desires, a self-centered devil on their neck!
 
 ghost-role-information-space-courier-trunk-name = Space Courier Trunk pAI
 ghost-role-information-space-courier-trunk-description = You are the personal AI included inside of a space courier's trunk.

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Neck/cloaks.yml
@@ -280,13 +280,12 @@
   parent: ClothingNeckBase
   id: ClothingNeckHorrific
   name: horrific necktie
-  description: The necktie is adorned with a garish pattern. It's disturbingly vivid. Somehow you feel as if it would be wrong to ever take it off. It's your friend now. You will betray it if you change it for some boring scarf.
+  description: The necktie is adorned with a garish pattern. It's disturbingly vivid. Somehow you feel as if it would be wrong to ever take it off. It's your friend now. You dont need to listen to it, but it makes some good points.
   components:
   - type: GhostRole
     makeSentient: true
     name: ghost-role-information-horrific-tie-name
     description: ghost-role-information-horrific-tie-description
-    rules: ghost-role-information-horrific-tie-rules
     mindRoles:
     - MindRoleGhostRoleNecktie
     raffle:

--- a/Resources/Prototypes/_Starlight/Entities/Clothing/Neck/cloaks.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Clothing/Neck/cloaks.yml
@@ -280,7 +280,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckHorrific
   name: horrific necktie
-  description: The necktie is adorned with a garish pattern. It's disturbingly vivid. Somehow you feel as if it would be wrong to ever take it off. It's your friend now. You dont need to listen to it, but it makes some good points.
+  description: The necktie is adorned with a garish pattern. It's disturbingly vivid. Somehow you feel as if it would be wrong to ever take it off. It's your friend now. You don't need to listen to it, but it makes some good points.
   components:
   - type: GhostRole
     makeSentient: true


### PR DESCRIPTION
Clears up the horrific necktie ghostrole to not be reliant on disco elysium knowledge and makes the purpose of it clearer.

## Short description
Horrific necktie role/item descriptions

Role Description: You are a horrific necktie, play into your wearers hedonistic and carefree desires, a self-centered devil on their neck!

Item Description: The necktie is adorned with a garish pattern. It's disturbingly vivid. Somehow you feel as if it would be wrong to ever take it off. It's your friend now. You don't need to listen to it, but it makes some good points.

## Why we need to add this
Clarity of role, a role shouldn't need a disclaimer to play another game to understand it.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- tweak: Horrific Necktie Role/Item Descriptions.
