### PR TITLE
Cadet Access is no more

### DIFF
--- a/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
+++ b/Resources/Locale/en-US/_Starlight/prototypes/access/accesses.ftl
@@ -20,7 +20,6 @@ id-card-access-level-robotics = Robotics
 
 # Security
 id-card-access-level-brigmedic = Brigmedic
-id-card-access-level-cadet = Cadet
 
 # Service
 id-card-access-level-clown = Clown

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -16,7 +16,6 @@
   supervisors: job-supervisors-security
   access:
 # - Security # Starlight change
-  - Cadet # Starlight change
   - Brig
   - Maintenance
   - External

--- a/Resources/Prototypes/_Starlight/Access/security.yml
+++ b/Resources/Prototypes/_Starlight/Access/security.yml
@@ -1,7 +1,3 @@
 - type: accessLevel
   id: Brigmedic
   name: id-card-access-level-brigmedic
-
-- type: accessLevel
-  id: Cadet
-  name: id-card-access-level-cadet

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -23,7 +23,7 @@
     stateDoorOpen: sec_open
     stateDoorClosed: sec_door
   - type: AccessReader
-    access: [["Security"], ["Cadet"]]
+    access: [["Security"]]
 
 # Brigmedic
 - type: entity


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Deletes Cadet Access
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It serves quiet literally zero purpose the only reason it was added was to prevent sec cadets from using the experimental hardsuit and e.t.c but that is dead and buried in the ground, atp its just useless there is not a SINGLE thing that uses cadet access
## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/a
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative. -->

:cl: Forrestgod
- remove: Removed Cadet Access.
