### PR TITLE
Allow Paramedics to Roll Antags

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -19,9 +19,6 @@
   extendedAccess:
   - Chemistry
   - Surgery # Starlight BEGIN
-  special:
-    - !type:AddImplantSpecial
-      implants: [ MindShieldImplant ]  # Starlight END
 
 - type: startingGear
   id: ParamedicGear

--- a/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
@@ -31,7 +31,6 @@
   jobBlacklist:
   - SalvageLead
   - SalvageSpecialist
-  - Paramedic
   - AssistantManager
 
 # Zombie (Initial Infected)


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Let Paramedics roll antag.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
That fact they can't is dumb. Reasoning is whack. Its metagamey as fuck that everyone just stamps them AA with nobody questioning it cause they're always a good guy.

There is no reason why they shouldn't be able to roll antags, and the reasons people will give can just be whatabouted to every other job on the station.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl:
- remove: Paramedics no longer have a mindshield.
- add: Paramedics can roll antags again.
