### PR TITLE
Changes to ninja threat calls for comms console

### DIFF
--- a/Resources/Locale/en-US/_Starlight/communications/terror.ftl
+++ b/Resources/Locale/en-US/_Starlight/communications/terror.ftl
@@ -10,4 +10,4 @@ terror-eeep = Attention crew, it appears that someone on your station has made a
 terror-strike-team = Attention crew, it appears that someone on your station has made an unexpected communication with a syndicate task force in nearby space.
 terror-abductors = Attention crew, it appears that someone on your station has made an unauthorized communication with a group of unidentified alien  life forms in nearby space.
 terror-terminator = Attention crew, it appears that someone on your station has made an unexpected communication with an unknown metal entity from nearby space.
-terror-strike-team = Attention crew, it appears that someone on your station has made an unexpected communication with a syndicate task force in nearby space.
+terror-honk = Attention crew, it appears that someone on your station has made an unexpected communication with... Oh god, what is that. WHAT IS THA-

--- a/Resources/Locale/en-US/_Starlight/communications/terror.ftl
+++ b/Resources/Locale/en-US/_Starlight/communications/terror.ftl
@@ -1,5 +1,5 @@
 # Ninja threats
-terror-clown = Attention crew, it appears that someone on your station has made an unexpected communication with a bombastic trio of honkies in nearby space.
+terror-disaster-syndies = Attention crew, it appears that someone on your station has made an unexpected communication with a group of horrifically war-torn disaster victims from a nearby syndicate outpost.
 terror-lone-op = Attention crew, it appears that someone on your station has made an unexpected communication with a blood-red marauder in nearby space.
 terror-ninja = Attention crew, it appears that someone on your station has made an unexpected communication with the spider clan in nearby space.
 terror-rod = Attention crew, it appears that someone on your station has made an unexpected communication with an unstoppable force in nearby space.
@@ -7,3 +7,7 @@ terror-rod-slug = Attention crew, it appears that someone on your station has ma
 terror-wizard = Attention crew, it appears that someone on your station has made an unexpected communication with a wizard federation representative in nearby space.
 terror-borgs = Attention crew, it appears that someone on your station has made an unexpected communication with an anomalous shuttle in nearby space.
 terror-eeep = Attention crew, it appears that someone on your station has made an unexpected communication with an adorable sentient tesla in nearby space.
+terror-strike-team = Attention crew, it appears that someone on your station has made an unexpected communication with a syndicate task force in nearby space.
+terror-abductors = Attention crew, it appears that someone on your station has made an unauthorized communication with a group of unidentified alien  life forms in nearby space.
+terror-terminator = Attention crew, it appears that someone on your station has made an unexpected communication with an unknown metal entity from nearby space.
+terror-strike-team = Attention crew, it appears that someone on your station has made an unexpected communication with a syndicate task force in nearby space.

--- a/Resources/Prototypes/_Starlight/ninja_threats.yml
+++ b/Resources/Prototypes/_Starlight/ninja_threats.yml
@@ -1,7 +1,7 @@
 - type: ninjaHackingThreat
-  id: Clown
-  announcement: terror-clown
-  rule: UnknownShuttleHonki
+  id: DisasterSyndies
+  announcement: terror-disaster-syndies
+  rule: UnknownShuttleSyndieEvacPod
 
 - type: ninjaHackingThreat
   id: LoneOp
@@ -42,3 +42,23 @@
   id: Colossus
   announcement: terror-colossus
   rule: ColossusSpawn
+
+- type: ninjaHackingThreat
+  id: StrikeTeam
+  announcement: terror-strike-team
+  rule: UnknownShuttleInstigator
+
+- type: ninjaHackingThreat
+  id: Abductors
+  announcement: terror-abductors
+  rule: AbductorsSpawn
+
+- type: ninjaHackingThreat
+  id: Terminator
+  announcement: terror-terminator
+  rule: TerminatorSpawn
+
+- type: ninjaHackingThreat
+  id: TheClownening
+  announcement: terror-honk
+  rule: GameRuleClownSwarm

--- a/Resources/Prototypes/threats.yml
+++ b/Resources/Prototypes/threats.yml
@@ -3,16 +3,20 @@
   id: NinjaThreats
   weights:
     Dragon: 1
-    Revenant: 1
     # Starlight Start
-    Clown: 1
-    LoneOp: 0.25
-    NinjaBackup: 0.75
-    Rod: 0.75
-    Wizard: 0.1
+    Revenant: 0.75 # Changed from 1 to .75 to aloow other threats to shine a bit more *revenant sucks*
+    DisasterSyndies: 0.8
+    LoneOp: 0.2
+    StrikeTeam: 0.15
+    NinjaBackup: 0.7
+    Rod: 0.8
+    Wizard: 0.25
+    Terminator: 0.2
+    TheClownening: 0.1
     #Xenoborgs: 0.05
-    Eeeplet: 0.5
-    Colossus: 0.2
+    Eeeplet: 0.45
+    Abductors: 0.5
+    Colossus: 0.25
     # Starlight End
 
 - type: ninjaHackingThreat


### PR DESCRIPTION
## Short description
Changing the weights of what can spawn via the ninja comms console interaction, along with adding more things that can possibly happen to have more variety. Alongside removing others that dont need to be there.

## Why we need to add this
The ninja comms console interaction is supposed to spawn a "threat" that will create a "distraction" for the station to deal with while the ninja is doing their objectives. This PR is following a suggestion to remove some unnecessary calls that do not achieve this goal, and replace them with others to fill in the gap left by the removal. I decided on also adjusting the weights of the threats, and adding others into the pool for variety. https://discord.com/channels/1272545509562777621/1542024556213047436

## Media (Video/Screenshots)
<img width="687" height="361" alt="image" src="https://github.com/user-attachments/assets/84186778-dce5-4a43-ad99-24547ce87f04" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added more ninja threats for the communications console interaction.
- remove: Removed the bombastic honks from ninja threats.
- tweak: Changed the weights of some of the ninja threats.
