### PR TITLE
K9 post release tweaks

### DIFF
--- a/Content.Client/_Starlight/Actions/Components/LatchBiteShakeVisualsComponent.cs
+++ b/Content.Client/_Starlight/Actions/Components/LatchBiteShakeVisualsComponent.cs
@@ -1,0 +1,13 @@
+using System.Numerics;
+
+namespace Content.Client._Starlight.Actions.Components;
+
+/// <summary>
+/// The K9's true resting sprite offset for the bite-shake animation, so
+/// restarts mid-wiggle don't compound a drift.
+/// </summary>
+[RegisterComponent]
+public sealed partial class LatchBiteShakeVisualsComponent : Component
+{
+    public Vector2 BaseOffset;
+}

--- a/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Client._Starlight.Actions.Components;
 using Content.Shared._Starlight.Actions.EntitySystems;
 using Content.Shared._Starlight.Actions.Events;
 using Robust.Client.Animations;
@@ -8,8 +9,7 @@ using Robust.Shared.Animations;
 namespace Content.Client._Starlight.Actions.EntitySystems;
 
 /// <summary>
-/// Client-side visual effects for latching - currently just the K9's
-/// head-shake on Bite Harder. SharedLatchSystem's handlers also run here.
+/// Client-side visual effects for latching (K9 head-shake on Bite Harder).
 /// </summary>
 public sealed partial class LatchSystem : SharedLatchSystem
 {
@@ -25,6 +25,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
         base.Initialize();
 
         SubscribeNetworkEvent<LatchBiteShakeEvent>(OnBiteShake);
+        SubscribeLocalEvent<LatchBiteShakeVisualsComponent, AnimationCompletedEvent>(OnShakeAnimationCompleted);
     }
 
     private void OnBiteShake(LatchBiteShakeEvent ev)
@@ -33,16 +34,26 @@ public sealed partial class LatchSystem : SharedLatchSystem
         if (!TryComp<SpriteComponent>(entity, out var sprite))
             return;
 
-        _animation.Play(entity, GetBiteShakeAnimation(sprite.Offset), BiteShakeAnimationKey);
+        var visuals = EnsureComp<LatchBiteShakeVisualsComponent>(entity);
+        if (!_animation.HasRunningAnimation(entity, BiteShakeAnimationKey))
+            visuals.BaseOffset = sprite.Offset;
+
+        _animation.Play(entity, GetBiteShakeAnimation(visuals.BaseOffset), BiteShakeAnimationKey);
+    }
+
+    private void OnShakeAnimationCompleted(Entity<LatchBiteShakeVisualsComponent> ent, ref AnimationCompletedEvent args)
+    {
+        if (args.Key == BiteShakeAnimationKey && args.Finished)
+            RemComp<LatchBiteShakeVisualsComponent>(ent);
     }
 
     /// <summary>
-    /// A quick side-to-side wiggle back to the sprite's current offset, like
-    /// a dog shaking its head mid-bite.
+    /// Quick side-to-side wiggle back to the sprite's current offset.
     /// </summary>
     private Animation GetBiteShakeAnimation(Vector2 startOffset)
     {
-        var frameLength = ShakeLength / ShakeCount;
+        // ShakeCount shakes plus one return-to-rest segment.
+        var frameLength = ShakeLength / (ShakeCount + 1);
         var keyFrames = new List<AnimationTrackProperty.KeyFrame> { new(startOffset, 0f) };
 
         for (var i = 0; i < ShakeCount; i++)

--- a/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -1,31 +1,106 @@
 using System.Numerics;
 using Content.Client._Starlight.Actions.Components;
+using Content.Client._Starlight.Actions.Overlays;
+using Content.Shared._Starlight.Actions.Components;
 using Content.Shared._Starlight.Actions.EntitySystems;
 using Content.Shared._Starlight.Actions.Events;
 using Robust.Client.Animations;
 using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
 using Robust.Shared.Animations;
+using Robust.Shared.Player;
+using Robust.Shared.Prototypes;
 
 namespace Content.Client._Starlight.Actions.EntitySystems;
 
 /// <summary>
-/// Client-side visual effects for latching (K9 head-shake on Bite Harder).
+/// Client-side visual effects for latching: K9 head-shake on Bite Harder, a
+/// teeth vignette and latcher outline shown to the target while latched.
 /// </summary>
 public sealed partial class LatchSystem : SharedLatchSystem
 {
     [Dependency] private AnimationPlayerSystem _animation = default!;
+    [Dependency] private IPlayerManager _player = default!;
+    [Dependency] private IOverlayManager _overlayMan = default!;
+    [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
 
     private const string BiteShakeAnimationKey = "latch-bite-shake";
     private const float ShakeLength = 0.25f;
     private const int ShakeCount = 4;
     private const float ShakeMagnitude = 0.08f;
 
+    private const string OutlineShaderId = "latch-target-outline";
+    private static readonly ProtoId<ShaderPrototype> OutlineShaderProto = "LatchTargetOutline";
+
+    private readonly LatchVignetteOverlay _vignette = new();
+    private ShaderInstance _outline = default!;
+
     public override void Initialize()
     {
         base.Initialize();
 
+        _outline = _prototypes.Index(OutlineShaderProto).Instance();
+
         SubscribeNetworkEvent<LatchBiteShakeEvent>(OnBiteShake);
         SubscribeLocalEvent<LatchBiteShakeVisualsComponent, AnimationCompletedEvent>(OnShakeAnimationCompleted);
+
+        SubscribeLocalEvent<LatchedComponent, AfterAutoHandleStateEvent>(OnLatchedStartup);
+        SubscribeLocalEvent<LatchedComponent, ComponentShutdown>(OnLatchedShutdown);
+        SubscribeLocalEvent<LocalPlayerAttachedEvent>(OnLocalPlayerAttached);
+        SubscribeLocalEvent<LocalPlayerDetachedEvent>(OnLocalPlayerDetached);
+    }
+
+    private void OnLatchedStartup(Entity<LatchedComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        if (_player.LocalEntity != ent.Owner)
+            return;
+
+        _overlayMan.AddOverlay(_vignette);
+        Highlight(ent.Comp.Latcher);
+    }
+
+    private void OnLatchedShutdown(Entity<LatchedComponent> ent, ref ComponentShutdown args)
+    {
+        if (_player.LocalEntity != ent.Owner)
+            return;
+
+        _overlayMan.RemoveOverlay(_vignette);
+        Unhighlight(ent.Comp.Latcher);
+    }
+
+    private void OnLocalPlayerAttached(LocalPlayerAttachedEvent ev)
+    {
+        if (!TryComp<LatchedComponent>(ev.Entity, out var latched))
+            return;
+
+        _overlayMan.AddOverlay(_vignette);
+        Highlight(latched.Latcher);
+    }
+
+    private void OnLocalPlayerDetached(LocalPlayerDetachedEvent ev)
+    {
+        _overlayMan.RemoveOverlay(_vignette);
+
+        if (TryComp<LatchedComponent>(ev.Entity, out var latched))
+            Unhighlight(latched.Latcher);
+    }
+
+    /// <summary>
+    /// Outlines the latcher's sprite - visible only on this client, so the
+    /// target can pick the K9 out even if it's obscured or hard to spot.
+    /// </summary>
+    private void Highlight(EntityUid latcher)
+    {
+        if (TryComp<SpriteComponent>(latcher, out var sprite))
+            _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(OutlineShaderId, _outline));
+    }
+
+    private void Unhighlight(EntityUid latcher)
+    {
+        if (TryComp<SpriteComponent>(latcher, out var sprite))
+            _sprite.RemovePostShader(sprite, OutlineShaderId);
     }
 
     private void OnBiteShake(LatchBiteShakeEvent ev)
@@ -39,6 +114,14 @@ public sealed partial class LatchSystem : SharedLatchSystem
             visuals.BaseOffset = sprite.Offset;
 
         _animation.Play(entity, GetBiteShakeAnimation(visuals.BaseOffset), BiteShakeAnimationKey);
+
+        // If I'm the one being bitten, spike the vignette's teeth in.
+        if (_player.LocalEntity is { } local &&
+            TryComp<LatchedComponent>(local, out var latched) &&
+            latched.Latcher == entity)
+        {
+            _vignette.BiteIntensity = 1f;
+        }
     }
 
     private void OnShakeAnimationCompleted(Entity<LatchBiteShakeVisualsComponent> ent, ref AnimationCompletedEvent args)

--- a/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -57,6 +57,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
         if (_player.LocalEntity != ent.Owner)
             return;
 
+        _vignette.BiteIntensity = 0f;
         _overlayMan.AddOverlay(_vignette);
         Highlight(ent.Comp.Latcher);
     }
