### PR TITLE
Fixes the minimum and maximum not working for ATS

### DIFF
--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -194,8 +194,27 @@ public sealed partial class ShuttleSystem
 
         if (_loader.TryLoadGrid(mapId, path, out var grid))
         {
-            if (HasComp<ShuttleComponent>(grid))
-                TryFTLProximity(grid.Value, targetGrid);
+            //Starlight start - Make the spawning system respect the minimum and maximum distance
+            var targetPhysics = _physicsQuery.Comp(targetGrid);
+            var targetCoordinates = new EntityCoordinates(targetGrid, targetPhysics.LocalCenter);
+
+            if (group.MinimumDistance > 0f || group.MaximumDistance > 0f)
+            {
+                if (group.MaximumDistance <= group.MinimumDistance)
+                {
+                    Log.Error($"Invalid grid spawn distance range for {ToPrettyString(stationUid)} / {path}: " +
+                              $"{group.MinimumDistance} to {group.MaximumDistance}");
+                    return false;
+                }
+
+                if (!TryGetFTLProximity(grid.Value, targetCoordinates, out var coordinates, out var angle,
+                        group.MinimumDistance, group.MaximumDistance))
+                    return false;
+
+                _transform.SetCoordinates(grid.Value, Transform(grid.Value), coordinates, rotation: angle);
+            }
+            else if (HasComp<ShuttleComponent>(grid)) TryFTLProximity(grid.Value, targetGrid);
+            //Starlight end
 
             if (group.NameGrid)
             {

--- a/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
+++ b/Content.Server/Shuttles/Systems/ShuttleSystem.GridFill.cs
@@ -202,8 +202,7 @@ public sealed partial class ShuttleSystem
             {
                 if (group.MaximumDistance <= group.MinimumDistance)
                 {
-                    Log.Error($"Invalid grid spawn distance range for {ToPrettyString(stationUid)} / {path}: " +
-                              $"{group.MinimumDistance} to {group.MaximumDistance}");
+                    Log.Error($"Invalid grid spawn distance range for {ToPrettyString(stationUid)} / {path}: " + $"{group.MinimumDistance} to {group.MaximumDistance}");
                     return false;
                 }
 

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -60,8 +60,8 @@
             - type: TradeStation
           paths:
             - /Maps/_Starlight/trading_outpost.yml # Starlight Edit, new ATS
-          minimumDistance: 100
-          maximumDistance: 200
+          minimumDistance: 100 #Starlight Edit, Spawn distance
+          maximumDistance: 200 #Starlight Edit, Spawn distance
 #        mining: !type:GridSpawnGroup # 🌟Starlight begin🌟
 #          paths:
 #            - /Maps/Shuttles/mining.yml

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -60,6 +60,8 @@
             - type: TradeStation
           paths:
             - /Maps/_Starlight/trading_outpost.yml # Starlight Edit, new ATS
+          minimumDistance: 100
+          maximumDistance: 200
 #        mining: !type:GridSpawnGroup # 🌟Starlight begin🌟
 #          paths:
 #            - /Maps/Shuttles/mining.yml


### PR DESCRIPTION
## Short description
Makes the ATS spawn at a larger distance from station
Closes #5916 

## Why we need to add this
ATS was nearly kissing the station in certain larger maps this fixes that as well as makes the code actually use a existing field instead of ignoring it

## Media (Video/Screenshots)
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/e9b632e8-e434-40e0-aa52-edd0ec9f4f76" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.


:cl: RedSpeeds
- fix: Fixed ATS nearly spawning into stations.

