### PR TITLE
Anomaly Particles

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -117,6 +117,13 @@
     damage:
       types:
         Heat: 10
+  # Starlight Start
+  - type: ChildEntities
+    childPrototypes:
+      - prototype: OverlayFireEffect
+      - prototype: OverlayEmbersEffect
+      - prototype: OverlaySmokeEffect
+  # Starlight End
 
 - type: entity
   id: AnomalyGravity
@@ -273,6 +280,10 @@
       - MobFleshClamp
       - MobFleshLover
       - FleshKudzu
+  # Starlight Start
+  - type: ParticleEmitter
+    effect: DrippingBlood
+  # Starlight End
 
 - type: entity
   id: AnomalyBluespace
@@ -322,6 +333,12 @@
       collection: RadiationPulse
       params:
         volume: 5
+  # Starlight Start
+  - type: ChildEntities
+    childPrototypes:
+      - prototype: OverlayBluespaceBurstEffect
+      - prototype: OverlayBluespaceSparksEffect
+  # Starlight End
 
 - type: entity
   id: AnomalyIce
@@ -378,6 +395,10 @@
     damage:
       types:
         Cold: 10
+  # Starlight Start
+  - type: ParticleEmitter
+    effect: SnowFall
+  # Starlight End
 
 - type: entity
   id: AnomalyRockBase
@@ -989,6 +1010,10 @@
     solution: anomaly
   - type: InjectableSolution
     solution: beaker
+  # Starlight Start
+  - type: ParticleEmitter
+    effect: DrippingLiquid
+  # Starlight End
 
 - type: entity
   id: AnomalyShadow
@@ -1054,6 +1079,10 @@
     damage:
       types:
         Cold: 10
+  # Starlight Start
+  - type: ParticleEmitter
+    effect: ShadowMist
+  # Starlight End
 
 - type: entity
   id: AnomalyTech
@@ -1089,6 +1118,10 @@
     ports:
       - Pulse
       - Timer
+  # Starlight Start
+  - type: ParticleEmitter
+    effect: BluespaceSparks
+  # Starlight End
 
 - type: entity
   id: AnomalyTechBeam

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -252,8 +252,6 @@
             maxRange: 1
           spawns:
             - AdminInstantEffectFlash
-    - type: ParticleEmitter
-      effect: ShadowMist
 
 - type: entity
   id: PortalShadekinHub

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies.yml
@@ -252,6 +252,8 @@
             maxRange: 1
           spawns:
             - AdminInstantEffectFlash
+    - type: ParticleEmitter
+      effect: ShadowMist
 
 - type: entity
   id: PortalShadekinHub

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies_effects.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Specific/Anomaly/anomalies_effects.yml
@@ -1,0 +1,49 @@
+- type: entity
+  id: OverlayFireEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ParticleEmitter
+    effect: SfFireContinuous
+  - type: Tag
+    tags:
+      - HideContextMenu
+
+- type: entity
+  id: OverlayEmbersEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ParticleEmitter
+    effect: SfFireEmbers
+  - type: Tag
+    tags:
+      - HideContextMenu
+
+- type: entity
+  id: OverlaySmokeEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ParticleEmitter
+    effect: SfFireSmoke
+  - type: Tag
+    tags:
+      - HideContextMenu
+
+- type: entity
+  id: OverlayBluespaceBurstEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ParticleEmitter
+    effect: BluespaceBurst
+  - type: Tag
+    tags:
+      - HideContextMenu
+
+- type: entity
+  id: OverlayBluespaceSparksEffect
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ParticleEmitter
+    effect: BluespaceSparks
+  - type: Tag
+    tags:
+      - HideContextMenu

