### PR TITLE
Timer Construction Fixes

### DIFF
--- a/Content.Server/Construction/ConstructionSystem.Initial.cs
+++ b/Content.Server/Construction/ConstructionSystem.Initial.cs
@@ -101,7 +101,8 @@ namespace Content.Server.Construction
             ConstructionGraphNode targetNode,
             ConstructionPrototype constructionPrototype, // Starlight edit
             EntityCoordinates coords,
-            Angle angle = default)
+            Angle angle = default,
+            Direction? checkDirection = null) // Starlight edit
         {
             // We need a place to hold our construction items!
             var container = _container.EnsureContainer<Container>(user, materialContainer, out var existed);
@@ -273,7 +274,9 @@ namespace Content.Server.Construction
             // Starlight edit start
             foreach (var condition in constructionPrototype.Conditions)
             {
-                if (!condition.Condition(user, coords, angle.GetCardinalDir()))
+                // Use the direction the placement was actually validated with; `angle` is forced
+                // to zero for recipes with canRotate: false, which would re-check a different facing.
+                if (!condition.Condition(user, coords, checkDirection ?? angle.GetCardinalDir()))
                 {
                     var message = condition.GenerateGuideEntry()?.Localization
                                   ?? "construction-system-construct-conditions-not-met";
@@ -561,7 +564,8 @@ namespace Content.Server.Construction
                     targetNode,
                     constructionPrototype, // Starlight edit
                     GetCoordinates(ev.Location),
-                    constructionPrototype.CanRotate ? ev.Angle : Angle.Zero) is not {Valid: true} structure)
+                    constructionPrototype.CanRotate ? ev.Angle : Angle.Zero,
+                    ev.Angle.GetCardinalDir()) is not {Valid: true} structure) // Starlight edit
             {
                 Cleanup();
                 return;

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -103,6 +103,7 @@
 # Construction Frame
 
 - type: entity
+  parent: BaseWallmount
   id: TimerFrame
   name: timer frame
   description: A construction frame for a timer.
@@ -111,6 +112,7 @@
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/signalscreen.rsi
     state: signalscreen
+    noRot: true
   - type: Construction
     graph: Timer
     node: frame

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/timer.yml
@@ -103,7 +103,7 @@
 # Construction Frame
 
 - type: entity
-  parent: BaseWallmount
+  parent: BaseWallmount # Starlight
   id: TimerFrame
   name: timer frame
   description: A construction frame for a timer.
@@ -112,7 +112,7 @@
     drawdepth: WallMountedItems
     sprite: Structures/Wallmounts/signalscreen.rsi
     state: signalscreen
-    noRot: true
+    noRot: true # Starlight
   - type: Construction
     graph: Timer
     node: frame


### PR DESCRIPTION
## Short description
Fixes two bugs relating to timers:
1. Brig timers and Screen timers couldn't be placed due to #5427 not accounting for constructions with no direction causing `adjWallRaycastResults` to check with two different directions. 
2. After building a signal timer the timer frame would be rotated 180 degrees and unclickable. It now  Now parents `BaseWallmount` with `noRot: true` to match ScreenTimer.

## Why we need to add this
Very clearly bugs. These prevent repairing solitary cells if destroyed since the construction will always fail.

## Media (Video/Screenshots)
### Before:

https://github.com/user-attachments/assets/070270d0-3b69-4f76-acc6-630713b91c4a

### After: 

https://github.com/user-attachments/assets/1814b0cf-882e-4c58-8beb-9e8cd7fc0d32

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->


:cl: 0warie
- fix: Fixed being unable to construct screen and brig timers.
- fix: Fixed signal timers turning into un-clickable timer frames after beginning construction.
