### PR TITLE
K9 can no longer roll antag + display weight

### DIFF
--- a/Resources/Prototypes/Roles/Antags/base.yml
+++ b/Resources/Prototypes/Roles/Antags/base.yml
@@ -68,6 +68,7 @@
   - Warden
   - Detective
   - Brigmedic # Starlight
+  - K9 # Starlight
   - DutyOfficer # Starlight
   - SecurityOfficer
   - SecurityCadet

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -7,6 +7,7 @@
   - !type:RoleTimeRequirement
     role: JobSecurityOfficer
     time: 10h # Starlight
+  displayWeight: 3 # Starlight
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
@@ -98,6 +98,7 @@
   - Warden
   - Detective
   - Brigmedic
+  - K9
   - DutyOfficer
   - SecurityOfficer
   - SecurityCadet

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Security/brigmedic.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Security/brigmedic.yml
@@ -13,6 +13,7 @@
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 15h # You'll realistically clear this if you clear the chem requirements. Brigmed is being changed to be more-paramedical anyways, so this works with that. Chem time should be removed later on.
+  displayWeight: 4
   startingGear: BrigmedicGear
   icon: "JobIconBrigmedic"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Security/duty_officer.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Security/duty_officer.yml
@@ -7,6 +7,7 @@
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
       time: 18000 # 5 hrs
+  displayWeight: 1
   startingGear: DutyOfficerGear
   icon: "JobIconDutyOfficer"
   supervisors: job-supervisors-warden

--- a/Resources/Prototypes/_Starlight/Roles/Jobs/Security/k9.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Jobs/Security/k9.yml
@@ -10,7 +10,7 @@
   - !type:RoleTimeRequirement
     role: JobDetective
     time: 3h
-  displayWeight: 1
+  displayWeight: 2
   icon: "JobIconK9"
   supervisors: job-supervisors-security
   jobEntity: MobK9


### PR DESCRIPTION
## Short description
K9 can no longer roll antag.

## Why we need to add this
Dog don't got hands but IS a job.

## Media (Video/Screenshots)
<img width="231" height="258" alt="image" src="https://github.com/user-attachments/assets/4a58f495-0bbd-4beb-836d-08e38699f586" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Moved K9 in security's display.
- fix: K9 can no longer roll antag.
