### PR TITLE
OKAY TAKE THREE I DIDN'T MESS ANYTHING UP THIS TIME (Contra SOP clarification)

### DIFF
--- a/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PermitAcquisition.xml
+++ b/Resources/ServerInfo/Guidebook/StarlightSOP/SecuritySOP/PermitAcquisition.xml
@@ -2,7 +2,7 @@
 # Permit Acquisition
 
 - 1.\n
-Both the Warden and Head of Security are cleared to approve permits for equipment that they themselves are allowed to use.\n\n
+Both the Warden and Head of Security are cleared to approve permits for equipment that they themselves are allowed to use, as well as minor contraband.\n\n
 1.1\n
 This should not be done without proper cause.\n\n
 1.2\n

--- a/Resources/ServerInfo/_Starlight/Guidebook/CorporateLaw/CrimeList.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/CorporateLaw/CrimeList.xml
@@ -451,7 +451,7 @@
     </ColorBox>
     <ColorBox Color="#2f3832">
       <Box HorizontalAlignment="Left" VerticalAlignment="Stretch" Margin="2">
-        To make, hold, or use minor contraband without authorization. Authorization may only be granted by the Warden, the Head of Security, or the Captain.
+        To make, hold, or use minor contraband without authorization. Authorization may only be granted by the Warden, the Head of Security, or the Captain. The Head of Personnel may approve items of clothing considered minor contraband.
       </Box>
     </ColorBox>
     <ColorBox Color="#2e422e">


### PR DESCRIPTION
## Short description
Minor changes to Corporate Law and Security SOP to formally permit Warden to approve minor contraband. After some discussion, additional line permitting HOP to approve minor contra _clothing_ only has been added. This is the interpretation of the law by the vast majority of players (see below) and it would be wise to head off any possibility for confusion. 

## Why we need to add this
The following passage on Minor Contraband in Corporate Law: 
_Authorization may only be granted by the Warden, Head of Security, or the Captain._
 is directly contradicted by Security SOP: 

_Both the Warden and Head of Security are cleared to approve permits for equipment that they themselves are allowed to use. This should not be done without proper cause. Captured enemy equipment, such as from the Syndicate, may be approved via Central Command decree if requested, but not on their own authority._

_The approval of permits is a privilege, not a right, and neither the Warden nor the Head of Security is obligated to approve any permits. Copies of all permits must be kept in the Warden's office. Permits are invalid if not kept on person._

The key issue at hand, here: Corporate Law explicitly states that the Warden (or HOS, or Cap) can approve minor contraband. However, this is directly contradicted by their own SOP, which emphasises that the only things they can approve are items they, themselves, are allowed to use. As minor contra is indeed, contra, it cannot be approved by the Warden (or indeed, any member of the crew). Short of faxxing Central Command, there is no way to get a harmless-but-practical minor contra item like a syndicate backpack (extra storage is nice!)  legally approved.

The proposed changes would fix the confusing overlap, provide players with a way to legally hold onto their maints loot (if they put in the legwork to draft and get stamped their paperwork) and better align SOP and rules-as-written with the common understanding of the playerbase.

<img width="681" height="162" alt="image" src="https://github.com/user-attachments/assets/7f324d81-26c4-4baa-91f8-fb3d22d8df58" />

Poll demonstrating the extent to which this is widespread attached.



## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**


:cl: deltaVelocity
- add: SOP change: HOP may now approve minor contraband articles of clothing. Things like shivs are still sec's remit.
- tweak: SOP change: It is now no longer (technically) impossible to get a permit for minor contraband.