### PR TITLE
No more lag for you comrads

### DIFF
--- a/Content.Shared/Physics/CollisionGroup.cs
+++ b/Content.Shared/Physics/CollisionGroup.cs
@@ -51,6 +51,7 @@ public enum CollisionGroup
     // Machines, computers
     MachineMask = Impassable | MidImpassable | LowImpassable,
     MachineLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable,
+    SovietLayer = Opaque | MidImpassable | LowImpassable | BulletImpassable, //Starlight - Unique layer for soviet crates to prevent lag thru collisions
     ConveyorMask = Impassable | MidImpassable | LowImpassable | DoorPassable,
 
     // Crates

--- a/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedEntityStorageSystem.cs
@@ -22,6 +22,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Spawners;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -63,7 +64,24 @@ public abstract partial class SharedEntityStorageSystem : EntitySystem
         SubscribeLocalEvent<EntityStorageComponent, BeforeExplodeEvent>(OnExploded);
 
         SubscribeLocalEvent<InsideEntityStorageComponent, EntGotRemovedFromContainerMessage>(OnRemoved);
+
+        SubscribeLocalEvent<EntityStorageComponent, TimedDespawnEvent>(OnTimedDespawn); //Starlight
     }
+
+    #region Starlight
+    private void OnTimedDespawn(Entity<EntityStorageComponent> ent, ref TimedDespawnEvent args)
+    {
+        ent.Comp.Open = true;
+        Dirty(ent, ent.Comp);
+        if (!ent.Comp.DeleteContentsOnDestruction)
+        {
+            EmptyContents(ent, ent.Comp);
+            return;
+        }
+
+        foreach (var item in new List<EntityUid>(ent.Comp.Contents.ContainedEntities)) Del(item);
+    }
+    #endregion
 
     protected virtual void OnComponentInit(EntityUid uid, EntityStorageComponent component, ComponentInit args)
     {

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -42,6 +42,7 @@
         density: 50
         mask:
         - CrateMask #this is so they can go under plastic flaps
+        - SovietLayer #Starlight: make generics collide with soviet crates
         layer:
         - MachineLayer
   - type: EntityStorage

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -8,7 +8,6 @@
     sprite: _Starlight/Structures/Storage/USSP/revolutionary.rsi
   - type: Sprite
     sprite: _Starlight/Structures/Storage/USSP/revolutionary.rsi
-    #Starlight start - Attempts to fix lag
   - type: Fixtures
     fixtures:
       fix1:
@@ -16,7 +15,6 @@
           - SovietLayer
   - type: TimedDespawn
     lifetime: 900
-    #Starlight end
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Effects/teleport_arrival.ogg

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/soviet_armaments_crate.yml
@@ -8,6 +8,15 @@
     sprite: _Starlight/Structures/Storage/USSP/revolutionary.rsi
   - type: Sprite
     sprite: _Starlight/Structures/Storage/USSP/revolutionary.rsi
+    #Starlight start - Attempts to fix lag
+  - type: Fixtures
+    fixtures:
+      fix1:
+        layer:
+          - SovietLayer
+  - type: TimedDespawn
+    lifetime: 900
+    #Starlight end
   - type: EmitSoundOnSpawn
     sound:
       path: /Audio/Effects/teleport_arrival.ogg


### PR DESCRIPTION
## Short description
This will remove soviet crates from colliding with eachother and deletes the crate after 15 minutes

## Why we need to add this
We have had a lot of lag incidents lately with soviets this PR aims to attempt to solve these lag problems

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- add: Soviet crates now despawn after 15 minutes dropping their content as they do.
- fix: Fixed Soviet crates wont collide with each other anymore in an attempt to fix lag.

