### PR TITLE
Adds ShouldMap for Ice cream maker, Kiki, Stir Stir, & Flippers

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/pets.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Markers/Spawners/pets.yml
@@ -1,6 +1,7 @@
 - type: entity
   parent: MarkerBase
   id: SpawnMobKoboldKiki
+  categories: [ ShouldMapStation ]
   name: Kiki Spawner
   suffix: Botanist Pet
   components:
@@ -16,6 +17,7 @@
 - type: entity
   parent: MarkerBase
   id: SpawnMobMonkeyStirStir
+  categories: [ ShouldMapStation ]
   name: Stir Stir Spawner
   suffix: Genpop Prisoner
   components:
@@ -31,6 +33,7 @@
 - type: entity
   parent: MarkerBase
   id: SpawnMobPenguinFlippers
+  categories: [ ShouldMapStation ]
   name: Rt Hon. Flippers Spawner
   suffix: Law Pet
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/ice_cream_maker.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/ice_cream_maker.yml
@@ -1,5 +1,6 @@
 - type: entity
   id: IceCreamMaker
+  categories: [ ShouldMapStation ]
   parent: [BaseMachinePowered, SmallConstructibleMachine]
   name: ice cream maker
   description: "Morale-boosting deserts, coming up."


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Mapping maintenance. These entities should now be mapped on all maps per #5250 and #5463

No changelog as this isn't a player facing change.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Updating tests is good.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
