### PR TITLE
Cyborg crawling fixes

### DIFF
--- a/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Stunnable;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Silicons.Borgs;
+
+/// <summary>
+/// When attached to a cyborg chassis, modifies crawling speed when a module is active.
+/// Decouples crawl speed from hand count and applies a fixed multiplier instead.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class BorgModuleCrawlModifierComponent : Component
+{
+    /// <summary>
+    /// Speed multiplier applied while knocked down and a cyborg module is selected.
+    /// </summary>
+    [DataField]
+    public float ActiveSpeedModifier = 0.5f;
+}
+
+/// <summary>
+/// Handles crawling speed for cyborgs with <see cref="BorgModuleCrawlModifierComponent"/>.
+/// When any module is active, crawl speed is set to a fixed multiplier instead of scaling with free hands.
+/// </summary>
+public sealed class BorgModuleCrawlModifierSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BorgModuleCrawlModifierComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh,
+            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
+    }
+
+    private void OnKnockedDownRefresh(Entity<BorgModuleCrawlModifierComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        if (!TryComp<BorgChassisComponent>(ent.Owner, out _))
+            return;
+
+        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
+            return;
+
+        // Cyborgs have no hands without a module. We use hand count to detect active modules
+        // instead of SelectedModule to avoid a timing issue where HandCountChanged fires
+        // before SelectedModule is set during ProvideItems.
+        if (hands.Hands.Count == 0)
+            return;
+
+        // Overrides the normal hand-based movement speed penalty. 
+		// If a cyborg has a module out, apply ActiveSpeedModifier.
+        float crawlerMod = 1f;
+        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
+            crawlerMod = crawler.SpeedModifier;
+
+        args.SpeedModifier = crawlerMod * ent.Comp.ActiveSpeedModifier;
+    }
+}

--- a/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
@@ -1,7 +1,3 @@
-using Content.Shared.Hands.Components;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Silicons.Borgs.Components;
-using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Starlight.Silicons.Borgs;
@@ -18,42 +14,4 @@ public sealed partial class BorgModuleCrawlModifierComponent : Component
     /// </summary>
     [DataField]
     public float ActiveSpeedModifier = 0.5f;
-}
-
-/// <summary>
-/// Handles crawling speed for cyborgs with <see cref="BorgModuleCrawlModifierComponent"/>.
-/// When any module is active, crawl speed is set to a fixed multiplier instead of scaling with free hands.
-/// </summary>
-public sealed class BorgModuleCrawlModifierSystem : EntitySystem
-{
-    /// <inheritdoc/>
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<BorgModuleCrawlModifierComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh,
-            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
-    }
-
-    private void OnKnockedDownRefresh(Entity<BorgModuleCrawlModifierComponent> ent, ref KnockedDownRefreshEvent args)
-    {
-        if (!TryComp<BorgChassisComponent>(ent.Owner, out _))
-            return;
-
-        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
-            return;
-
-        // Cyborgs have no hands without a module. We use hand count to detect active modules
-        // instead of SelectedModule to avoid a timing issue where HandCountChanged fires
-        // before SelectedModule is set during ProvideItems.
-        if (hands.Hands.Count == 0)
-            return;
-
-        // Overrides the normal hand-based movement speed penalty.
-        // If a cyborg has a module out, apply ActiveSpeedModifier.
-        float crawlerMod = 1f;
-        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
-            crawlerMod = crawler.SpeedModifier;
-
-        args.SpeedModifier = crawlerMod * ent.Comp.ActiveSpeedModifier;
-    }
 }

