### PR TITLE
DeForest automender

### DIFF
--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/Medical/deforest.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/Medical/deforest.yml
@@ -1,6 +1,6 @@
 # Deforest Vendor stuff
 # Interstellar = Departmental, Planetary = Civilian
-# Better injectors, worse topicals and no automenders
+# Better injectors, worse topicals
 - type: vendingMachineInventory
   id: DeforestInterstellarWallInventory
   startingInventory:

--- a/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/Medical/deforest.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/VendingMachines/Inventories/Medical/deforest.yml
@@ -55,10 +55,10 @@
     HandheldHealthAnalyzer: 3
     ClothingBeltMedical: 3
     ClothingBeltMedicalEMT: 2
-    Gauze: 5
+    Gauze: 4
     DeforestBrutePack: 4
     DeforestOintment: 4
-    Bloodpack: 5
+    Bloodpack: 4
     Tourniquet: 2
     ChemistryBottleEpinephrine: 3
     ChemistryBottleBicaridine: 1
@@ -77,6 +77,8 @@
     ClothingEyesHudMedical: 2
     ClothingEyesEyepatchHudMedical: 2
     ClothingEyeGlassesMedicalPrescription: 2
+    AutoMenderBruteFilled: 1
+    AutoMenderBurnFilled: 1
     SpaceMedipen: 1
   contrabandInventory:
     RadAutoInjector: 2


### PR DESCRIPTION
## Short description
Adds automenders to DeForest's vendor.

## Why we need to add this
The only time this was ever mapped it was promptly removed when it was discovered that it didn't have automenders; wanted to have some variety but if the alternative is these literally never being used, I'd rather drop the variety

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Adds automenders to DeForest's vendor.
