### PR TITLE
Intellicard fixes and adding pAI to allowed targets

### DIFF
--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -273,11 +273,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     }
 
     private void OnIntellicardDoAfter(Entity<StationAiHolderComponent> ent, ref IntellicardDoAfterEvent args) => IntellicardTransfer(ent.Owner, ent.Comp, args); // Starlight-edit
-
     private void OnIntellicardBorgDoAfter(Entity<BorgBrainComponent> ent, ref IntellicardDoAfterEvent args) => IntellicardTransfer(ent.Owner, null, args); // Starlight-edit
-    #region Starlight
-    private void OnIntellicardPaiDoAfter(Entity<PAIComponent> ent, ref IntellicardDoAfterEvent args) => TransferPai(ent.Owner, args);
-    #endregion
     private void IntellicardTransfer(EntityUid uid, StationAiHolderComponent? component, IntellicardDoAfterEvent args) // Starlight-edit
     {
         if (args.Cancelled)

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -40,7 +40,6 @@ using Robust.Shared.Utility;
 using Content.Shared._Starlight.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.TextToSpeech;
-using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using System.Linq;
 using Content.Shared.Silicons.Laws.Components;
@@ -379,58 +378,6 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         }
         // Starlight-end
     }
-
-    // Starlight: wipe the name of the entity to the prototype name, used for entities when they are downloaded/uploaded
-    private void ResetNameToPrototype(EntityUid entity)
-    {
-        if (MetaData(entity).EntityPrototype is { } prototype)
-            _metadata.SetEntityName(entity, prototype.Name);
-    }
-    #region Starlight
-    private bool IsAiInterface(EntityUid entity)
-    {
-        if (TryComp<BorgChassisComponent>(entity, out var chassis) && chassis.BrainEntity is { } brain)
-            entity = brain;
-
-        return HasComp<StationAIShuntComponent>(entity);
-    }
-
-    private void TransferPai(EntityUid pai, IntellicardDoAfterEvent args)
-    {
-        if (args.Cancelled || args.Handled)
-            return;
-
-        if (args.Args.Target is not { } card || !TryComp<StationAiHolderComponent>(card, out var cardHolder))
-            return;
-
-        var slot = cardHolder.Slot;
-        if (slot.Item is { } stored)
-        {
-            if (!_mind.TryGetMind(stored, out var mindId, out var mind))
-                return;
-
-            if (_mind.TryGetMind(pai, out _, out _))
-                return;
-
-            var name = _nameModifier.GetBaseName(stored);
-            _mind.TransferTo(mindId, pai, ghostCheckOverride: true, mind: mind);
-            _metadata.SetEntityName(pai, name);
-            Del(stored);
-            args.Handled = true;
-            return;
-        }
-
-        if (slot.ContainerSlot is not { } containerSlot || !_mind.TryGetMind(pai, out var paiMindId, out var paiMind))
-            return;
-
-        var paiName = _nameModifier.GetBaseName(pai);
-        var brain = SpawnInContainerOrDrop(DefaultAi, card, containerSlot.ID);
-        _metadata.SetEntityName(brain, paiName);
-        _metadata.SetEntityName(card, paiName);
-        _mind.TransferTo(paiMindId, brain, ghostCheckOverride: true, mind: paiMind);
-        args.Handled = true;
-    }
-    #endregion
     private void OnHolderInteract(Entity<StationAiHolderComponent> ent, ref AfterInteractEvent args)
     {
         if (args.Handled || !args.CanReach || args.Target == null)

--- a/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/Silicons/StationAi/SharedStationAiSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared.Mind;
 using Content.Shared.Mind.Components; // Starlight-edit
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.PAI;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
@@ -39,6 +40,7 @@ using Robust.Shared.Utility;
 using Content.Shared._Starlight.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.TextToSpeech;
+using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using System.Linq;
 using Content.Shared.Silicons.Laws.Components;
@@ -122,6 +124,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         SubscribeLocalEvent<StationAiHolderComponent, IntellicardDoAfterEvent>(OnIntellicardDoAfter);
 
         SubscribeLocalEvent<BorgBrainComponent, IntellicardDoAfterEvent>(OnIntellicardBorgDoAfter); // Starlight-edit
+        SubscribeLocalEvent<PAIComponent, IntellicardDoAfterEvent>(OnIntellicardPaiDoAfter); // Starlight-edit
 
         SubscribeLocalEvent<StationAiCoreComponent, EntInsertedIntoContainerMessage>(OnAiInsert);
         SubscribeLocalEvent<StationAiCoreComponent, EntRemovedFromContainerMessage>(OnAiRemove);
@@ -273,7 +276,9 @@ public abstract partial class SharedStationAiSystem : EntitySystem
     private void OnIntellicardDoAfter(Entity<StationAiHolderComponent> ent, ref IntellicardDoAfterEvent args) => IntellicardTransfer(ent.Owner, ent.Comp, args); // Starlight-edit
 
     private void OnIntellicardBorgDoAfter(Entity<BorgBrainComponent> ent, ref IntellicardDoAfterEvent args) => IntellicardTransfer(ent.Owner, null, args); // Starlight-edit
-
+    #region Starlight
+    private void OnIntellicardPaiDoAfter(Entity<PAIComponent> ent, ref IntellicardDoAfterEvent args) => TransferPai(ent.Owner, args);
+    #endregion
     private void IntellicardTransfer(EntityUid uid, StationAiHolderComponent? component, IntellicardDoAfterEvent args) // Starlight-edit
     {
         if (args.Cancelled)
@@ -286,6 +291,9 @@ public abstract partial class SharedStationAiSystem : EntitySystem
             return;
 
         var target = args.Args.Target.Value;
+        if (IsAiInterface(target)) // Starlight-edit
+            return;
+
         if (TryComp<BorgChassisComponent>(target, out var chassis) && chassis.BrainEntity is { } chassisBrain)
             target = chassisBrain;
 
@@ -378,7 +386,51 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         if (MetaData(entity).EntityPrototype is { } prototype)
             _metadata.SetEntityName(entity, prototype.Name);
     }
+    #region Starlight
+    private bool IsAiInterface(EntityUid entity)
+    {
+        if (TryComp<BorgChassisComponent>(entity, out var chassis) && chassis.BrainEntity is { } brain)
+            entity = brain;
 
+        return HasComp<StationAIShuntComponent>(entity);
+    }
+
+    private void TransferPai(EntityUid pai, IntellicardDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (args.Args.Target is not { } card || !TryComp<StationAiHolderComponent>(card, out var cardHolder))
+            return;
+
+        var slot = cardHolder.Slot;
+        if (slot.Item is { } stored)
+        {
+            if (!_mind.TryGetMind(stored, out var mindId, out var mind))
+                return;
+
+            if (_mind.TryGetMind(pai, out _, out _))
+                return;
+
+            var name = _nameModifier.GetBaseName(stored);
+            _mind.TransferTo(mindId, pai, ghostCheckOverride: true, mind: mind);
+            _metadata.SetEntityName(pai, name);
+            Del(stored);
+            args.Handled = true;
+            return;
+        }
+
+        if (slot.ContainerSlot is not { } containerSlot || !_mind.TryGetMind(pai, out var paiMindId, out var paiMind))
+            return;
+
+        var paiName = _nameModifier.GetBaseName(pai);
+        var brain = SpawnInContainerOrDrop(DefaultAi, card, containerSlot.ID);
+        _metadata.SetEntityName(brain, paiName);
+        _metadata.SetEntityName(card, paiName);
+        _mind.TransferTo(paiMindId, brain, ghostCheckOverride: true, mind: paiMind);
+        args.Handled = true;
+    }
+    #endregion
     private void OnHolderInteract(Entity<StationAiHolderComponent> ent, ref AfterInteractEvent args)
     {
         if (args.Handled || !args.CanReach || args.Target == null)
@@ -401,15 +453,19 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         // Starlight-start: Downloadable borgs
 
         var borgTarget = args.Target.Value;
-        var borgMindTarget = borgTarget; // Starlight-edit
+        var borgMindTarget = borgTarget;
+        if (IsAiInterface(borgTarget))
+            return;
+
         if (TryComp<BorgChassisComponent>(borgTarget, out var chassis) && chassis.BrainEntity is { } chassisBrain)
             borgTarget = chassisBrain;
 
         var isBorg = HasComp<BorgBrainComponent>(borgTarget);
+        var isPai = HasComp<PAIComponent>(borgTarget);
         var isShunted = TryComp<StationAIShuntComponent>(borgTarget, out var shunt) && shunt.Return != null;
         var borgHaveMind = TryComp<MindContainerComponent>(borgMindTarget, out var mindContainer) && mindContainer.HasMind; // Starlight-edit
 
-        if (targetHolder == null && !isBorg)
+        if (targetHolder == null && !isBorg && !isPai)
         {
             var message = cardHasAi ? "intellicard-cannot-transfer-to" : "intellicard-core-empty";
             _popup.PopupClient(Loc.GetString(message), args.User, args.User, PopupType.Medium);
@@ -425,7 +481,7 @@ public abstract partial class SharedStationAiSystem : EntitySystem
             args.Handled = true;
             return;
         }
-        if (!cardHasAi && !coreHasAi && !(isBorg && borgHaveMind)) // Starlight-edit
+        if (!cardHasAi && !coreHasAi && !(isBorg && borgHaveMind) && !isPai) // Starlight: pai is also possible
         {
             _popup.PopupClient(Loc.GetString("intellicard-core-empty"), args.User, args.User, PopupType.Medium);
             args.Handled = true;
@@ -434,7 +490,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
         // Starlight-start: Downloadable borgs
         if (isShunted)
         {
-            _popup.PopupClient(Loc.GetString("intellicard-shunted"), args.User, args.User, PopupType.Medium);
+            if (HasComp<BorgBrainComponent>(ent.Owner))
+                _popup.PopupClient(Loc.GetString("intellicard-shunted"), args.User, args.User, PopupType.Medium);
             args.Handled = true;
             return;
         }
@@ -445,8 +502,8 @@ public abstract partial class SharedStationAiSystem : EntitySystem
             var ev = new ChatNotificationEvent(_downloadChatNotificationPrototype, args.Used, args.User);
             RaiseLocalEvent(held.Value, ref ev);
         }
-        // Starlight-start: borgs can be downloaded/uploaded
-        else if (isBorg)
+        // Starlight-start: borgs/pAI can be downloaded/uploaded
+        else if (isBorg || isPai)
         {
             var ev = new ChatNotificationEvent(_downloadChatNotificationPrototype, args.Used, args.User);
             RaiseLocalEvent(args.Target.Value, ref ev);

--- a/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/Borgs/StationAIShuntSystem.cs
@@ -67,6 +67,15 @@ public sealed partial class StationAIShuntSystem : EntitySystem
 
         if (!TryComp<StationAIShuntComponent>(target, out var shunt))
             return;
+
+        // We check first if this is already "posessed" for one or another reason. This is a remote, not a ghost maker.
+        if (_mindSystem.TryGetMind(target, out _, out _))
+        {
+            if (_net.IsServer)
+                _popup.PopupEntity(Loc.GetString("shunt-target-occupied"), target, uid, PopupType.Large);
+            return;
+        }
+
         if (!_mindSystem.TryGetMind(uid, out var mindId, out var _))
             return;
         if (!TryComp<MobStateComponent>(uid, out var state) || state.CurrentState != MobState.Alive)

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,3 +1,4 @@
+//ReSharper disable CheckNamespace
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.Silicons.Borgs;
 

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Intellicard;
 using Content.Shared.PAI;
+using Content.Shared.Popups;
 //ReSharper disable CheckNamespace
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.Silicons.Borgs;
@@ -40,7 +41,10 @@ public abstract partial class SharedStationAiSystem
                 return;
 
             if (_mind.TryGetMind(pai, out _, out _))
+            {
+                _popup.PopupEntity(Loc.GetString("pai-target-occupied"), pai, args.User, PopupType.Large);
                 return;
+            }
 
             var name = _nameModifier.GetBaseName(stored);
             _mind.TransferTo(mindId, pai, ghostCheckOverride: true, mind: mind);
@@ -58,6 +62,7 @@ public abstract partial class SharedStationAiSystem
         _metadata.SetEntityName(brain, paiName);
         _metadata.SetEntityName(card, paiName);
         _mind.TransferTo(paiMindId, brain, ghostCheckOverride: true, mind: paiMind);
+        ResetNameToPrototype(pai);
         args.Handled = true;
     }
 }

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,0 +1,58 @@
+using Content.Shared.Silicons.Borgs.Components;
+using Content.Shared._Starlight.Silicons.Borgs;
+
+namespace Content.Shared.Silicons.StationAi;
+
+public abstract partial class SharedStationAiSystem
+{
+    // Starlight: wipe the name of the entity to the prototype name, used for entities when they are downloaded/uploaded
+    private void ResetNameToPrototype(EntityUid entity)
+    {
+        if (MetaData(entity).EntityPrototype is { } prototype)
+            _metadata.SetEntityName(entity, prototype.Name);
+    }
+
+    private bool IsAiInterface(EntityUid entity)
+    {
+        if (TryComp<BorgChassisComponent>(entity, out var chassis) && chassis.BrainEntity is { } brain)
+            entity = brain;
+
+        return HasComp<StationAIShuntComponent>(entity);
+    }
+
+    private void TransferPai(EntityUid pai, IntellicardDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (args.Args.Target is not { } card || !TryComp<StationAiHolderComponent>(card, out var cardHolder))
+            return;
+
+        var slot = cardHolder.Slot;
+        if (slot.Item is { } stored)
+        {
+            if (!_mind.TryGetMind(stored, out var mindId, out var mind))
+                return;
+
+            if (_mind.TryGetMind(pai, out _, out _))
+                return;
+
+            var name = _nameModifier.GetBaseName(stored);
+            _mind.TransferTo(mindId, pai, ghostCheckOverride: true, mind: mind);
+            _metadata.SetEntityName(pai, name);
+            Del(stored);
+            args.Handled = true;
+            return;
+        }
+
+        if (slot.ContainerSlot is not { } containerSlot || !_mind.TryGetMind(pai, out var paiMindId, out var paiMind))
+            return;
+
+        var paiName = _nameModifier.GetBaseName(pai);
+        var brain = SpawnInContainerOrDrop(DefaultAi, card, containerSlot.ID);
+        _metadata.SetEntityName(brain, paiName);
+        _metadata.SetEntityName(card, paiName);
+        _mind.TransferTo(paiMindId, brain, ghostCheckOverride: true, mind: paiMind);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,3 +1,5 @@
+using Content.Shared.Intellicard;
+using Content.Shared.PAI;
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.Silicons.Borgs;
 
@@ -5,6 +7,8 @@ namespace Content.Shared.Silicons.StationAi;
 
 public abstract partial class SharedStationAiSystem
 {
+    private void OnIntellicardPaiDoAfter(Entity<PAIComponent> ent, ref IntellicardDoAfterEvent args) => TransferPai(ent.Owner, args);
+
     // Starlight: wipe the name of the entity to the prototype name, used for entities when they are downloaded/uploaded
     private void ResetNameToPrototype(EntityUid entity)
     {

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -42,7 +42,7 @@ public abstract partial class SharedStationAiSystem
 
             if (_mind.TryGetMind(pai, out _, out _))
             {
-                _popup.PopupEntity(Loc.GetString("pai-target-occupied"), pai, args.User, PopupType.Large);
+                _popup.PopupEntity(Loc.GetString("intellicard-core-occupied"), pai, args.User, PopupType.Large);
                 return;
             }
 

--- a/Resources/Locale/en-US/_Starlight/borg/pai.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/pai.ftl
@@ -1,0 +1,1 @@
+pai-target-occupied = An pAI is already using that device.

--- a/Resources/Locale/en-US/_Starlight/borg/pai.ftl
+++ b/Resources/Locale/en-US/_Starlight/borg/pai.ftl
@@ -1,1 +1,0 @@
-pai-target-occupied = An pAI is already using that device.


### PR DESCRIPTION
## Short description
- This will fix the bug that intellicards can target AI Interfaces or borgs with them installed (entity transfer in/out)
- This will add the ability to the intellicard to also target pAI's (in/out)

## Why we need to add this
While very convenient, AI Interfaces are to be be used only for shunting. This fixes an obviously problem that was also reported as such (directly to me as i have made the merged pull request https://github.com/ss14Starlight/space-station-14/pull/5776

pAI's are just players in boxes. It makes sense to be able to transfer those to any other digital interface instead of them being ghosting and doing it that way.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/4c51d12e-4aa9-4588-bd25-16a46a4066ba


## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Floximo
- add: Intellicards can now target pAI and transfer in both directions.
- fix: AI Interfaces or borgs with AI Interfaces can no longer be target/source of intellicard transfers.
