### PR TITLE
Hide the alive icon from medical HUDs

### DIFF
--- a/Content.Shared/Damage/Components/DamageableComponent.cs
+++ b/Content.Shared/Damage/Components/DamageableComponent.cs
@@ -79,7 +79,7 @@ public sealed partial class DamageableComponent : Component
     [DataField]
     public Dictionary<MobState, ProtoId<HealthIconPrototype>> HealthIcons = new()
     {
-        { MobState.Alive, "HealthIconFine" },
+        // { MobState.Alive, "HealthIconFine" }, Starlight - hide alive icon
         { MobState.Critical, "HealthIconCritical" },
         { MobState.Dead, "HealthIconDead" },
     };


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Remove the blue cross icon from entities that are alive that the medical HUD displays.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It blocks the chat bubbles, it's redundant and annoying. It's obvious when someone is alive.
Health bars are already hidden for healthy entities, so this fits right in.


## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Much cleaner!
<img width="343" height="113" alt="image" src="https://github.com/user-attachments/assets/8487b7a1-b266-4173-b49a-310df9cc09f7" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- tweak: Medical HUDs no longer display the alive icon.