@@ -75,6 +76,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
         if (!TryComp<LatchedComponent>(ev.Entity, out var latched))
             return;
 
+        _vignette.BiteIntensity = 0f;
         _overlayMan.AddOverlay(_vignette);
         Highlight(latched.Latcher);
     }

--- a/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Client/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -1,8 +1,71 @@
+using System.Numerics;
 using Content.Shared._Starlight.Actions.EntitySystems;
+using Content.Shared._Starlight.Actions.Events;
+using Robust.Client.Animations;
+using Robust.Client.GameObjects;
+using Robust.Shared.Animations;
 
 namespace Content.Client._Starlight.Actions.EntitySystems;
 
 /// <summary>
-/// Empty on purpose - exists so SharedLatchSystem's handlers also run on the client.
+/// Client-side visual effects for latching - currently just the K9's
+/// head-shake on Bite Harder. SharedLatchSystem's handlers also run here.
 /// </summary>
-public sealed partial class LatchSystem : SharedLatchSystem;
+public sealed partial class LatchSystem : SharedLatchSystem
+{
+    [Dependency] private AnimationPlayerSystem _animation = default!;
+
+    private const string BiteShakeAnimationKey = "latch-bite-shake";
+    private const float ShakeLength = 0.25f;
+    private const int ShakeCount = 4;
+    private const float ShakeMagnitude = 0.08f;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeNetworkEvent<LatchBiteShakeEvent>(OnBiteShake);
+    }
+
+    private void OnBiteShake(LatchBiteShakeEvent ev)
+    {
+        var entity = GetEntity(ev.Latcher);
+        if (!TryComp<SpriteComponent>(entity, out var sprite))
+            return;
+
+        _animation.Play(entity, GetBiteShakeAnimation(sprite.Offset), BiteShakeAnimationKey);
+    }
+
+    /// <summary>
+    /// A quick side-to-side wiggle back to the sprite's current offset, like
+    /// a dog shaking its head mid-bite.
+    /// </summary>
+    private Animation GetBiteShakeAnimation(Vector2 startOffset)
+    {
+        var frameLength = ShakeLength / ShakeCount;
+        var keyFrames = new List<AnimationTrackProperty.KeyFrame> { new(startOffset, 0f) };
+
+        for (var i = 0; i < ShakeCount; i++)
+        {
+            var x = (i % 2 == 0 ? 1f : -1f) * ShakeMagnitude;
+            keyFrames.Add(new AnimationTrackProperty.KeyFrame(startOffset + new Vector2(x, 0f), frameLength));
+        }
+
+        keyFrames.Add(new AnimationTrackProperty.KeyFrame(startOffset, frameLength));
+
+        return new Animation
+        {
+            Length = TimeSpan.FromSeconds(ShakeLength),
+            AnimationTracks =
+            {
+                new AnimationTrackComponentProperty
+                {
+                    ComponentType = typeof(SpriteComponent),
+                    Property = nameof(SpriteComponent.Offset),
+                    InterpolationMode = AnimationInterpolationMode.Cubic,
+                    KeyFrames = keyFrames,
+                },
+            },
+        };
+    }
+}

--- a/Content.Client/_Starlight/Actions/Overlays/LatchVignetteOverlay.cs
+++ b/Content.Client/_Starlight/Actions/Overlays/LatchVignetteOverlay.cs
@@ -1,0 +1,117 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Timing;
+
+namespace Content.Client._Starlight.Actions.Overlays;
+
+/// <summary>
+/// Jagged teeth vignette shown to the latch target - red at the tips,
+/// fading to black at their base. Fixed length; on each Bite Harder hit the
+/// whole row pushes toward screen center, backed by a solid black fill,
+/// then eases back to baseline.
+/// </summary>
+public sealed partial class LatchVignetteOverlay : Robust.Client.Graphics.Overlay
+{
+    public override OverlaySpace Space => OverlaySpace.ScreenSpace;
+
+    private const int ToothCount = 14;
+    private const float ToothLengthFraction = 0.10f;
+    private const float BaselinePushFraction = 0.10f;
+    private const float BitePushFraction = 0.32f;
+    private const float DecayPerSecond = 2.5f;
+
+    private static readonly Color _tipColor = Color.FromSrgb(new Color(0.7f, 0f, 0f, 0.9f));
+    private static readonly Color _baseColor = Color.FromSrgb(new Color(0f, 0f, 0f, 0.9f));
+    private static readonly Color _fillColor = new(0f, 0f, 0f, 0.9f);
+
+    // Deterministic per-tooth length variance so the row reads as jagged
+    // rather than a perfectly even sawtooth.
+    private static readonly float[] _toothJitter =
+    {
+        0f, 0.4f, -0.25f, 0.15f, -0.4f, 0.3f, 0f,
+        -0.3f, 0.4f, -0.15f, 0.25f, -0.35f, 0.1f, -0.1f,
+    };
+
+    /// <summary>
+    /// 0 at rest, 1 at a bite's peak. LatchSystem sets this to 1 on each
+    /// Bite Harder hit; it eases back down here every frame.
+    /// </summary>
+    public float BiteIntensity;
+
+    private readonly List<DrawVertexUV2DColor> _toothVerts = [];
+    private readonly List<Vector2> _fillVerts = [];
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        BiteIntensity = MathF.Max(0f, BiteIntensity - DecayPerSecond * args.DeltaSeconds);
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        var bounds = args.ViewportBounds;
+        var width = (float)bounds.Width;
+        var height = (float)bounds.Height;
+
+        var pushDepth = height * (BaselinePushFraction + (BitePushFraction - BaselinePushFraction) * BiteIntensity);
+        var toothLength = height * ToothLengthFraction;
+
+        _fillVerts.Clear();
+        BuildFill(width, pushDepth, fromTop: true, screenHeight: height);
+        BuildFill(width, pushDepth, fromTop: false, screenHeight: height);
+        args.ScreenHandle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, _fillVerts, _fillColor);
+
+        _toothVerts.Clear();
+        BuildToothRow(width, pushDepth, toothLength, fromTop: true, screenHeight: height);
+        BuildToothRow(width, pushDepth, toothLength, fromTop: false, screenHeight: height);
+        args.ScreenHandle.DrawPrimitives(DrawPrimitiveTopology.TriangleList, Texture.White, CollectionsMarshal.AsSpan(_toothVerts));
+    }
+
+    /// <summary>
+    /// Solid rectangle from the screen edge to pushDepth, covering the area
+    /// the teeth vacated as they pushed in.
+    /// </summary>
+    private void BuildFill(float width, float pushDepth, bool fromTop, float screenHeight)
+    {
+        var near = fromTop ? 0f : screenHeight;
+        var far = fromTop ? pushDepth : screenHeight - pushDepth;
+
+        _fillVerts.Add(new Vector2(0f, near));
+        _fillVerts.Add(new Vector2(width, near));
+        _fillVerts.Add(new Vector2(0f, far));
+        _fillVerts.Add(new Vector2(width, near));
+        _fillVerts.Add(new Vector2(width, far));
+        _fillVerts.Add(new Vector2(0f, far));
+    }
+
+    private void BuildToothRow(float width, float pushDepth, float toothLength, bool fromTop, float screenHeight)
+    {
+        var toothWidth = width / ToothCount;
+
+        for (var i = 0; i < ToothCount; i++)
+        {
+            var jitteredLength = toothLength * (1f + _toothJitter[i % _toothJitter.Length]);
+            var xLeft = i * toothWidth;
+            var xRight = xLeft + toothWidth;
+            var xMid = (xLeft + xRight) / 2f;
+
+            var baseDepth = pushDepth;
+            var tipDepth = pushDepth + jitteredLength;
+
+            if (fromTop)
+            {
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xLeft, baseDepth), Vector2.Zero, _baseColor));
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xRight, baseDepth), Vector2.Zero, _baseColor));
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xMid, tipDepth), Vector2.Zero, _tipColor));
+            }
+            else
+            {
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xLeft, screenHeight - baseDepth), Vector2.Zero, _baseColor));
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xRight, screenHeight - baseDepth), Vector2.Zero, _baseColor));
+                _toothVerts.Add(new DrawVertexUV2DColor(new Vector2(xMid, screenHeight - tipDepth), Vector2.Zero, _tipColor));
+            }
+        }
+    }
+}

