### PR TITLE
Made romerol work again thru digestion

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -663,7 +663,7 @@
             - !type:ReagentCondition
               reagent: Romerol
               min: 5
-        # Starlight-Start: Cyclorite Metabolism
+    # Starlight-Start: Cyclorite Metabolism & Pill fixes
         - !type:AdjustReagent
           conditions:
           - !type:ReagentCondition
@@ -671,6 +671,22 @@
             min: 0.26
           - !type:MetabolizerTypeCondition
             type: [ Cyclorite ]
+          reagent: Romerol
+          amount: 0.25
+    Digestion:
+      effects:
+        - !type:CauseZombieInfection
+          conditions:
+            - !type:ReagentCondition
+              reagent: Romerol
+              min: 5
+        - !type:AdjustReagent
+          conditions:
+            - !type:ReagentCondition
+              reagent: Romerol
+              min: 0.26
+            - !type:MetabolizerTypeCondition
+              type: [ Cyclorite ]
           reagent: Romerol
           amount: 0.25
           # Starlight-End


### PR DESCRIPTION
## Short description
Made romerol toxin work again when ingested

## Why we need to add this
Because i dont like bugs so smush em

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: RedSpeeds
- fix: Fixed Romerol not working when ingested.

