### PR TITLE
Reverting Cryopod nerf from upstream

### DIFF
--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -45,7 +45,7 @@ public sealed partial class CryoPodComponent : Component
     /// (injection interval)
     /// </summary>
     [DataField]
-    public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(2);
+    public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// The timestamp for the next injection.

--- a/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
+++ b/Content.Shared/Medical/Cryogenics/CryoPodComponent.cs
@@ -45,7 +45,7 @@ public sealed partial class CryoPodComponent : Component
     /// (injection interval)
     /// </summary>
     [DataField]
-    public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(1);
+    public TimeSpan BeakerTransferTime = TimeSpan.FromSeconds(1); // Starlight-edit: 1u/1s
 
     /// <summary>
     /// The timestamp for the next injection.


### PR DESCRIPTION
## Short description
Reverting the cryopod inject speed that was introduced in the UI update.

See [the original commit for it](https://github.com/space-wizards/space-station-14/pull/41850), and especially the Balance section, where it is stated:

> Small note concerning gameplay balance: I turned the cryo pod's injection speed down to inject 1u every two seconds, so that it matches the metabolism rate of cryo medicine. **This is intended to help you waste less cryoxadone.**

(Emphasis mine)

## Why we need to add this
Cryopods does not see much use anymore unless used for specialties treatment, because they require unusual procedure, proper setup, are not engaging for the medical crew (dump in and wait), and more importantly are *much slower* than basic chemical treatment.

Before the nerf to inject speed, the pods had the ability to inject two chems at once, which made them more competitive on heal speed compared to alternatives.

I want to reintroduce the ability to inject two chem at once, because while it does not change how fast cryochems themselves are able to heal, it brings back interactivity and more complex interactions which involves dosage and on the fly chem mixing.

I will also note that the reasoning for the original nerf completely falls apart on Starlight considering cryoxadone is amongst the easiest chems to make in huge quantity and originates exclusively from infinitely available components.


## Media (Video/Screenshots)
https://github.com/user-attachments/assets/8ac938ed-9bca-4dcf-a51a-6115e2fcb50e


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [ ] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Glomzubuk
- tweak: Reverted cryopod inject speed back to pre-ui update values.