--- a/Content.Client/_Starlight/Actions/UI/LatchStatusControl.cs
+++ b/Content.Client/_Starlight/Actions/UI/LatchStatusControl.cs
@@ -20,6 +20,12 @@ public sealed class LatchStatusControl : PanelContainer
     private readonly ProgressBar _bar;
     private readonly ProgressBar _maxBar;
     private readonly Label _instruction;
+    private readonly Button _biteHarderButton;
+
+    /// <summary>
+    /// Raised when the Bite Harder button is pressed.
+    /// </summary>
+    public event Action? BiteHarderPressed;
 
     public LatchStatusControl()
     {
@@ -70,10 +76,19 @@ public sealed class LatchStatusControl : PanelContainer
             MouseFilter = MouseFilterMode.Ignore,
         };
 
+        _biteHarderButton = new Button
+        {
+            Text = Loc.GetString("latch-bite-harder-button"),
+            HorizontalExpand = true,
+            Visible = false,
+        };
+        _biteHarderButton.OnPressed += _ => BiteHarderPressed?.Invoke();
+
         layout.AddChild(_title);
+        layout.AddChild(_instruction);
+        layout.AddChild(_biteHarderButton);
         layout.AddChild(BarRow(Loc.GetString("latch-label-timeremaining"), _bar));
         layout.AddChild(BarRow(Loc.GetString("latch-label-timemax"), _maxBar));
-        layout.AddChild(_instruction);
         AddChild(layout);
 
         Visible = false;
@@ -101,16 +116,18 @@ public sealed class LatchStatusControl : PanelContainer
     }
 
     /// <summary>
-    /// Updates both bars and the instruction text.
+    /// Updates both bars, the instruction text, and whether the Bite Harder
+    /// button is shown (only relevant to the latcher, not the target).
     /// </summary>
     /// <param name="fraction">Remaining time before the current end time, 0 to 1.</param>
     /// <param name="maxFraction">Remaining time before the hard cap, 0 to 1.</param>
-    public void UpdateState(float fraction, float maxFraction, string instruction)
+    public void UpdateState(float fraction, float maxFraction, string instruction, bool showBiteHarder)
     {
         Visible = true;
         _bar.Value = fraction;
         _maxBar.Value = maxFraction;
         _instruction.Text = instruction;
+        _biteHarderButton.Visible = showBiteHarder;
     }
 
     /// <summary>

--- a/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
+++ b/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
@@ -74,7 +74,8 @@ public sealed partial class LatchUIController : UIController
         // BiteHarder action entity and trigger it directly.
         foreach (var action in _actions.GetActions(local))
         {
-            if (_entities.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID != latchComp.BiteHarderAction)
+            if (!_entities.TryGetComponent<MetaDataComponent>(action, out var metadata)
+                || metadata.EntityPrototype?.ID != latchComp.BiteHarderAction.Id)
                 continue;
 
             _actions.TriggerAction(action);

--- a/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
+++ b/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
@@ -96,7 +96,7 @@ public sealed partial class LatchUIController : UIController
 
         string instruction;
         TimeSpan endTime, maxEndTime, maxDuration;
-        bool isLatcher;
+        bool isLatcher, below;
 
         // As the latcher.
         if (_entities.TryGetComponent<LatchComponent>(local, out var latchComp) && latchComp.Active)
@@ -106,6 +106,7 @@ public sealed partial class LatchUIController : UIController
             maxEndTime = latchComp.MaxEndTime;
             maxDuration = latchComp.MaxDuration;
             isLatcher = true;
+            below = latchComp.LatcherUiBelow;
         }
         // As the target.
         else if (_entities.TryGetComponent<LatchedComponent>(local, out var latchedComp) &&
@@ -117,6 +118,7 @@ public sealed partial class LatchUIController : UIController
             maxEndTime = latcherComp.MaxEndTime;
             maxDuration = latcherComp.MaxDuration;
             isLatcher = false;
+            below = latcherComp.TargetUiBelow;
         }
         else
         {
@@ -135,10 +137,16 @@ public sealed partial class LatchUIController : UIController
         var maxFraction = GetFraction(maxEndTime, maxDuration);
         _control.UpdateState(fraction, maxFraction, instruction, isLatcher);
 
-        var worldPos = _transform.GetWorldPosition(xform) + new Vector2(0, VerticalOffset);
+        // Normally anchored to the panel's bottom edge, VerticalOffset above
+        // the target. If the K9 started behind that spot, anchor to the top
+        // edge instead, offset below, so the K9 stays visible and clickable.
+        var offset = below ? -VerticalOffset : VerticalOffset;
+        var worldPos = _transform.GetWorldPosition(xform) + new Vector2(0, offset);
         var uiScale = UIManager.RootControl.UIScale;
-        var lowerCenter = _eyeManager.WorldToScreen(worldPos) / uiScale;
-        var screenPos = lowerCenter - new Vector2(_control.Width / 2f, _control.Height);
+        var anchor = _eyeManager.WorldToScreen(worldPos) / uiScale;
+        var screenPos = below
+            ? anchor - new Vector2(_control.Width / 2f, 0f)
+            : anchor - new Vector2(_control.Width / 2f, _control.Height);
         LayoutContainer.SetPosition(_control, screenPos);
     }
 

--- a/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
+++ b/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Client._Starlight.Actions.UI;
+using Content.Client.Actions;
 using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Shared._Starlight.Actions.Components;
 using JetBrains.Annotations;