--- a/Resources/Prototypes/_Starlight/particle_effects.yml
+++ b/Resources/Prototypes/_Starlight/particle_effects.yml
@@ -1,0 +1,168 @@
+- type: particleEffect
+  id: DrippingBlood
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: soft_dot
+  startColor: "#a80000"
+  endColor: "#730b0b"
+  alphaOverLifetime:
+    - time: 0.0
+      value: 1.0
+    - time: 1.0
+      value: 0.0
+  emissionRate: 10
+  maxCount: 100
+  particleSize: 1
+  burst: false
+  duration: 0
+  gravity: 1
+  drag: 0.1
+  noiseStrength: 0.15
+  noiseFrequency: 0.8
+  spreadAngle: 60
+  emitAngle: 180
+  shape:
+    type: CircleFill
+    radius: 0.3
+
+- type: particleEffect
+  id: SnowFall
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: cross
+  startColor: "#f0f0f0"
+  endColor: "#c2f0ff"
+  alphaOverLifetime:
+    - time: 0.0
+      value: 1.0
+    - time: 2.5
+      value: 0.1
+  lifetime: 2.5
+  lifetimeVariance: 0.8
+  speed: 0.9
+  emissionRate: 15
+  maxCount: 100
+  particleSize: 1
+  burst: false
+  duration: 0
+  gravity: 2.5
+  drag: 0.1
+  noiseStrength: 0.15
+  noiseFrequency: 0.8
+  spreadAngle: 60
+  emitAngle: 0
+  shape:
+    type: CircleFill
+    radius: 2
+
+- type: particleEffect
+  id: DrippingLiquid
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: soft_dot
+  startColor: "#c2f0ff"
+  endColor: "#d4feff"
+  alphaOverLifetime:
+    - time: 0.0
+      value: 1.0
+    - time: 1.0
+      value: 0.0
+  lifetime: 1
+  lifetimeVariance: 0.2
+  emissionRate: 10
+  maxCount: 100
+  particleSize: 1
+  burst: false
+  duration: 0
+  gravity: 0.8
+  drag: 0.1
+  noiseStrength: 0.15
+  noiseFrequency: 0.8
+  spreadAngle: 60
+  emitAngle: 180
+  shape:
+    type: CircleFill
+    radius: 0.3
+
+- type: particleEffect
+  id: ShadowMist
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: soft_dot
+  shader: unshaded
+  startColor: "#8f4be3"
+  endColor: "#603987"
+  alphaOverLifetime:
+    - time: 0.0
+      value: 1.0
+    - time: 2.5
+      value: 0.1
+  lifetime: 2.5
+  lifetimeVariance: 0.8
+  emissionRate: 15
+  maxCount: 100
+  particleSize: 1
+  burst: false
+  duration: 0
+  gravity: 2.5
+  drag: 0.1
+  noiseStrength: 0.15
+  noiseFrequency: 0.8
+  spreadAngle: 60
+  emitAngle: 0
+  shape:
+    type: CircleFill
+    radius: 1.5
+
+- type: particleEffect
+  id: BluespaceBurst
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: soft_dot
+  colorOverLifetime:
+    - time: 0.0
+      color: "#36a1ff"
+    - time: 0.3
+      color: "#1eafd4"
+  shader: unshaded
+  lifetime: 1.2
+  lifetimeVariance: 0.4
+  speed: 1.5
+  speedVariance: 0.5
+  particleSize: 0.5
+  sizeVariance: 0.5
+  stretchFactor: 0.25
+  emissionRate: 0
+  maxCount: 30
+  burst: true
+  gravity: -0.5
+  spreadAngle: 360
+  emitAngle: 0
+
+- type: particleEffect
+  id: BluespaceSparks
+  sprite:
+    sprite: _Starfall/Particles/generic.rsi
+    state: cross
+  shader: unshaded
+  startColor: "#36a1ff"
+  endColor: "#1eafd4"
+  alphaOverLifetime:
+    - time: 0.0
+      value: 1.0
+    - time: 1.0
+      value: 0.0
+  emissionRate: 10
+  maxCount: 50
+  particleSize: 1
+  burst: false
+  duration: 0
+  gravity: -0.2
+  drag: 0.1
+  noiseStrength: 0.15
+  noiseFrequency: 0.8
+  spreadAngle: 60
+  emitAngle: 180
+  shape:
+    type: CircleFill
+    radius: 0.8


### PR DESCRIPTION
## Short description
Added Particles to many Anomalies, using https://github.com/ss14Starlight/space-station-14/pull/5334 / https://github.com/funky-station/forky-station/pull/67

For anyone porting this, it also makes use of the ChildEntitySystem found at Content.Shared/_Starlight/ChildEntities which may need ported to enable having multiple particles coming from one entity.

- Snow falls around Ice Anomalies
- Bluespace sparks radiate around Bluespace and Tech Anomalies
- Fire, smoke, and embers rise from the Pyro Anomaly
- Drips of liquid or blood fall from the Liquid and Flesh Anomalies
- Enderman particles drift around the Shadow and Dark Anomalies

## Why we need to add this
More anomaly visual polish. They really also need a resprite in the future, but the particles help them feel more grand and visually interesting.

## Media (Video/Screenshots)
<img width="1179" height="622" alt="image" src="https://github.com/user-attachments/assets/efddb4ba-27ca-4fa6-9db4-ce70234e9416" />


## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- add: Added Particles to several anomalies for more visual polish. Pyro, Ice, Bluespace, Tech, Flesh, Liquid, Dark, and Shadow.

