### PR TITLE
Fixes not being able to trash medipens

### DIFF
--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Weapons.Melee.Events;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
+using Content.Shared.Disposal.Components; // Starlight
 
 namespace Content.Shared.Chemistry.EntitySystems;
 
@@ -76,6 +77,10 @@ public sealed partial class InjectorSystem : EntitySystem
         args.SpawnInteractionParticles &= injector.Comp.ShowInteractionParticles; // Starlight
 
         if (args.Handled || !args.CanReach || args.Target is not { Valid: true } target)
+            return;
+
+        // Starlight: Don't process disposal units, fixes not being able to trash medipens
+        if (HasComp<DisposalUnitComponent>(target))
             return;
 
         // Is the target a mob? If yes, use a do-after to give them time to respond.

--- a/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
+++ b/Content.Shared/Chemistry/EntitySystems/InjectorSystem.cs
@@ -22,7 +22,7 @@ using Content.Shared.Weapons.Melee.Events;
 using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
-using Content.Shared.Disposal.Components; // Starlight
+using Content.Shared.Disposal.Components;
 
 namespace Content.Shared.Chemistry.EntitySystems;
 


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR fixes not being able to insert medipens (all varieties, both unused and expended) into disposal units as it would give an error stating "You aren't able to transfer into the disposal unit!" if you tried.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's really stupid that to throw away medipens after using them you need to throw them at a disposal unit repeatedly until you don't miss. Some people also don't know about this workaround so you just have used pens littered about because people don't know how to throw them away.

You were able to trash syringes and such before without any issues but as they use the same system I've included them in the video for thoroughness to prove they still work. They had an issue where it'd give you an error that you couldn't inject into the disposal unit when you trashed them, but they'd still be inserted. This also fixes that.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/46b6a0c6-f4fb-4be5-9d14-7d86c32fc8d1

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rhapsody (Pepta Vismahl)
- fix: Fixed not being able to trash medipens. You no longer need to be Kobe to clean up after yourself.