@@ -27,6 +28,7 @@ public sealed partial class LatchUIController : UIController
 
     private LatchStatusControl? _control;
     private SharedTransformSystem? _transform;
+    private ActionsSystem? _actions;
 
     public override void Initialize()
     {
@@ -44,15 +46,37 @@ public sealed partial class LatchUIController : UIController
             return;
 
         _transform ??= _entities.System<SharedTransformSystem>();
+        _actions ??= _entities.System<ActionsSystem>();
 
         _control = new LatchStatusControl();
+        _control.BiteHarderPressed += OnBiteHarderPressed;
         viewport.AddChild(_control);
     }
 
     private void OnScreenUnload()
     {
+        if (_control is not null)
+            _control.BiteHarderPressed -= OnBiteHarderPressed;
+
         _control?.Orphan();
         _control = null;
+    }
+
+    private void OnBiteHarderPressed()
+    {
+        if (_actions is null || _player.LocalEntity is not { } local)
+            return;
+
+        // Same as clicking the action in the hotbar - find the granted
+        // BiteHarder action entity and trigger it directly.
+        foreach (var action in _actions.GetActions(local))
+        {
+            if (_entities.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID != "LatchBiteHarder")
+                continue;
+
+            _actions.TriggerAction(action);
+            return;
+        }
     }
 
     public override void FrameUpdate(FrameEventArgs args)
@@ -68,6 +92,7 @@ public sealed partial class LatchUIController : UIController
 
         string instruction;
         TimeSpan endTime, maxEndTime, maxDuration;
+        bool isLatcher;
 
         // As the latcher.
         if (_entities.TryGetComponent<LatchComponent>(local, out var latchComp) && latchComp.Active)
@@ -76,6 +101,7 @@ public sealed partial class LatchUIController : UIController
             endTime = latchComp.EndTime;
             maxEndTime = latchComp.MaxEndTime;
             maxDuration = latchComp.MaxDuration;
+            isLatcher = true;
         }
         // As the target.
         else if (_entities.TryGetComponent<LatchedComponent>(local, out var latchedComp) &&
@@ -86,6 +112,7 @@ public sealed partial class LatchUIController : UIController
             endTime = latcherComp.EndTime;
             maxEndTime = latcherComp.MaxEndTime;
             maxDuration = latcherComp.MaxDuration;
+            isLatcher = false;
         }
         else
         {
@@ -102,7 +129,7 @@ public sealed partial class LatchUIController : UIController
 
         var fraction = GetFraction(endTime, maxDuration);
         var maxFraction = GetFraction(maxEndTime, maxDuration);
-        _control.UpdateState(fraction, maxFraction, instruction);
+        _control.UpdateState(fraction, maxFraction, instruction, isLatcher);
 
         var worldPos = _transform.GetWorldPosition(xform) + new Vector2(0, VerticalOffset);
         var uiScale = UIManager.RootControl.UIScale;

--- a/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
+++ b/Content.Client/_Starlight/Actions/UserInterface/LatchUIController.cs
@@ -67,11 +67,14 @@ public sealed partial class LatchUIController : UIController
         if (_actions is null || _player.LocalEntity is not { } local)
             return;
 
+        if (!_entities.TryGetComponent<LatchComponent>(local, out var latchComp))
+            return;
+
         // Same as clicking the action in the hotbar - find the granted
         // BiteHarder action entity and trigger it directly.
         foreach (var action in _actions.GetActions(local))
         {
-            if (_entities.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID != "LatchBiteHarder")
+            if (_entities.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID != latchComp.BiteHarderAction)
                 continue;
 
             _actions.TriggerAction(action);

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -18,7 +18,6 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
-using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Wieldable;
@@ -65,26 +64,12 @@ public sealed partial class LatchSystem : SharedLatchSystem
         SubscribeLocalEvent<LatchComponent, ComponentShutdown>(OnLatchShutdown);
         SubscribeLocalEvent<LatchComponent, DamageChangedEvent>(OnLatcherDamaged);
         SubscribeLocalEvent<LatchComponent, MobStateChangedEvent>(OnLatcherMobStateChanged);
-        SubscribeLocalEvent<LatchComponent, BeingPulledAttemptEvent>(OnLatcherBeingPulledAttempt);
 
         SubscribeLocalEvent<LatchedComponent, ComponentShutdown>(OnLatchedShutdown);
         SubscribeLocalEvent<LatchedComponent, MobStateChangedEvent>(OnTargetMobStateChanged);
-        SubscribeLocalEvent<LatchedComponent, BeingPulledAttemptEvent>(OnTargetBeingPulledAttempt);
 
         SubscribeLocalEvent<LatchBiteHarderActionEvent>(OnBiteHarderAction);
         SubscribeLocalEvent<LatchReleaseActionEvent>(OnReleaseAction);
-    }
-
-    private void OnLatcherBeingPulledAttempt(Entity<LatchComponent> ent, ref BeingPulledAttemptEvent args)
-    {
-        if (ent.Comp.Active)
-            args.Cancel();
-    }
-
-    private void OnTargetBeingPulledAttempt(Entity<LatchedComponent> ent, ref BeingPulledAttemptEvent args)
-    {
-        if (TryComp<LatchComponent>(ent.Comp.Latcher, out var latchComp) && latchComp.Active)
-            args.Cancel();
     }
 
     /// <summary>

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -387,8 +387,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
                 continue;
             }
 
-            // Knocked out of range; RangeTolerance avoids instant-breaking
-            // from jitter.
+            // Knocked out of range; the joint pulls it back, this just times out if it can't.
             var distance = (_transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target)).Length();
             if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance &&
                 now - comp.StartTime >= comp.RefundGracePeriod)

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -192,6 +192,16 @@ public sealed partial class LatchSystem : SharedLatchSystem
         latched.Latcher = uid;
         Dirty(target, latched);
 
+        var toLatcher = _transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target);
+        var withinObscureRange = MathF.Abs(toLatcher.Y) <= comp.UiObscureNorthRange
+            && MathF.Abs(toLatcher.X) <= comp.UiObscureHorizontalTolerance;
+
+        // K9 north of target -> K9 sits where the target's own UI would be -> target's UI flips below.
+        comp.TargetUiBelow = withinObscureRange && toLatcher.Y > 0f;
+
+        // K9 south of target -> target sits where the K9's own UI would be -> latcher's UI flips below.
+        comp.LatcherUiBelow = withinObscureRange && toLatcher.Y < 0f;
+
         if (TryComp<PullableComponent>(uid, out var latcherPullable))
             _pulling.TryStopPull(uid, latcherPullable);
 

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -12,7 +12,6 @@ using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
-using Content.Shared.Interaction;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
@@ -22,10 +21,8 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
-using Content.Shared.Whitelist;
 using Content.Shared.Wieldable;
 using Robust.Server.Audio;
-using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
@@ -45,8 +42,6 @@ public sealed partial class LatchSystem : SharedLatchSystem
     [Dependency] private SharedChatSystem _chat = default!;
     [Dependency] private CombatModeSystem _combatMode = default!;
     [Dependency] private DamageableSystem _damageable = default!;
-    [Dependency] private EntityWhitelistSystem _whitelist = default!;
-    [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
@@ -76,7 +71,6 @@ public sealed partial class LatchSystem : SharedLatchSystem
         SubscribeLocalEvent<LatchedComponent, MobStateChangedEvent>(OnTargetMobStateChanged);
         SubscribeLocalEvent<LatchedComponent, BeingPulledAttemptEvent>(OnTargetBeingPulledAttempt);
 
-        SubscribeLocalEvent<LatchActionEvent>(OnLatchAction);
         SubscribeLocalEvent<LatchBiteHarderActionEvent>(OnBiteHarderAction);
         SubscribeLocalEvent<LatchReleaseActionEvent>(OnReleaseAction);
     }
