### PR TITLE
Stamp Recipes

### DIFF
--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/command.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/Packs/command.yml
@@ -2,3 +2,6 @@
   id: StarlightCommandSuppliesStatic
   recipes:
   - HandheldStationMap
+  - RubberStampApproved
+  - RubberStampDenied
+  - BoxStamps

--- a/Resources/Prototypes/_Starlight/Recipes/Lathes/misc.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Lathes/misc.yml
@@ -606,3 +606,24 @@
   completetime: 1
   materials:
     Plastic: 50
+
+- type: latheRecipe
+  id: RubberStampApproved
+  result: RubberStampApproved
+  completetime: 1
+  materials:
+    Plastic: 100
+
+- type: latheRecipe
+  id: RubberStampDenied
+  result: RubberStampDenied
+  completetime: 1
+  materials:
+    Plastic: 100
+
+- type: latheRecipe
+  id: BoxStamps
+  result: BoxStamps
+  completetime: 2
+  materials:
+    Cardboard: 500


### PR DESCRIPTION
## Short description
Adding the approved stamp, denied stamp, and the stamp box into the command techfab as recipes.

## Why we need to add this
It allows more command roles to be able to use these stamps for beaurocracy https://discord.com/channels/1272545509562777621/1544502544045178920

## Media (Video/Screenshots)

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added the approved stamp, denied stamp, and the stamp box into the command techfab.
