### PR TITLE
Fix ShowHealthIconsComponent ignoring configured damage container type whitelists

### DIFF
--- a/Content.Client/Overlays/ShowHealthIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthIconsSystem.cs
@@ -88,7 +88,7 @@ public sealed partial class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealt
                 else if (damageableComponent.HealthIcons.TryGetValue(state.CurrentState, out var value) && _prototypeMan.Resolve(value, out var icon))
                     result.Add(icon);
             }
-        /*
+        /* Starlight
         }
         */
 

--- a/Content.Client/Overlays/ShowHealthIconsSystem.cs
+++ b/Content.Client/Overlays/ShowHealthIconsSystem.cs
@@ -76,8 +76,10 @@ public sealed partial class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealt
         var result = new List<HealthIconPrototype>();
 
         // Here you could check health status, diseases, mind status, etc. and pick a good icon, or multiple depending on whatever.
+        /* Starlight - Respect icon display configuration
         if (damageableComponent?.DamageContainerID == "Biological")
         {
+        */
             if (TryComp<MobStateComponent>(entity, out var state))
             {
                 // Since there is no MobState for a rotting mob, we have to deal with this case first.
@@ -86,7 +88,9 @@ public sealed partial class ShowHealthIconsSystem : EquipmentHudSystem<ShowHealt
                 else if (damageableComponent.HealthIcons.TryGetValue(state.CurrentState, out var value) && _prototypeMan.Resolve(value, out var icon))
                     result.Add(icon);
             }
+        /*
         }
+        */
 
         return result;
     }

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -27,6 +27,9 @@
     - Biological
     - Hybrid # Starlight end, Neocytes
   - type: ShowHealthIcons
+    damageContainers: # Starlight start
+      - Biological
+      - Hybrid # Starlight end, Neocytes
 
 - type: entity
   parent: ClothingEyesHudBase

--- a/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/hud.yml
@@ -27,9 +27,6 @@
     - Biological
     - Hybrid # Starlight end, Neocytes
   - type: ShowHealthIcons
-    damageContainers: # Starlight start
-      - Biological
-      - Hybrid # Starlight end, Neocytes
 
 - type: entity
   parent: ClothingEyesHudBase

--- a/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
@@ -57,6 +57,9 @@
       - Biological
       - Hybrid # Neocytes
     - type: ShowHealthIcons
+      damageContainers:
+        - Biological
+        - Hybrid
 
 - type: entity
   id: EyeImplantChemistry

--- a/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/eye.yml
@@ -102,6 +102,9 @@
       - Biological
       - Hybrid # Neocytes
     - type: ShowHealthIcons
+      damageContainers:
+        - Biological
+        - Hybrid
     - type: ShowJobIcons
     - type: ShowMindShieldIcons
     - type: ShowCriminalRecordIcons

--- a/Resources/Prototypes/_Starlight/Partials/Entities/Clothing/Eyes/hud.yml
+++ b/Resources/Prototypes/_Starlight/Partials/Entities/Clothing/Eyes/hud.yml
@@ -1,0 +1,7 @@
+- type: !PartialOnly entity
+  id: ShowMedicalIcons
+  components:
+    - type: ShowHealthIcons
+      damageContainers:
+        - Biological
+        - Hybrid


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Neocytes now correctly display health icons, not just health bars.

ShowHealthIconsComponent allows configuring which container IDs it should display icons for.
This was ignored by its system, only displaying biological. 

I also fixed up the various medical HUDs and implants that already display health bars for neocytes to also display icons for them.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This was likely a bug.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before:
<img width="308" height="295" alt="image" src="https://github.com/user-attachments/assets/03c67e8b-7a78-49bb-8087-e03b999469e1" />


After:
<img width="207" height="275" alt="image" src="https://github.com/user-attachments/assets/3a87e1e7-15f4-4758-b71f-c7e073e27b19" />

Makes rotting neocytes obvious:
<img width="549" height="293" alt="image" src="https://github.com/user-attachments/assets/ec139c95-8758-49d7-82ce-52cea76804e3" />




## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: STARLIGHT TEAM
- fix: Neocytes now correctly display health icons in various medical HUDs.
