### PR TITLE
Switch a jug for a chemical case in the advanced first aid cyborg module

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -1128,15 +1128,17 @@
           - Pill
           - PatchPack # Starlight
           - Patch # Starlight
-    - item: Beaker
-      hand:
-        emptyLabel: borg-slot-chemical-containers-empty
-        emptyRepresentative: Beaker
-        whitelist:
-          components:
-          - FitsInDispenser
-          tags:
-          - ChemDispensable
+    # Starlight-remove - replace first freeform beaker slot with built-in chemical case
+    #- item: Beaker
+    #      hand:
+    #        emptyLabel: borg-slot-chemical-containers-empty
+    #        emptyRepresentative: Beaker
+    #        whitelist:
+    #          components:
+    #          - FitsInDispenser
+    #          tags:
+    #          - ChemDispensable
+    - item: BottleCaseMedical # Starlight
     - item: Beaker
       hand:
         emptyLabel: borg-slot-chemical-containers-empty


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
This PR switches out one of the medical cyborg's advanced first aid module's beaker/jug slots with a 4x2 chemical case for holding bottles. This change is overall roughly similar in raw amount of chemicals stored compared to normal jugs (240u between all eight bottles versus 200u in a regular jug, 300u in a silver jug, or 400u in a golden jug) while allowing the medical cyborg a bit more flexibility in what they're carrying to allow for a limited amount of field triage, or to treat more reasonably in medbay without having to draw from the chem locker every time. This change is locked to the advanced first aid module in order to preserve some amount of gameplay friction before the advanced module becomes available.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This was originally posted as a suggestion on the Discord and appeared to be well received. At the moment one of the most painful aspects of playing a medical cyborg is the poor inventory management and variety in chemicals that they can hold. Allowing the cyborg an internal bottle case to hold a small amount of some different chemicals can help make this more bearable and enable field triage as a medical cyborg, without having to do something like carrying a bag behind them. The limited capacity of bottles ensures that they aren't unbound from medbay, and that the medical cyborg can't just use the bottles to hold more of the same chem than a jug (the total capacity of the bottle case is 240u, which while larger than a jug by 40u, is only available in the advanced module, by which point you're likely to have unlocked silver/gold jugs anyway, meaning this can be interpreted as a net reduction in carry capacity).

This change is _not_ cascaded to the syndicate advanced chemical module as that module opts to replace the pill/bottle slot with a hydraulic pipette (so bottle management isn't possible), and I'm not sure I should remove that given that syndicate medical cyborgs don't have a base chemical module. This also serves to diversify the syndicate advanced chemical module from the advanced first aid module, which is otherwise currently identical besides the pipette and nuke disk tracker. If desired I could add a pill/bottle slot and apply the change to the syndicate module too.

This feature was originally part of the MedTak medical module and was implemented using that as a basis.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/58207182-7fcd-4b9e-b6a1-5831216c8243

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rhapsody (Pepta Vismahl)
- tweak: In the advanced first aid cyborg module, changed a beaker/jug slot to a chemical case slot, allowing bottles to be stored.