### PR TITLE
Dragon's Devour applies Ichor into the stomach instead of directly into the bloodstream

### DIFF
--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -153,7 +153,7 @@ public sealed partial class DevourSystem : EntitySystem
             if (stomachs.Count > 0) 
             { 
                 var stomach = stomachs[0]; 
-                var success = _stomach.TryTransferSolution( stomach.Owner, ichorInjection); 
+                _stomach.TryTransferSolution( stomach.Owner, ichorInjection); 
             }
 
             ent.Comp.Devoured++; //Starlight devour counter.

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -29,13 +29,15 @@ public sealed partial class DevourSystem : EntitySystem
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private SharedActionsSystem _actionsSystem = default!;
     [Dependency] private SharedAudioSystem _audioSystem = default!;
-    [Dependency] private StomachSystem _stomach = default!;
-    [Dependency] private SharedBodySystem _body = default!;
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
-    [Dependency] private DamageableSystem _damageSystem = default!; //Starlight
-    [Dependency] private MobThresholdSystem _thresholdSystem = default!; //Starlight
+    #region "Starlight"
+    [Dependency] private DamageableSystem _damageSystem = default!;
+    [Dependency] private MobThresholdSystem _thresholdSystem = default!;
+    [Dependency] private StomachSystem _stomach = default!;
+    [Dependency] private SharedBodySystem _body = default!;
+    #endregion
 
     public override void Initialize()
     {
@@ -147,14 +149,15 @@ public sealed partial class DevourSystem : EntitySystem
         // Grant ichor if the devoured thing meets the dragon's food preference
         if (target != null && _whitelistSystem.IsWhitelistPassOrNull(ent.Comp.FoodPreferenceWhitelist, (EntityUid)target)) //Starlight, args.Args.Target replaced with target
         {
-            
+            // Starlight-start
             var stomachs = _body.GetBodyOrganEntityComps<StomachComponent>(ent.Owner);
             
             if (stomachs.Count > 0) 
             { 
                 var stomach = stomachs[0]; 
-                _stomach.TryTransferSolution( stomach.Owner, ichorInjection); 
+                _stomach.TryTransferSolution(stomach.Owner, ichorInjection); 
             }
+            // Starlight-end
 
             ent.Comp.Devoured++; //Starlight devour counter.
         }

--- a/Content.Shared/Devour/DevourSystem.cs
+++ b/Content.Shared/Devour/DevourSystem.cs
@@ -1,4 +1,7 @@
 using Content.Shared._Starlight.Medical.Body.Systems;
+using Content.Shared._Starlight.Medical.Body.Components;
+using Content.Shared.Body.Systems;
+using Content.Shared.Body.Components;
 using Content.Shared.Actions;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Devour.Components;
@@ -26,7 +29,8 @@ public sealed partial class DevourSystem : EntitySystem
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private SharedActionsSystem _actionsSystem = default!;
     [Dependency] private SharedAudioSystem _audioSystem = default!;
-    [Dependency] private SharedBloodstreamSystem _bloodstreamSystem = default!;
+    [Dependency] private StomachSystem _stomach = default!;
+    [Dependency] private SharedBodySystem _body = default!;
     [Dependency] private SharedContainerSystem _containerSystem = default!;
     [Dependency] private SharedDoAfterSystem _doAfterSystem = default!;
     [Dependency] private SharedPopupSystem _popupSystem = default!;
@@ -143,7 +147,15 @@ public sealed partial class DevourSystem : EntitySystem
         // Grant ichor if the devoured thing meets the dragon's food preference
         if (target != null && _whitelistSystem.IsWhitelistPassOrNull(ent.Comp.FoodPreferenceWhitelist, (EntityUid)target)) //Starlight, args.Args.Target replaced with target
         {
-            _bloodstreamSystem.TryAddToBloodstream(ent.Owner, ichorInjection);
+            
+            var stomachs = _body.GetBodyOrganEntityComps<StomachComponent>(ent.Owner);
+            
+            if (stomachs.Count > 0) 
+            { 
+                var stomach = stomachs[0]; 
+                var success = _stomach.TryTransferSolution( stomach.Owner, ichorInjection); 
+            }
+
             ent.Comp.Devoured++; //Starlight devour counter.
         }
 


### PR DESCRIPTION
## Short description

Dragon's Devour ability applies Ichor into the stomach instead of directly into the bloodstream

## Why we need to add this

Ichor only works when digested

## Media (Video/Screenshots)

<img width="1280" height="720" alt="dragondevour" src="https://github.com/user-attachments/assets/3fbe206a-40e7-4c84-b424-622943b7bdac" />

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: qbrx
- tweak: Dragon's devour now applies Ichor into the stomach, allowing it to digest properly.