### PR TITLE
Fix alcohol lag bug (hopefully)

### DIFF
--- a/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
+++ b/Content.Client/Players/PlayTimeTracking/JobRequirementsManager.cs
@@ -60,7 +60,7 @@ public sealed partial class JobRequirementsManager : ISharedPlaytimeManager
 
         // NullLink start
         _net.RegisterNetMessage<MsgUpdatePlayerPlayTime>(Update);
-        _achievements.AchievementsUpdated += OnAchievementsUpdated;
+        _achievements.AchievementUnlocked += OnAchievementsUnlocked;
         _cfg.OnValueChanged(NullLinkCCVars.Project, OnProjectChanged, true);
         _cfg.OnValueChanged(NullLinkCCVars.Server, OnServerChanged, true);
         // NullLink end
@@ -121,7 +121,7 @@ public sealed partial class JobRequirementsManager : ISharedPlaytimeManager
         Updated?.Invoke();
     }
 
-    private void OnAchievementsUpdated()
+    private void OnAchievementsUnlocked(string achievement)
         =>  Updated?.Invoke();
     // Nulllink end
 


### PR DESCRIPTION
## Short description
Legendary long elusive alcohol lag bug, summoner of many a "remove alcohol shader" red herring, isolated
Big thanks to blimpuf downstream for noticing a rather repetitive block of code.

Background:
- ethanol "lag" bug occured exclusively during the metabolisation of alcohol, not at other times
- lag was incredibly chuggy fps, no network rubberbanding or anything
- only reported by certain players, impossible to reproduce in dev env
- some players noted getting spammed with hundreds of locale warnings (specifically those related to profile loading) while experiencing this lag

Thesis:
- i posited that something was causing profile ui to spam reload, suspected it to be railroading or achievements system, but could never pin it down

What happens:
- while metabolising alcohol, progress is added/checked to the ethanol acihevement task. This is done regardless of whether or not the ethanol task has been fully completed. Every achievement progress update sends a net message from server -> client with full achievement list and update.
- This means that every metabolism event update, the client is getting an achievements update. Not most efficient, but not bad either, and certainly not root cause of all the lag.
- When event is received by client, it is stored in a dict, and an action is fired. This action is subscribed to by the achievements UI, and the job manager UI.
- every time the job manager UI's update is invoked, it fully rebuilds the job timer, humanoid profile editor, and antag list UI from scratch. SL edits call the job manager update every time an achievement *progress* is received.
- as far as I can find, there is no use case where the job manager needs to know achievement progress (achievement UI is handled entirely seperately to this), it doesn't use any data from the event and my assumption is that it is there for potential future achievement-based unlocks, but was made to be achievement progress instead.

Anyway, net result is that drinking alcohol -> spams progress updates every tick -> every progress update causes incredibly expensive humanoid profile/antag select/job UIs to fully reload at a rate of server tickspersecond * number of metabolism events per tick

The fix:
fix is literally just make it only update those UIs when an achievement is unlocked, not every individual progress increment
It's not used anywhere in code and there is no reason for those UIs to be interested in individual progress steps, especially since those can't possibly happen outside of game when those UIs are actually being viewed

Limitations:
- Achievements is still sending a ton of progress update events, which probably isn't great (but not terrible) for network. As I don't think anyone is willing to fully rewrite the achievements system, this is an evil that will stay with us for now.
- Despite my confidence, I cannot truly test whether this fixes the lag in dev, as achievement progress is sent through nulllink, not game server.


## Why we need to add this
erm

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Arkanic
- fix: Ethanol lag bugfix (hopefully) (likely) (for real this time).