@@ -130,32 +124,6 @@ public sealed partial class LatchSystem : SharedLatchSystem
 
         if (TryComp<LatchComponent>(comp.Latcher, out var latchComp) && latchComp.Active && latchComp.Target == uid)
             EndLatch(comp.Latcher, latchComp);
-    }
-
-    /// <summary>
-    /// Validates and starts a latch attempt.
-    /// </summary>
-    private void OnLatchAction(LatchActionEvent ev)
-    {
-        if (ev.Handled)
-            return;
-
-        var uid = ev.Performer;
-        if (!TryComp<LatchComponent>(uid, out var comp) || comp.Active)
-            return;
-
-        var target = ev.Target;
-        if (target == uid)
-            return;
-
-        if (!_whitelist.IsWhitelistPassOrNull(comp.Whitelist, target))
-            return;
-
-        if (HasComp<LatchedComponent>(target))
-            return;
-
-        StartLatch(uid, comp, target);
-        ev.Handled = true;
     }
 
     private void OnBiteHarderAction(LatchBiteHarderActionEvent ev)
@@ -221,10 +189,11 @@ public sealed partial class LatchSystem : SharedLatchSystem
 
     /// <summary>
     /// Begins a latch: locks movement, downs the target, blocks a hand, and
-    /// grants Bite Harder.
+    /// grants Bite Harder. The joint's already been created by the shared
+    /// base class by the time this runs.
     /// </summary>
     /// <param name="target">The entity being latched onto.</param>
-    private void StartLatch(EntityUid uid, LatchComponent comp, EntityUid target)
+    protected override void StartLatch(EntityUid uid, LatchComponent comp, EntityUid target)
     {
         comp.Active = true;
         comp.Target = target;
@@ -243,31 +212,6 @@ public sealed partial class LatchSystem : SharedLatchSystem
 
         if (TryComp<PullableComponent>(target, out var targetPullable))
             _pulling.TryStopPull(target, targetPullable);
-
-        // Engage range allows pouncing past melee range; pull the K9 in if
-        // the path is clear, else leave the joint uncapped for this latch.
-        var targetPos = _transform.GetWorldPosition(target);
-        var toLatcher = _transform.GetWorldPosition(uid) - targetPos;
-        var pounceDistance = toLatcher.Length();
-        var jointMaxLength = comp.MaxJointLength;
-
-        if (pounceDistance > comp.MaxJointLength)
-        {
-            var pullInPos = targetPos + toLatcher / pounceDistance * comp.MaxJointLength;
-            var pullInCoords = new MapCoordinates(pullInPos, Transform(target).MapID);
-
-            if (_interaction.InRangeUnobstructed(uid, pullInCoords, pounceDistance))
-                _transform.SetWorldPosition(uid, pullInPos);
-            else
-                jointMaxLength = pounceDistance; // couldn't get closer
-        }
-
-        comp.LatchJointId = $"latch-joint-{GetNetEntity(uid)}";
-        var joint = _joints.CreateDistanceJoint(uid, target, id: comp.LatchJointId);
-        joint.CollideConnected = false;
-        joint.MinLength = 0f;
-        joint.MaxLength = jointMaxLength;
-        joint.Stiffness = 0f;
 
         if (_virtualItem.TrySpawnVirtualItemInHand(uid, target, out var blockingItem))
         {
@@ -444,24 +388,13 @@ public sealed partial class LatchSystem : SharedLatchSystem
             }
 
             // Knocked out of range; RangeTolerance avoids instant-breaking
-            // from jitter. Within the grace window, pull the K9 to the
-            // target instead of breaking. After that, treat it as a real
-            // separation.  If the latch is particularly far away but not
-            // enough to completely refund the action, move the K9 closer.
+            // from jitter.
             var distance = (_transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target)).Length();
-            if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance)
+            if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance &&
+                now - comp.StartTime >= comp.RefundGracePeriod)
             {
-                if (now - comp.StartTime < comp.RefundGracePeriod)
-                {
-                    var midpoint = (_transform.GetWorldPosition(uid) + _transform.GetWorldPosition(target)) / 2f;
-                    _transform.SetWorldPosition(uid, midpoint);
-
-                }
-                else
-                {
-                    EndLatch(uid, comp);
-                    continue;
-                }
+                EndLatch(uid, comp);
+                continue;
             }
 
             // Re-assert every tick so this can't be toggled back on mid-latch.

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Server.Actions;
 using Content.Server.CombatMode;
 using Content.Shared._Starlight.Actions.Components;
@@ -5,11 +6,13 @@ using Content.Shared._Starlight.Actions.EntitySystems;
 using Content.Shared._Starlight.Actions.Events;
 using Content.Shared.Alert;
 using Content.Shared.Bed.Sleep;
+using Content.Shared.Camera;
 using Content.Shared.Charges.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Systems;
 using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
@@ -22,7 +25,9 @@ using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
 using Content.Shared.Wieldable;
 using Robust.Server.Audio;