--- a/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierComponent.cs
@@ -26,6 +26,7 @@ public sealed partial class BorgModuleCrawlModifierComponent : Component
 /// </summary>
 public sealed class BorgModuleCrawlModifierSystem : EntitySystem
 {
+    /// <inheritdoc/>
     public override void Initialize()
     {
         base.Initialize();
@@ -47,8 +48,8 @@ public sealed class BorgModuleCrawlModifierSystem : EntitySystem
         if (hands.Hands.Count == 0)
             return;
 
-        // Overrides the normal hand-based movement speed penalty. 
-		// If a cyborg has a module out, apply ActiveSpeedModifier.
+        // Overrides the normal hand-based movement speed penalty.
+        // If a cyborg has a module out, apply ActiveSpeedModifier.
         float crawlerMod = 1f;
         if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
             crawlerMod = crawler.SpeedModifier;

--- a/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/BorgModuleCrawlModifierSystem.cs
@@ -1,0 +1,44 @@
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared.Stunnable;
+
+namespace Content.Shared._Starlight.Silicons.Borgs;
+
+/// <summary>
+/// Handles crawling speed for cyborgs with <see cref="BorgModuleCrawlModifierComponent"/>.
+/// When any module is active, crawl speed is set to a fixed multiplier instead of scaling with free hands.
+/// </summary>
+public sealed class BorgModuleCrawlModifierSystem : EntitySystem
+{
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BorgModuleCrawlModifierComponent, KnockedDownRefreshEvent>(OnKnockedDownRefresh,
+            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
+    }
+
+    private void OnKnockedDownRefresh(Entity<BorgModuleCrawlModifierComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        if (!TryComp<BorgChassisComponent>(ent.Owner, out _))
+            return;
+
+        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
+            return;
+
+        // Cyborgs have no hands without a module. We use hand count to detect active modules
+        // instead of SelectedModule to avoid a timing issue where HandCountChanged fires
+        // before SelectedModule is set during ProvideItems.
+        if (hands.Hands.Count == 0)
+            return;
+
+        // Overrides the normal hand-based movement speed penalty.
+        // If a cyborg has a module out, apply ActiveSpeedModifier.
+        float crawlerMod = 1f;
+        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
+            crawlerMod = crawler.SpeedModifier;
+
+        args.SpeedModifier = crawlerMod * ent.Comp.ActiveSpeedModifier;
+    }
+}

--- a/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
+++ b/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
@@ -1,6 +1,3 @@
-using Content.Shared.Hands.Components;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Stunnable;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared._Starlight.Stunnable;
@@ -13,37 +10,4 @@ namespace Content.Shared._Starlight.Stunnable;
 [RegisterComponent, NetworkedComponent]
 public sealed partial class CanCrawlWithoutHandsComponent : Component
 {
-}
-
-/// <summary>
-/// Handles <see cref="CanCrawlWithoutHandsComponent"/> - overrides the default
-/// hands-required crawl block when the entity has zero hands.
-/// Runs after <see cref="SharedHandsSystem"/> to replace the 0 speed with normal crawl speed.
-/// </summary>
-public sealed partial class CanCrawlWithoutHandsSystem : EntitySystem
-{
-    [Dependency] private SharedHandsSystem _hands = default!;
-
-    /// <inheritdoc/>
-    public override void Initialize()
-    {
-        base.Initialize();
-        SubscribeLocalEvent<CanCrawlWithoutHandsComponent, KnockedDownRefreshEvent>(OnRefresh,
-            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
-    }
-
-    private void OnRefresh(Entity<CanCrawlWithoutHandsComponent> ent, ref KnockedDownRefreshEvent args)
-    {
-        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
-            return;
-
-        var total = _hands.GetHandCount((ent.Owner, hands));
-        if (total != 0)
-            return;
-
-        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
-            args.SpeedModifier = crawler.SpeedModifier;
-        else
-            args.SpeedModifier = 1f;
-    }
 }

--- a/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
+++ b/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
@@ -1,0 +1,48 @@
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Stunnable;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.Stunnable;
+
+/// <summary>
+/// Allows an entity to crawl even without hands.
+/// Add this component to any entity that should be able to crawl with zero hands,
+/// such as cyborgs when no module is selected.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class CanCrawlWithoutHandsComponent : Component
+{
+}
+
+/// <summary>
+/// Handles <see cref="CanCrawlWithoutHandsComponent"/> - overrides the default
+/// hands-required crawl block when the entity has zero hands.
+/// Runs after <see cref="SharedHandsSystem"/> to replace the 0 speed with normal crawl speed.
+/// </summary>
+public sealed partial class CanCrawlWithoutHandsSystem : EntitySystem
+{
+    [Dependency] private SharedHandsSystem _hands = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CanCrawlWithoutHandsComponent, KnockedDownRefreshEvent>(OnRefresh,
+            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
+    }
+
+    private void OnRefresh(Entity<CanCrawlWithoutHandsComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
+            return;
+
+        var total = _hands.GetHandCount((ent.Owner, hands));
+        if (total != 0)
+            return;
+
+        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
+            args.SpeedModifier = crawler.SpeedModifier;
+        else
+            args.SpeedModifier = 1f;
+    }
+}

--- a/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
+++ b/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsComponent.cs
@@ -24,6 +24,7 @@ public sealed partial class CanCrawlWithoutHandsSystem : EntitySystem
 {
     [Dependency] private SharedHandsSystem _hands = default!;
 
+    /// <inheritdoc/>
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsSystem.cs
+++ b/Content.Shared/_Starlight/Stunnable/CanCrawlWithoutHandsSystem.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Stunnable;
+
+namespace Content.Shared._Starlight.Stunnable;
+
+/// <summary>
+/// Handles <see cref="CanCrawlWithoutHandsComponent"/> - overrides the default
+/// hands-required crawl block when the entity has zero hands.
+/// Runs after <see cref="SharedHandsSystem"/> to replace the 0 speed with normal crawl speed.
+/// </summary>
+public sealed partial class CanCrawlWithoutHandsSystem : EntitySystem
+{
+    [Dependency] private SharedHandsSystem _hands = default!;
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<CanCrawlWithoutHandsComponent, KnockedDownRefreshEvent>(OnRefresh,
+            after: new[] { typeof(SharedHandsSystem), typeof(SharedStunSystem) });
+    }
+
+    private void OnRefresh(Entity<CanCrawlWithoutHandsComponent> ent, ref KnockedDownRefreshEvent args)
+    {
+        if (!TryComp<HandsComponent>(ent.Owner, out var hands))
+            return;
+
+        var total = _hands.GetHandCount((ent.Owner, hands));
+        if (total != 0)
+            return;
+
+        if (TryComp<CrawlerComponent>(ent.Owner, out var crawler))
+            args.SpeedModifier = crawler.SpeedModifier;
+        else
+            args.SpeedModifier = 1f;
+    }
+}

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -91,6 +91,8 @@
     disableExplosionRecursion: true
     canBeStripped: false
   - type: HandlessDoAfter # Starlight
+  - type: CanCrawlWithoutHands # Starlight: Allow crawling without hands
+  - type: BorgModuleCrawlModifier # Starlight: Half crawl speed when module active
   - type: ComplexInteraction
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Cyborgs can now crawl unconditionally as long as they aren't down (and at half speed with a module active).

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
For a long while now cyborgs have had an issue wherein they aren't able to crawl if they had a module deployed and it didn't have any freeform hand slots empty (for example if you had the tools module open you just couldn't crawl at all in any situation). This was very unclear behavior and if you aren't in the know just made it seem like cyborgs arbitrarily can't crawl sometimes. This issue was related to how movement speed is calculated based on available hand slots (if all of your hand slots are occupied, you can't crawl at all). To fix this, two components have been created:

1. CanCrawlWithoutHands, a generic component that can be added to anything we want to be able to crawl without hands. This is used by cyborgs when they don't have a module out because in that state they have no hands.
2. BorgModuleCrawlModifier, a component intended specifically for cyborgs that checks if they have a module active then allows them to crawl at half normal crawling speed if they do, regardless of whether any freeform hand slots are open or are otherwise present (half speed is the speed you would be at when one hand is holding something on an entity with hands that is crawling)

Both components have been added to base_borg_chassis.yml so that it affects any cyborgs that inherit from it. This ensures that cyborgs retain their ability to crawl in a manner that's more intuitive and doesn't seem arbitrary. This does not impact their ability to move while crit; cyborgs in crit still cannot move, as expected.

Compared to #5789, this is implemented as components instead of adding the carveout directly to the hand system, and CanCrawlWithoutHands was added as a component for generic use by request of @walksanatora.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/ab16cc8d-19d0-43bd-bdf0-4606fc7be2e4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rhapsody (Pepta Vismahl)
- tweak: Cyborgs can now crawl without a module active, and crawl at half speed with any module active.