### PR TITLE
Update MedTak silicon to use the new damage modifier

### DIFF
--- a/Resources/Prototypes/_Starlight/Admeme/MedTak/Entities/Mobs/medtak_chassis.yml
+++ b/Resources/Prototypes/_Starlight/Admeme/MedTak/Entities/Mobs/medtak_chassis.yml
@@ -97,3 +97,5 @@
       color: "#d55858"
       radius: 5
       energy: 3
+    - type: Damageable
+      damageModifierSet: ArmoredSilicon


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
New damage modifiers were added for borgs, updates the MedTak silicon to use the armoured set.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
An armoured chassis should probably use armour.
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="428" height="464" alt="image" src="https://github.com/user-attachments/assets/40b1b5c6-796f-4f3d-a137-12264d20753a" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: SevenShades
- tweak: Updated MedTak silicon to use armour.