### PR TITLE
Changes to the ore box

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/ore_box.yml
@@ -68,6 +68,7 @@
     storageCloseSound: /Audio/Effects/closetclose.ogg
     whitelist:
       tags:
+      - ArtifactFragment # Starlight Edit - allow artifact fragments to be stored in ore box
       - Ore
   - type: UserInterface
     interfaces:
@@ -107,7 +108,7 @@
   - type: ComponentToggler
     components:
     - type: MagnetPickup
-      range: 2
+      range: 4
       requiresEquipping: false
       slotFlags: 0
   - type: Dumpable


### PR DESCRIPTION
## Short description
Im proposing to change the ore box to where it can hold artifact fragments, and has a magnet range of 4.

## Why we need to add this
To make using the ore box better. https://discord.com/channels/1272545509562777621/1544388503801172000

## Media (Video/Screenshots)
https://discord.com/channels/1272545509562777621/1544388503801172000/1544424360813531256

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Ore box has bigger magnet now, pull from further away.
- tweak: Ore box can now pick up artifact fragment.