+using Robust.Shared.Map;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -41,16 +46,21 @@ public sealed partial class LatchSystem : SharedLatchSystem
     [Dependency] private CombatModeSystem _combatMode = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private SharedInteractionSystem _interaction = default!;
     [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
     [Dependency] private PullingSystem _pulling = default!;
+    [Dependency] private SharedCameraRecoilSystem _recoil = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedStaminaSystem _stamina = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedVirtualItemSystem _virtualItem = default!;
     [Dependency] private SharedWieldableSystem _wieldable = default!;
     [Dependency] private StandingStateSystem _standing = default!;
+
+    // Subtle relative to explosions (which scale up to ~0.4f) - a jolt, not a blast.
+    private const float BiteHarderCameraKick = 0.15f;
 
     public override void Initialize()
     {
@@ -184,6 +194,11 @@ public sealed partial class LatchSystem : SharedLatchSystem
         Dirty(uid, comp);
 
         _audio.PlayPvs(comp.BiteHarderSound, uid);
+        RaiseNetworkEvent(new LatchBiteShakeEvent(GetNetEntity(uid)), Filter.Pvs(uid, entityManager: EntityManager));
+
+        var kickDirection = _transform.GetWorldPosition(target) - _transform.GetWorldPosition(uid);
+        if (kickDirection != Vector2.Zero)
+            _recoil.KickCamera(target, kickDirection.Normalized() * BiteHarderCameraKick);
 
         return true;
     }
@@ -229,11 +244,29 @@ public sealed partial class LatchSystem : SharedLatchSystem
         if (TryComp<PullableComponent>(target, out var targetPullable))
             _pulling.TryStopPull(target, targetPullable);
 
+        // Engage range allows pouncing past melee range; pull the K9 in if
+        // the path is clear, else leave the joint uncapped for this latch.
+        var targetPos = _transform.GetWorldPosition(target);
+        var toLatcher = _transform.GetWorldPosition(uid) - targetPos;
+        var pounceDistance = toLatcher.Length();
+        var jointMaxLength = comp.MaxJointLength;
+
+        if (pounceDistance > comp.MaxJointLength)
+        {
+            var pullInPos = targetPos + toLatcher / pounceDistance * comp.MaxJointLength;
+            var pullInCoords = new MapCoordinates(pullInPos, Transform(target).MapID);
+
+            if (_interaction.InRangeUnobstructed(uid, pullInCoords, pounceDistance))
+                _transform.SetWorldPosition(uid, pullInPos);
+            else
+                jointMaxLength = pounceDistance; // couldn't get closer
+        }
+
         comp.LatchJointId = $"latch-joint-{GetNetEntity(uid)}";
         var joint = _joints.CreateDistanceJoint(uid, target, id: comp.LatchJointId);
         joint.CollideConnected = false;
         joint.MinLength = 0f;
-        joint.MaxLength = comp.MaxJointLength;
+        joint.MaxLength = jointMaxLength;
         joint.Stiffness = 0f;
 
         if (_virtualItem.TrySpawnVirtualItemInHand(uid, target, out var blockingItem))
@@ -418,7 +451,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
             var distance = (_transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target)).Length();
             if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance)
             {
-                if (now - comp.StartTime < comp.RefundGracePeriod && distance <= comp.MaxDriftPullDistance)
+                if (now - comp.StartTime < comp.RefundGracePeriod)
                 {
                     var midpoint = (_transform.GetWorldPosition(uid) + _transform.GetWorldPosition(target)) / 2f;
                     _transform.SetWorldPosition(uid, midpoint);

--- a/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
+++ b/Content.Server/_Starlight/Actions/EntitySystems/LatchSystem.cs
@@ -13,12 +13,16 @@ using Content.Shared.FixedPoint;
 using Content.Shared.Inventory.VirtualItem;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Movement.Pulling.Components;
+using Content.Shared.Movement.Pulling.Systems;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Pulling.Events;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Whitelist;
 using Content.Shared.Wieldable;
 using Robust.Server.Audio;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -37,8 +41,10 @@ public sealed partial class LatchSystem : SharedLatchSystem
     [Dependency] private CombatModeSystem _combatMode = default!;
     [Dependency] private DamageableSystem _damageable = default!;
     [Dependency] private EntityWhitelistSystem _whitelist = default!;
+    [Dependency] private SharedJointSystem _joints = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private MovementSpeedModifierSystem _speed = default!;
+    [Dependency] private PullingSystem _pulling = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedStaminaSystem _stamina = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
@@ -54,13 +60,27 @@ public sealed partial class LatchSystem : SharedLatchSystem
         SubscribeLocalEvent<LatchComponent, ComponentShutdown>(OnLatchShutdown);
         SubscribeLocalEvent<LatchComponent, DamageChangedEvent>(OnLatcherDamaged);
         SubscribeLocalEvent<LatchComponent, MobStateChangedEvent>(OnLatcherMobStateChanged);
+        SubscribeLocalEvent<LatchComponent, BeingPulledAttemptEvent>(OnLatcherBeingPulledAttempt);
 
         SubscribeLocalEvent<LatchedComponent, ComponentShutdown>(OnLatchedShutdown);
         SubscribeLocalEvent<LatchedComponent, MobStateChangedEvent>(OnTargetMobStateChanged);
+        SubscribeLocalEvent<LatchedComponent, BeingPulledAttemptEvent>(OnTargetBeingPulledAttempt);
 
         SubscribeLocalEvent<LatchActionEvent>(OnLatchAction);
         SubscribeLocalEvent<LatchBiteHarderActionEvent>(OnBiteHarderAction);
         SubscribeLocalEvent<LatchReleaseActionEvent>(OnReleaseAction);
+    }
+
+    private void OnLatcherBeingPulledAttempt(Entity<LatchComponent> ent, ref BeingPulledAttemptEvent args)
+    {
+        if (ent.Comp.Active)
+            args.Cancel();
+    }
+
+    private void OnTargetBeingPulledAttempt(Entity<LatchedComponent> ent, ref BeingPulledAttemptEvent args)
+    {
+        if (TryComp<LatchComponent>(ent.Comp.Latcher, out var latchComp) && latchComp.Active)
+            args.Cancel();
     }
 
     /// <summary>
@@ -133,9 +153,19 @@ public sealed partial class LatchSystem : SharedLatchSystem
         if (ev.Handled)
             return;
 
-        var uid = ev.Performer;
-        if (!TryComp<LatchComponent>(uid, out var comp) || !comp.Active || comp.Target is not { } target)
+        if (!TryComp<LatchComponent>(ev.Performer, out var comp))
             return;
+
+        ev.Handled = DoBiteHarder(ev.Performer, comp);
+    }
+
+    /// <summary>
+    /// Deals one latch tick early and extends the duration.
+    /// </summary>
+    private bool DoBiteHarder(EntityUid uid, LatchComponent comp)
+    {
+        if (!comp.Active || comp.Target is not { } target)
+            return false;
 
         // Ratio of the bite's damage that got through armor.
         var effectiveness = 0f;
@@ -155,7 +185,7 @@ public sealed partial class LatchSystem : SharedLatchSystem
 
         _audio.PlayPvs(comp.BiteHarderSound, uid);
 
-        ev.Handled = true;
+        return true;
     }
 
     /// <summary>
@@ -192,6 +222,19 @@ public sealed partial class LatchSystem : SharedLatchSystem
         var latched = EnsureComp<LatchedComponent>(target);
         latched.Latcher = uid;
         Dirty(target, latched);
