### PR TITLE
Kiki, Pun Pun, Stir Stir, and other antag rolling animals can roll antag again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/simplemob.yml
@@ -73,7 +73,7 @@
   parent:
   - MobRespirator
   - MobAtmosStandard
-  - SimpleSpaceMobBase
+  - SimpleSpaceMobBaseTemplate # Starlight
   id: SimpleMobBaseTemplate # Starlight, changed so we can inherit this among antag-rolling and non-antag rolling animals
   suffix: AI
   abstract: true


### PR DESCRIPTION
## Short description
Kiki, Pun Pun, Stir Stir, and other antag rolling animals can roll antag again

## Why we need to add this
Inheritance error bug

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Kiki, Pun Pun, Stir Stir, and other antag rolling animals can roll antag again.
