### PR TITLE
ID card computer alt interact now removes the target ID

### DIFF
--- a/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
@@ -35,10 +35,6 @@ namespace Content.Shared.Access.Systems
         {
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.PrivilegedIdCardSlotId, component.PrivilegedIdSlot);
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.TargetIdCardSlotId, component.TargetIdSlot);
-#pragma warning disable RA0002
-            // Starlight: Target should eject first on alt-click. Need to suppress error to prevent build fail due to read/write access.
-            component.TargetIdSlot.Priority = 1;
-#pragma warning restore RA0002
         }
 
         private void OnComponentRemove(EntityUid uid, IdCardConsoleComponent component, ComponentRemove args)

--- a/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
@@ -36,7 +36,7 @@ namespace Content.Shared.Access.Systems
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.PrivilegedIdCardSlotId, component.PrivilegedIdSlot);
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.TargetIdCardSlotId, component.TargetIdSlot);
 #pragma warning disable RA0002
-            // Target should eject first on alt-click
+            // Starlight: Target should eject first on alt-click. Need to suppress error to prevent build fail due to read/write access.
             component.TargetIdSlot.Priority = 1;
 #pragma warning restore RA0002
         }

--- a/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
+++ b/Content.Shared/Access/Systems/SharedIdCardConsoleSystem.cs
@@ -35,6 +35,10 @@ namespace Content.Shared.Access.Systems
         {
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.PrivilegedIdCardSlotId, component.PrivilegedIdSlot);
             _itemSlotsSystem.AddItemSlot(uid, IdCardConsoleComponent.TargetIdCardSlotId, component.TargetIdSlot);
+#pragma warning disable RA0002
+            // Target should eject first on alt-click
+            component.TargetIdSlot.Priority = 1;
+#pragma warning restore RA0002
         }
 
         private void OnComponentRemove(EntityUid uid, IdCardConsoleComponent component, ComponentRemove args)

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -733,6 +733,7 @@
         components:
         - IdCard
     targetIdSlot:
+      priority: 1 # Starlight: Eject target ID first when alt interacting, instead of privileged ID
       name: id-card-console-target-id
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -733,7 +733,6 @@
         components:
         - IdCard
     targetIdSlot:
-      priority: 1 # Starlight: Eject target ID first when alt interacting, instead of privileged ID
       name: id-card-console-target-id
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -128,6 +128,7 @@
           components:
           - IdCard
       targetIdSlot:
+        priority: 1
         name: id-card-clipboard-target-id
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/folders.yml
@@ -128,7 +128,6 @@
           components:
           - IdCard
       targetIdSlot:
-        priority: 1
         name: id-card-clipboard-target-id
         ejectSound: /Audio/Machines/id_swipe.ogg
         insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -343,6 +343,7 @@
         components:
         - IdCard
     targetIdSlot:
+      priority: 1
       name: UniversalIdConsole-targetId
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/Computers/computers.yml
@@ -343,7 +343,6 @@
         components:
         - IdCard
     targetIdSlot:
-      priority: 1
       name: UniversalIdConsole-targetId
       ejectSound: /Audio/Machines/id_swipe.ogg
       insertSound: /Audio/Weapons/Guns/MagIn/batrifle_magin.ogg


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Currently when using alt interact (alt-click) on the ID card computer, it ejects the privileged ID card. However, it would be more intuitive if it removed the target ID, which is what this PR changes. This affects anything that inherits from IdCardConsole, so that includes the master ID card computer and the bureaucratic digi-board.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This change is needed because it makes more sense for alt interact to remove the target ID card (the one to be modified) since it fits the workflow of the HoP better; they remove the target ID from the ID computer a lot more often than they'll be removing the privileged ID, and doing this prevents them from accidentally handing over the privileged ID (I've done this more often than I'd like to admit).

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://github.com/user-attachments/assets/3358643b-faf8-458c-8cc1-7032c0f69196

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rhapsody (Pepta Vismahl)
- add: Alt interacting with the ID card computer or similar now ejects the target ID first instead of the privileged ID.