### PR TITLE
Supermatter Patch

### DIFF
--- a/Content.Server/_Starlight/Energy/Supermatter/Const.cs
+++ b/Content.Server/_Starlight/Energy/Supermatter/Const.cs
@@ -16,28 +16,28 @@ internal static class Const
 
     public static GasProperties[] GasProperties =
     [//  HEATT   HEATM  RADS REGEM REACM DESM GADA
-        new (0.24f, 1.20f, 1.4f, 0f, 0f, 0f, 0f), // oxygen
-        new (0.20f, 1.46f, 1.5f, 0f, 0f, 0f, 0f), // nitrogen
-        new (0.12f, 2.21f, 3.5f, 0f, 0f, 0f, 0f), // carbon dioxide
-        new (0.60f, 0.61f, 1.3f, 0f, 0f, 0f, 0f), // plasma
-        new (0.30f, 0.45f, 1.2f, 0f, 0.5f, 0f, 0f), // tritium
-        new (0.14f, 2.31f, 2.5f, 0f, 0f, 0f, 0f), // vapor
-        new (0.16f, 2.11f, 4.4f, 0f, 0f, 0f, 0f), // ammonia
-        new (0.13f, 2.19f, 2.2f, 0f, -0.02f, 0f, 0f), // nitrous oxide
+        new (0.24f, 1.20f, 1.4f, 0f, 0f, 0.1f, 0f), // oxygen
+        new (0.20f, 1.46f, 1.5f, 0f, 0f, -0.1f, 0f), // nitrogen
+        new (0.12f, 2.21f, 3.5f, 0f, 0f, -0.25f, 0f), // carbon dioxide
+        new (0.60f, 0.61f, 1.3f, 0f, 0.25f, 0f, 0f), // plasma
+        new (0.30f, 0.45f, 1.2f, 0f, 0.75f, 0f, 0f), // tritium
+        new (0.14f, 2.31f, 2.5f, 0f, 0.1f, 0.1f, 0f), // vapor
+        new (0.16f, 2.11f, 4.4f, 0.25f, 0f, 0f, 0f), // ammonia
+        new (0.13f, 2.19f, 2.2f, 0.5f, -0.02f, 0f, 0f), // nitrous oxide
         new (1.00f, 0.01f, 1.1f, 0f, -0.1f, 0f, 0f), // frezon
         new (0.25f, 1.20f, 1.80f, 0f, 0f, 0f, 0f), // BZ (catalist so an not competing gas) //FUNKY GASES
-        new (0.40f, 0.50f, 1.8f, 1f, -0.1f, -0.1f, 0f), // Healium (support gas) {Special effect: increase passive}
-        new (0.30f, 0.50f, 1.2f, 0f, 0.75f, 0.5f, 0f), // Nitrium {Special effect: SM reacts more, cost of stability}
-        new (0.30f, 1.0f, 1.7f, 0f, 0f, 0f, 0f), // Pluoxium better then o2 not insane
-        new (0.35f, 0.35f, 1.1f, 0f, 0.25f, 0f, 0f), // Hydrogen Better heatT than Trit but "ignites" faster
+        new (0.40f, 0.50f, 1.8f, 5f, -0.25f, -0.5f, 0f), // Healium (support gas) {Special effect: increase passive}
+        new (0.30f, 0.50f, 1.2f, 0f, 1.5f, 0.5f, 0f), // Nitrium {Special effect: SM reacts more, cost of stability}
+        new (0.30f, 1.0f, 3.25f, 0f, 0f, 0f, 0f), // Pluoxium better then o2 not insane
+        new (0.35f, 0.35f, 1.1f, 0f, 0.5f, 0f, 0f), // Hydrogen Better heatT than Trit but "ignites" faster
         new (2.0f, 0.05f, 1.05f, 0f, -0.5f, -0.5f, 0f), // HyperNoblium Hard to make thus great heat absorb its an supercooland, decreases reacfifiy
-        new (0.20f, 1.5f, 1.5f, 0f, 2.0f, 0.5f, 0f), // ProtoNitrate (heavy gas/cloning gas) 2 might be an bit much
-        new (0.10f, 3.00f, 1.01f, -0.5f, 0f, 0.5f, 10f), // Zauker (Heats up quickly, why would you get this near the SM?) {Special effect:decrease passive + moddamage}
-        new (0.1f, 3.0f, 3.0f, 0f, -1f, 0f, 0f), // Halon (horrible cooland, but great rad protection, flooding SM makes it stop fire anyways.)
+        new (0.20f, 1.5f, 1.5f, 0f, 4.0f, 0.5f, 0f), // ProtoNitrate (heavy gas/cloning gas) 2 might be an bit much
+        new (0.10f, 3.00f, 1.01f, -0.5f, 0.5f, 0.5f, 100f), // Zauker (Heats up quickly, why would you get this near the SM?) {Special effect:decrease passive + moddamage}
+        new (0.1f, 3.0f, 3.0f, 0f, -.5f, -0.25f, 0f), // Halon (horrible cooland, but great rad protection, flooding SM makes it stop fire anyways.)
         new (0.45f, 0.4f, 1.3f, 0f, -0.1f, 0f, 0f), // Helium (good thermal conductivity, heats quickly to molar mass)
-        new (0.10f, 4.0f, 1.1f, -0.2f, 1.0f, 0.5f, 0f), // AntiNoblium (HyNoB stable, thus "anti" highly unstable) //END FUNKY
-        new (0.25f, 1.2f, 1.7f, 0f, 0f, 0f, 0f), // Ulnitranium (close to ploux) //STARLIGHT GASES
-        new (0.35f, 1.0f, 2.0f, 0.2f, -0.2f, 0f, 0f), // ZXA (another support gas) //END STARLIGHT
+        new (0.10f, 4.0f, 1.1f, -0.2f, 5.0f, 0.5f, 0f), // AntiNoblium (HyNoB stable, thus "anti" highly unstable) //END FUNKY
+        new (0.25f, 1.2f, 3.0f, 0f, 0f, 0f, 0f), // Ulnitranium (close to ploux) //STARLIGHT GASES
+        new (0.35f, 1.0f, 2.0f, 1.0f, -0.2f, 0f, 0f), // ZXA (another support gas) //END STARLIGHT
     ];
 
     /*Cooling gases: Frezon, HyperNob

--- a/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
+++ b/Content.Server/_Starlight/Energy/Supermatter/SupermatterSystem.cs
@@ -255,9 +255,9 @@ public sealed partial class SupermatterSystem : AccUpdateEntitySystem
 
         var ReactionMod = supermatter.Comp.ReactionModifier.Float();//make gases that risk higher reactifify also make more gas/also produce less for "safer" gases
 
-        gas.AdjustMoles((int)Gas.Tritium, breakDelta.Float()/2* ReactionMod);
-
-        gas.AdjustMoles((int)Gas.Oxygen, breakDelta.Float()*4* ReactionMod);
+        gas.AdjustMoles((int)Gas.Tritium, breakDelta.Float() / 2 * ReactionMod);
+        gas.AdjustMoles((int)Gas.Plasma, breakDelta.Float() * ReactionMod);
+        gas.AdjustMoles((int)Gas.Oxygen, breakDelta.Float() * 4 * ReactionMod);
     }
 
     private static void ProcessHeat(Entity<SupermatterComponent> supermatter, GasMixture gas, float heatTransfer, float heatModifier)


### PR DESCRIPTION
## Short description
Makes the SM release plasma alongside its existing products.
Tweaks to gas modifier values to make exotic gasses more powerful, and mundane gasses have some secondary uses.

## Why we need to add this
The SM doesn't make enough product to be worth the time.
Its "standard" across the station-verse for the supermatter to make raw plasma, not tritium. The trit production gives the SL SM unique boons so it can stay.
Exotic gasses are kinda... disappointingly weak.

## Media (Video/Screenshots)
I'll put some media when you fix the air injector bug so i can actually play in localhost

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: OJG
- tweak: The supermatter now releases plasma alongside its existing gas products.
- tweak: Changes to the gas modifiers of the SM that make exotic gasses more potent.