### PR TITLE
Mailbox naming consistency

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Storage/mailboxes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Storage/mailboxes.yml
@@ -110,7 +110,7 @@
 
 - type: entity
   id: ScienceMailBox
-  name: science mailBox
+  name: science mailbox
   description: A mailbox for storing and retrieving mail. Allows for Science to store and retrieve their mail.
   parent: BaseMailBox
   components:
@@ -138,7 +138,7 @@
 
 - type: entity
   id: ServiceMailBox
-  name: service mailBox
+  name: service mailbox
   description: A mailbox for storing and retrieving mail. Allows for Service to store and retrieve their mail.
   parent: BaseMailBox
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Structures/Storage/mailboxes.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Storage/mailboxes.yml
@@ -1,7 +1,7 @@
 ﻿- type: entity
   id: BaseMailBox
-  name: Base Mail Box
-  description: A mail box for storing and retrieving mail.
+  name: mailbox
+  description: A mailbox for storing and retrieving mail.
   parent: [BaseMachinePowered, ConstructibleMachine]
   abstract: true
   components:
@@ -54,8 +54,8 @@
 
 - type: entity
   id: CargoMailBox
-  name: Cargo Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Cargo to store and retrieve their mail.
+  name: cargo mailbox
+  description: A mailbox for storing and retrieving mail. Allows for Cargo to store and retrieve their mail.
   parent: BaseMailBox
   components:
       - type: MailBox
@@ -68,8 +68,8 @@
 
 - type: entity
   id: CommandMailBox
-  name: Command Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Command to store and retrieve their mail.
+  name: command mailbox
+  description: A mailbox for storing and retrieving mail. Allows for Command to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox
@@ -82,8 +82,8 @@
 
 - type: entity
   id: EngineeringMailBox
-  name: Engineering Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Engineering to store and retrieve their mail.
+  name: engineering mailbox
+  description: A mailbox for storing and retrieving mail. Allows for Engineering to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox
@@ -96,8 +96,8 @@
 
 - type: entity
   id: MedicalMailBox
-  name: Medical Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Medical to store and retrieve their mail.
+  name: medical mailbox
+  description: A mailbox for storing and retrieving mail. Allows for Medical to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox
@@ -110,8 +110,8 @@
 
 - type: entity
   id: ScienceMailBox
-  name: Science Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Science to store and retrieve their mail.
+  name: science mailBox
+  description: A mailbox for storing and retrieving mail. Allows for Science to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox
@@ -124,8 +124,8 @@
 
 - type: entity
   id: SecurityMailBox
-  name: Security Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Security to store and retrieve their mail.
+  name: security mailbox
+  description: A mailbox for storing and retrieving mail. Allows for Security to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox
@@ -138,8 +138,8 @@
 
 - type: entity
   id: ServiceMailBox
-  name: Service Mail Box
-  description: A mail box for storing and retrieving mail. Allows for Service to store and retrieve their mail.
+  name: service mailBox
+  description: A mailbox for storing and retrieving mail. Allows for Service to store and retrieve their mail.
   parent: BaseMailBox
   components:
     - type: MailBox


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
small PR
- `Cargo Mail Box` -> `cargo mailbox`, etc.
- made the same changes for the rest of the mailboxes

No changelog because while this is a "player facing change", it's so minor it's not worth informing players via changelog.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- SS14 uses lowercase for most names (except acronyms)
- mailbox is the more common spelling

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
