### PR TITLE
Removes QM access from funding allocation computer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/computers.yml
@@ -1348,7 +1348,7 @@
     key: enum.FundingAllocationConsoleUiKey.Key
   - type: ActivatableUIRequiresAccess
   - type: AccessReader
-    access: [["HeadOfPersonnel"], ["Quartermaster"]] #Starlight edit: added Quatermaster
+    access: [["HeadOfPersonnel"]]
   - type: UserInterface
     interfaces:
       enum.FundingAllocationConsoleUiKey.Key:


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reverts changes made in #2452 where the funding allocation computer was given QM access.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Poll results: https://discord.com/channels/1272545509562777621/1322283126285668382/1540718349833474129
<img width="483" height="277" alt="image" src="https://github.com/user-attachments/assets/af12f084-bc2a-4944-b820-506fd2507918" />

Basically, there was plans to make this a computer that the QM managed, but these mapping changes... never actually got implemented? I ran a poll to see if people actually still wanted QM to have this computer, and the results came out about 50-50 (with a slight edge towards HOP).

Given that the poll results are as close as they are, it does not make sense to me to edit the entire map pool to move this computer from where it was already living on the majority of maps - the HOP office. Mapping guidelines have been updated to say:
- put the computer in HOP
- if no room in HOP, put it on Bridge
- you can have this computer in HOP _and_ the Bridge if you want to / have space for it

I'll be following up this PR with mapping PRs to change the very few maps (Novo Lobster, Serpentcrest, Cork) that had this computer mapped to the QM Office.

Below is a list of where the Funding Allocation Computer is on our maps.
```
Bridge Only:
- Cluster
- Leth
- Ming
- Sepultum
- Saltern
- Silica
- Starboard

Bridge & HOP:
- Kiloton
- Prism
- Space Mall

HOP Only:
- Bagel
- Box
- Cog
- Elkridge
- Fland
- Hotel
- Manor
- Oasis
- Orwell
- Packed
- Plasma

Bridge & QM:
- Novo Lobster

QM Only:
- Cork
- Lagan

Bridge, HOP, & QM:
- Serpentcrest

Entirely Missing:
- Reach
```

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- remove: Quartermaster access from the funding allocation computer.
