### PR TITLE
Fix k9s teleporting across the station

### DIFF
--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -368,7 +368,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
             var distance = (_transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target)).Length();
             if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance)
             {
-                if (now - comp.StartTime < comp.RefundGracePeriod)
+                if (now - comp.StartTime < comp.RefundGracePeriod && distance <= comp.MaxDriftPullDistance)
                 {
                     _transform.SetCoordinates(uid, Transform(target).Coordinates);
                 }

--- a/Content.Shared/Actions/SharedActionsSystem.cs
+++ b/Content.Shared/Actions/SharedActionsSystem.cs
@@ -400,7 +400,10 @@ public abstract partial class SharedActionsSystem : EntitySystem
             _rotateToFace.TryFaceCoordinates(user, targetWorldPos);
 
         if (!ValidateEntityTarget(user, target, ent))
+        {
+            args.Invalid = true; // Starlight
             return;
+        }
 
         _adminLogger.Add(LogType.Action,
             $"{ToPrettyString(user):user} is performing the {Name(ent):action} action (provided by {ToPrettyString(args.Provider):provider}) targeted at {ToPrettyString(target):target}.");
@@ -423,7 +426,10 @@ public abstract partial class SharedActionsSystem : EntitySystem
             _rotateToFace.TryFaceCoordinates(user, _transform.ToMapCoordinates(target).Position);
 
         if (!ValidateWorldTarget(user, target, ent))
+        {
+            args.Invalid = true; // Starlight
             return;
+        }
 
         // if the client specified an entity it needs to be valid
         var targetEntity = GetEntity(args.Input.EntityTarget);

--- a/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
@@ -65,6 +65,16 @@ public sealed partial class LatchComponent : Component
     public float DriftBreakTolerance = 0.5f;
 
     /// <summary>
+    /// Hard ceiling on how far the grace-period recovery pull (see Update()) is allowed
+    /// to move the latcher to reach the target. Meant only to smooth minor jitter right
+    /// after a latch starts; if the target is farther than this, something else moved
+    /// it (or the target was wrong to begin with) and the latch should just break instead
+    /// of dragging the latcher along, however far, to reach it.
+    /// </summary>
+    [DataField]
+    public float MaxDriftPullDistance = 3f;
+
+    /// <summary>
     /// The starting, base duration of the latch, in seconds.
     /// </summary>
     [DataField]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes a bug discovered on Delta related to predicted movement states and latching.
K9s were latching onto targets, but sometimes in strange distance calculation scenarios, the latch would silently fail and fall-through the latch target onto their previous, teleporting them across time and space to bite onto their previous target.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Bugfix and defensive coding is good.
Added a safeguard max distance calculation to latching, and invalidated args on a couple of upstream spots where an action fails.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: Fixed K9s teleporting across the station to their previous latch target.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
