### PR TITLE
Increased devil spawn rate from 5% to 10%

### DIFF
--- a/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/dynamic_rules.yml
@@ -149,7 +149,7 @@
           - !type:PlayerCountCondition
             min: 40
         - id: Devil
-          prob: 0.05
+          prob: 0.10
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition
@@ -532,7 +532,7 @@
           - !type:PlayerCountCondition
             min: 40
         - id: Devil
-          prob: 0.05
+          prob: 0.10
           conditions:
           - !type:HasBudgetCondition
           - !type:MaxRuleOccurenceCondition

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -109,13 +109,13 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.48 # Starlight. Adds up to 1.
+      prob: 0.43 # Starlight. Adds up to 1.
     - id: VampireLess # Starlight. The rework is here.
       prob: 0.25
     - id: SubWizard
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: Devil
-      prob: 0.05 # rare
+      prob: 0.10 # rare Starlight: More devils
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
     #- id: SubBrighteye # Brighteye is disabled until more work is put in.
@@ -151,13 +151,13 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.55
+      prob: 0.50 # Starlight had to lower to account for increase in devils
     - id: SLChangeling #Starlight lings
       prob: 0.20 # Can be a little higher now, since lings don't have their standalone anymore.
     - id: SubWizard
       prob: 0.05 # We can go back down to 0.05, since they scale now.
     - id: Devil
-      prob: 0.05 # rare
+      prob: 0.10 # rare Starlight: More devils
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #  prob: 0.05
     #- id: SubBrighteye
@@ -172,11 +172,11 @@
   - type: SubGamemodes
     rules:
     - id: ThiefLess # So that only 3 thieves max spawn in rev games.
-      prob: 0.28 # Starlight, to account for Wizard and Xenoborgs
+      prob: 0.23 # Starlight, to account for Wizard and Xenoborgs
     - id: SubWizard
       prob: 0.05
     - id: Devil
-      prob: 0.05
+      prob: 0.10 #Starlight, More devils
     #- id: SubXenoborgs # Subgamemode replaced with SubXenoborgs
     #      prob: 0.05
     #- id: SubBrighteye

--- a/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Starlight/GameRules/roundstart.yml
@@ -109,7 +109,7 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.43 # Starlight. Adds up to 1.
+      prob: 0.48 # Starlight. Adds up to 1.
     - id: VampireLess # Starlight. The rework is here.
       prob: 0.25
     - id: SubWizard
@@ -151,7 +151,7 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.50 # Starlight had to lower to account for increase in devils
+      prob: 0.55 # Starlight had to lower to account for increase in devils
     - id: SLChangeling #Starlight lings
       prob: 0.20 # Can be a little higher now, since lings don't have their standalone anymore.
     - id: SubWizard
@@ -172,7 +172,7 @@
   - type: SubGamemodes
     rules:
     - id: ThiefLess # So that only 3 thieves max spawn in rev games.
-      prob: 0.23 # Starlight, to account for Wizard and Xenoborgs
+      prob: 0.28 # Starlight, to account for Wizard and Xenoborgs
     - id: SubWizard
       prob: 0.05
     - id: Devil


### PR DESCRIPTION
## Short description
Increases the devil spawn rate

## Why we need to add this
Devil is a very fun RP heavy roll however due to the fact its so rare to roll we nearly never see it by increasing the chance for it to spawn it allows for more antag RP

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- tweak: Increased Devil spawn rate to 10% from 5%.

