### PR TITLE
Portable Rechargers Change

### DIFF
--- a/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Power/portable_recharger.yml
@@ -1,0 +1,9 @@
+- type: !PartialOnly entity
+  id: PortableRecharger
+  components:
+  - type: Clothing
+    equippedPrefix: charging
+    quickEquip: false
+    slots:
+    - back
+    - suitstorage


### PR DESCRIPTION
## Short description
Allowing portable rechargers to be equipped on the suit slot.

## Why we need to add this
The portable recharger is nigh never used due to how clunky it is, how fat it is in your bag, and it only being equippable on your back slot. Changing it to work on the suit storage slot would allow it to be useful and more used.

## Media (Video/Screenshots)
<img width="368" height="184" alt="image" src="https://github.com/user-attachments/assets/3828f1c5-49aa-4e70-b7e9-86957156a679" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- tweak: Changed the portable recharger, now you can put it in a suitslot.
