### PR TITLE
Allow K9s to be put in pet carriers

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/k9.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/k9.yml
@@ -99,6 +99,7 @@
     tags:
     - DogEmotes
     - DoorBumpOpener
+    - VimPilot
   - type: AlwaysRevolutionaryConvertible
   - type: CanEnterCryostorage
   - type: Zoomies


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Allow security k9s to fit in pet carriers (and vims I guess)

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
<img width="502" height="56" alt="image" src="https://github.com/user-attachments/assets/eab98ad8-6e33-461c-96a7-6c9c3b9cf1ec" />

Pet carriers are gated by if the creature can pilot a vim.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: K9s can now fit in pet carriers.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