+
+        if (TryComp<PullableComponent>(uid, out var latcherPullable))
+            _pulling.TryStopPull(uid, latcherPullable);
+
+        if (TryComp<PullableComponent>(target, out var targetPullable))
+            _pulling.TryStopPull(target, targetPullable);
+
+        comp.LatchJointId = $"latch-joint-{GetNetEntity(uid)}";
+        var joint = _joints.CreateDistanceJoint(uid, target, id: comp.LatchJointId);
+        joint.CollideConnected = false;
+        joint.MinLength = 0f;
+        joint.MaxLength = comp.MaxJointLength;
+        joint.Stiffness = 0f;
 
         if (_virtualItem.TrySpawnVirtualItemInHand(uid, target, out var blockingItem))
         {
@@ -238,6 +281,12 @@ public sealed partial class LatchSystem : SharedLatchSystem
         comp.Active = false;
         comp.Target = null;
         comp.TickPaused = false;
+
+        if (comp.LatchJointId is { } jointId)
+        {
+            _joints.RemoveJoint(uid, jointId);
+            comp.LatchJointId = null;
+        }
 
         _action.RemoveAction(uid, comp.BiteHarderActionEntity);
         comp.BiteHarderActionEntity = null;
@@ -364,13 +413,16 @@ public sealed partial class LatchSystem : SharedLatchSystem
             // Knocked out of range; RangeTolerance avoids instant-breaking
             // from jitter. Within the grace window, pull the K9 to the
             // target instead of breaking. After that, treat it as a real
-            // separation.
+            // separation.  If the latch is particularly far away but not
+            // enough to completely refund the action, move the K9 closer.
             var distance = (_transform.GetWorldPosition(uid) - _transform.GetWorldPosition(target)).Length();
             if (distance > comp.DriftBreakRange + comp.DriftBreakTolerance)
             {
                 if (now - comp.StartTime < comp.RefundGracePeriod && distance <= comp.MaxDriftPullDistance)
                 {
-                    _transform.SetCoordinates(uid, Transform(target).Coordinates);
+                    var midpoint = (_transform.GetWorldPosition(uid) + _transform.GetWorldPosition(target)) / 2f;
+                    _transform.SetWorldPosition(uid, midpoint);
+
                 }
                 else
                 {

--- a/Content.Shared/Containers/DragInsertContainerSystem.cs
+++ b/Content.Shared/Containers/DragInsertContainerSystem.cs
@@ -83,7 +83,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
         if (!comp.UseVerbs)
             return;
 
-        if (!args.CanInteract || !args.CanAccess || args.Hands == null)
+        if (!args.CanInteract || !args.CanAccess) // Starlight - remove hands check here so handless entities can cryo
             return;
 
         if (!_container.TryGetContainer(uid, comp.ContainerId, out var container))
@@ -94,7 +94,7 @@ public sealed partial class DragInsertContainerSystem : EntitySystem
             return;
 
         // Eject verb
-        if (container.ContainedEntities.Count > 0)
+        if (args.Hands != null && container.ContainedEntities.Count > 0) // Starlight - hands nullcheck
         {
             // make sure that we can actually take stuff out of the container
             var emptyableCount = 0;

--- a/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
@@ -65,16 +65,6 @@ public sealed partial class LatchComponent : Component
     public float DriftBreakTolerance = 0.5f;
 
     /// <summary>
-    /// Hard ceiling on how far the grace-period recovery pull (see Update()) is allowed
-    /// to move the latcher to reach the target. Meant only to smooth minor jitter right
-    /// after a latch starts; if the target is farther than this, something else moved
-    /// it (or the target was wrong to begin with) and the latch should just break instead
-    /// of dragging the latcher along, however far, to reach it.
-    /// </summary>
-    [DataField]
-    public float MaxDriftPullDistance = 3f;
-
-    /// <summary>
     /// Cap on the physics joint's max length. Matches baseline unarmed melee
     /// range (1.5), not DriftBreakRange, so the target can always punch back.
     /// </summary>

--- a/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
@@ -75,6 +75,21 @@ public sealed partial class LatchComponent : Component
     public float MaxDriftPullDistance = 3f;
 
     /// <summary>
+    /// Cap on the physics joint's max length. Matches baseline unarmed melee
+    /// range (1.5), not DriftBreakRange, so the target can always punch back.
+    /// </summary>
+    [DataField]
+    public float MaxJointLength = 1.5f;
+
+    /// <summary>
+    /// Physics joint keeping latcher and target from drifting apart (e.g. in
+    /// zero-g). Update()'s distance check remains as a backstop for physics-
+    /// bypassing separations like a hard teleport.
+    /// </summary>
+    [AutoNetworkedField, DataField]
+    public string? LatchJointId;
+
+    /// <summary>
     /// The starting, base duration of the latch, in seconds.
     /// </summary>
     [DataField]

--- a/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/LatchComponent.cs
@@ -72,6 +72,20 @@ public sealed partial class LatchComponent : Component
     public float MaxJointLength = 1.5f;
 
     /// <summary>
+    /// How far north the latcher can start and still count as behind the status
+    /// UI, which flips the panel to draw below the target instead.
+    /// </summary>
+    [DataField]
+    public float UiObscureNorthRange = 2.5f;
+
+    /// <summary>
+    /// Horizontal tolerance for the above check - latcher must start roughly
+    /// straight north, not far off to either side.
+    /// </summary>
+    [DataField]
+    public float UiObscureHorizontalTolerance = 2.5f;
+
+    /// <summary>
     /// Physics joint keeping latcher and target from drifting apart (e.g. in
     /// zero-g). Update()'s distance check remains as a backstop for physics-
     /// bypassing separations like a hard teleport.
@@ -161,6 +175,24 @@ public sealed partial class LatchComponent : Component
     /// </summary>
     [ViewVariables, AutoNetworkedField]
     public EntityUid? Target;
+
+    /// <summary>
+    /// Set once at latch start if the K9 began roughly north of the target,
+    /// which would put the K9 behind the TARGET's status UI. Target's client
+    /// draws its own panel below itself instead of above when this is true.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public bool TargetUiBelow;
+
+    /// <summary>
+    /// Set once at latch start if the target began roughly north of the K9
+    /// (i.e. the K9 started south of the target), which would put the target
+    /// behind the LATCHER's own status UI. Latcher's client draws its own
+    /// panel below itself instead of above when this is true.
+    /// </summary>
+    [ViewVariables, AutoNetworkedField]
+    public bool LatcherUiBelow;
+
 
     /// <summary>
     /// The specific, discrete end time designated for the latch.

--- a/Content.Shared/_Starlight/Actions/Components/LatchedComponent.cs
+++ b/Content.Shared/_Starlight/Actions/Components/LatchedComponent.cs
@@ -5,7 +5,7 @@ namespace Content.Shared._Starlight.Actions.Components;
 /// <summary>
 /// Applied to a latch target. Tracks the latcher and the blocked hand item.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
 public sealed partial class LatchedComponent : Component
 {
     [ViewVariables, AutoNetworkedField]

--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
@@ -57,7 +57,8 @@ public abstract partial class SharedLatchSystem : EntitySystem
     }
 
     /// <summary>
-    /// Creates the physics joint between latcher and target. 
+    /// Creates the physics joint between latcher and target.
+    /// </summary>
     protected void CreateLatchJoint(EntityUid uid, LatchComponent comp, EntityUid target)
     {
         if (Timing.ApplyingState)

--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
@@ -1,7 +1,10 @@
 using Content.Shared._Starlight.Actions.Components;
+using Content.Shared._Starlight.Actions.Events;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Timing;
 
 namespace Content.Shared._Starlight.Actions.EntitySystems;
@@ -9,6 +12,8 @@ namespace Content.Shared._Starlight.Actions.EntitySystems;
 public abstract partial class SharedLatchSystem : EntitySystem
 {
     [Dependency] protected IGameTiming Timing = default!;
+    [Dependency] private SharedJointSystem _joints = default!;
+    [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
     public override void Initialize()
     {
@@ -19,6 +24,51 @@ public abstract partial class SharedLatchSystem : EntitySystem
 
         SubscribeLocalEvent<LatchComponent, AttackAttemptEvent>(OnLatcherAttackAttempt);
         SubscribeLocalEvent<LatchBlockedHandComponent, ContainerGettingRemovedAttemptEvent>(OnBlockedHandRemoveAttempt);
+
+        SubscribeLocalEvent<LatchActionEvent>(OnLatchAction);
+    }
+
+    private void OnLatchAction(LatchActionEvent ev)
+    {
+        if (ev.Handled)
+            return;
+
+        var uid = ev.Performer;
+        if (!TryComp<LatchComponent>(uid, out var comp) || comp.Active)
+            return;
+
+        var target = ev.Target;
+        if (target == uid || HasComp<LatchedComponent>(target))
+            return;
+
+        if (!_whitelist.IsWhitelistPassOrNull(comp.Whitelist, target))
+            return;
+
+        CreateLatchJoint(uid, comp, target);
+        StartLatch(uid, comp, target);
+        ev.Handled = true;
+    }
+
+    /// <summary>
+    /// Authoritative side-effects of starting a latch. Overridden serverside.
+    /// </summary>
+    protected virtual void StartLatch(EntityUid uid, LatchComponent comp, EntityUid target)
+    {
+    }
+
+    /// <summary>
+    /// Creates the physics joint between latcher and target. 
+    protected void CreateLatchJoint(EntityUid uid, LatchComponent comp, EntityUid target)
+    {
+        if (Timing.ApplyingState)
+            return;
+
+        comp.LatchJointId = $"latch-joint-{GetNetEntity(uid)}";
+        var joint = _joints.CreateDistanceJoint(uid, target, id: comp.LatchJointId);
+        joint.CollideConnected = false;
+        joint.MinLength = 0f;
+        joint.MaxLength = comp.MaxJointLength;
+        joint.Stiffness = 0f;
     }
 
     private void OnLatcherRefreshMovementSpeed(EntityUid uid, LatchComponent comp, RefreshMovementSpeedModifiersEvent ev)

--- a/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
+++ b/Content.Shared/_Starlight/Actions/EntitySystems/SharedLatchSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared._Starlight.Actions.Components;
 using Content.Shared._Starlight.Actions.Events;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Pulling.Events;
 using Content.Shared.Whitelist;
 using Robust.Shared.Containers;
 using Robust.Shared.Physics.Systems;
@@ -24,6 +25,9 @@ public abstract partial class SharedLatchSystem : EntitySystem
 
         SubscribeLocalEvent<LatchComponent, AttackAttemptEvent>(OnLatcherAttackAttempt);
         SubscribeLocalEvent<LatchBlockedHandComponent, ContainerGettingRemovedAttemptEvent>(OnBlockedHandRemoveAttempt);
+
+        SubscribeLocalEvent<LatchComponent, BeingPulledAttemptEvent>(OnLatcherBeingPulledAttempt);
+        SubscribeLocalEvent<LatchedComponent, BeingPulledAttemptEvent>(OnTargetBeingPulledAttempt);
 
         SubscribeLocalEvent<LatchActionEvent>(OnLatchAction);
     }
@@ -90,6 +94,18 @@ public abstract partial class SharedLatchSystem : EntitySystem
     {
         if (comp.Active)
             ev.Cancel();
+    }
+
+    private void OnLatcherBeingPulledAttempt(Entity<LatchComponent> ent, ref BeingPulledAttemptEvent args)
+    {
+        if (ent.Comp.Active)
+            args.Cancel();
+    }
+
+    private void OnTargetBeingPulledAttempt(Entity<LatchedComponent> ent, ref BeingPulledAttemptEvent args)
+    {
+        if (TryComp<LatchComponent>(ent.Comp.Latcher, out var latchComp) && latchComp.Active)
+            args.Cancel();
     }
 
     /// <summary>

--- a/Content.Shared/_Starlight/Actions/Events/LatchBiteShakeEvent.cs
+++ b/Content.Shared/_Starlight/Actions/Events/LatchBiteShakeEvent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Starlight.Actions.Events;
+
+/// <summary>
+/// Tells clients to play the K9's brief head-shake animation on a Bite Harder use.
+/// </summary>
+[Serializable, NetSerializable]
+public sealed class LatchBiteShakeEvent : EntityEventArgs
+{
+    public NetEntity Latcher;
+
+    public LatchBiteShakeEvent(NetEntity latcher) => Latcher = latcher;
+}

--- a/Resources/Locale/en-US/_Starlight/ui/latch.ftl
+++ b/Resources/Locale/en-US/_Starlight/ui/latch.ftl
@@ -1,6 +1,7 @@
 latch-title = LATCHED
 latch-label-timeremaining = Time
 latch-label-timemax = Max
+latch-bite-harder-button = Bite Harder
 
 latch-instruction-latcher = Bite harder to deal more damage
     and extend the latch duration!

--- a/Resources/Prototypes/_Starlight/Actions/k9.yml
+++ b/Resources/Prototypes/_Starlight/Actions/k9.yml
@@ -15,7 +15,7 @@
   - type: AutoRecharge
     rechargeDuration: 60
   - type: TargetAction
-    range: 1.5
+    range: 3
   - type: EntityTargetAction
     canTargetSelf: false
     whitelist:

--- a/Resources/Prototypes/_Starlight/Shaders/shaders.yml
+++ b/Resources/Prototypes/_Starlight/Shaders/shaders.yml
@@ -110,3 +110,13 @@
   path: "/Textures/_Starlight/Shaders/displacement_unshaded.swsl"
   params:
     displacementSize: 127
+
+- type: shader
+  id: LatchTargetOutline
+  kind: source
+  path: "/Textures/Shaders/outline.swsl"
+  params:
+    outline_color: "#FF0000AA"
+    light_boost: 2
+    light_gamma: 1.5
+    light_whitepoint: 48


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Some fixes and QoL improvements for K9s after watching them post-release.
1. K9s can now enter cryosleep on their own.
2. The 'Bite Harder' action for K9s now appears in the Latch UI, in addition to its usual place in the hotbar.
3. K9s and their target can no longer be pulled while latched; existing pull actions on both parties are cancelled when the latch starts.
4. K9s can no longer latch and exist outside of melee range of a target; they are pulled within melee range of their target.
5. K9s can latch from slightly further away; this helps account for network judder and odd client prediction states.
6. Visual feedback - players were complaining about a lack of visual clarity on what was going on with the latch.  The K9 now shakes when biting harder, and the victim of the latch gets screen shake when bitten harder.
7. K9s now have a physics joint between them and their latch target; this primarily prevents the K9 and their target from drifting away from each other in zero-grav positions and cancelling the latch.
8. New latch vignette animation:  when latched by a K9, a prominent vignette shows to signal you're bit; when the K9 bites down harder, the vignette responds.
9. Being bit by a K9 now highlights the K9 biting you.
10. Latch UI dynamically re-positions based on where the K9 is when the bite starts.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Continual K9 improvements based on post-implementation feedback.
Had to do a very small upstream file touch to allow K9s to cryosleep.  Mobs without hands that can't enter cryo storage (most of them!) aren't really affected.  This is simply a strict improvement to cryosleep logic.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Entering cryosleep

https://github.com/user-attachments/assets/a9942a12-9a10-45c3-9406-c033622e3c0e

Bite Harder button on UI

<img width="365" height="300" alt="image" src="https://github.com/user-attachments/assets/caadda83-2eec-45e2-bf88-a856103a4830" />

Attempting to pull a latched pair

https://github.com/user-attachments/assets/ee84f33f-b951-4702-89f7-169501c258e9

Several visual things:
1. Latch range correction with extended latch distance; places K9 within melee range
2. Visual feedback demonstration, K9 shaking when biting harder and victim's camera shaking
 
https://github.com/user-attachments/assets/3e2e2994-aed7-4797-8490-d28ed1c42234

Physics joint preventing differing movement vectors in zero grav from detaching the latch

https://github.com/user-attachments/assets/a0d30f46-66c8-4be6-988e-1e64a8df7cff

Vignette (added later, not shown in other clips as a result), showing the bite progress.
Also shows dynamic UI repositioning.

https://github.com/user-attachments/assets/f0b31e7e-cf61-487f-96ad-72a20a2f9d72


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Sparlight
- add: K9 - Visual feedback; when K9s bite harder they shake a little, and the victim's screen shakes.
- add: K9 - Visual feedback; a new vignette overlay shows you are being bitten.
- add: K9 - Visual feedback: the K9 that is latched onto you is now prominently highlighted.
- add: K9 - A new 'bite harder' button appears directly in the Latch UI when latched onto a target.
- fix: K9s can now enter cryosleep on their own.
- fix: K9s no longer almost immediately detach their latch when in zero grav.
- fix: K9s can no longer latch outside of melee range, preventing them from being hit.
- tweak: K9s and their target can no longer be pulled while a latch is active.
- tweak: K9s can initiate a latch from slightly farther away; this fixes network judder quietly failing latches.
- tweak: The latch UI now re-positions to avoid the K9 or its target being hidden behind the UI.
