### PR TITLE
I made it into a alt verb.

### DIFF
--- a/Content.Server/_Starlight/CosmicCult/MonumentSystem.cs
+++ b/Content.Server/_Starlight/CosmicCult/MonumentSystem.cs
@@ -27,6 +27,8 @@ using Robust.Shared.Timing;
 using Content.Shared.Damage.Systems;
 using Robust.Shared.Serialization.Markdown.Mapping;
 using SpawnOnDespawnComponent = Content.Shared._Starlight.Spawners.Components.SpawnOnDespawnComponent;
+using Content.Shared.Verbs;
+using Robust.Shared.Utility;
 
 namespace Content.Server._Starlight.CosmicCult;
 
@@ -61,7 +63,7 @@ public sealed partial class MonumentSystem : SharedMonumentSystem
 
         SubscribeLocalEvent<EvacShuttleLeftEvent>(OnShuttleEvac); // for no more finale once the evac shuttle leaves
         SubscribeLocalEvent<MonumentComponent, InteractUsingEvent>(OnInfuseHeldEntropy);
-        SubscribeLocalEvent<MonumentComponent, ActivateInWorldEvent>(OnInfuseEntropy);
+        SubscribeLocalEvent<MonumentComponent, GetVerbsEvent<AlternativeVerb>>(AddInfuseEntropyVerb);
     }
 
     public override void Update(float frameTime) // This Update() can fit so much functionality in it
@@ -215,13 +217,21 @@ public sealed partial class MonumentSystem : SharedMonumentSystem
     public void UpdateMonumentProgress(Entity<MonumentComponent> ent, Entity<CosmicCultRuleComponent> cult)
         => ent.Comp.CurrentProgress = ent.Comp.TotalEntropy + (cult.Comp.TotalCult * _config.GetCVar(StarlightCCVars.CosmicCultistEntropyValue));
 
-    private void OnInfuseEntropy(Entity<MonumentComponent> uid, ref ActivateInWorldEvent args)
+    private void AddInfuseEntropyVerb(Entity<MonumentComponent> uid, ref GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!args.Complex)
+        if (!args.CanComplexInteract)
             return;
         if (TryComp<CosmicCultComponent>(args.User, out var cultComp) && cultComp.EntropyStored > 0)
         {
-            args.Handled = AddEntropy(uid, (args.User, cultComp));
+            var who = args.User;
+            AlternativeVerb infuse = new()
+            {
+                Text = Loc.GetString("verb-infuse-entropy"),
+                Message = Loc.GetString("verb-infuse-entropy-description"),
+                Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/_Starlight/CosmicCult/Icons/objectives.rsi"),"siphon"),
+                Act = () => AddEntropy(uid, (who, cultComp))
+            };
+            args.Verbs.Add(infuse);
         }
     }
 

--- a/Resources/Locale/en-US/_Starlight/cosmiccult/verbs.ftl
+++ b/Resources/Locale/en-US/_Starlight/cosmiccult/verbs.ftl
@@ -1,0 +1,2 @@
+verb-infuse-entropy = Infuse Entropy
+verb-infuse-entropy-description = Infuses your collected entropy into the monument.

--- a/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCult.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/CosmicCult/CosmicCult.xml
@@ -35,7 +35,7 @@
 
   Using Siphon Entropy on an unsuspecting crewmember will stealthily award you [color=#4cabb3]Entropy[/color]. This will cause a small a portion of the crewmember's health to decay over time.
 
-  You can hold up to 14 Motes of Entropy, and approaching The Monument will automatically deposit all Entropy you posess.
+  You can hold up to 14 Motes of Entropy, and Alt-Clicking The Monument will deposit all Entropy you posess.
 
   <Box>
     <GuideEntityEmbed Entity="CosmicVacuousSpire" Caption="A vacuous spire"/>

--- a/runclientserver-Tools.bat
+++ b/runclientserver-Tools.bat
@@ -1,0 +1,6 @@
+@echo off
+dotnet build Content.Client --configuration Tools
+dotnet build Content.Server --configuration Tools
+
+Start "Client" "runclient-Tools.bat"
+Start "Server" "runserver-Tools.bat"


### PR DESCRIPTION
## Short description
Decent suggest for coscult so I went and implented it

## Why we need to add this
It can be annoying when you wanna do some crafting instead of going to phase 3. now it is a alt-click.

## Media (Video/Screenshots)
<img width="732" height="108" alt="image" src="https://github.com/user-attachments/assets/e6c78bf0-bac7-4530-adb5-ad0dc53dd2b2" />
(ignore broken loc string I fixed it right after)

<img width="1402" height="792" alt="image" src="https://github.com/user-attachments/assets/072bb013-35a5-4c0c-9d42-c6a62d5cf604" />
You can have the UI open without inserting entropy

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl:
- tweak: Cosmic cult now inserts entropy into the monument with a alt-verb allowing you to better choose when you tier up.
