### PR TITLE
Fix K9 identity concealment issue

### DIFF
--- a/Content.Shared/IdentityManagement/IdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/IdentitySystem.cs
@@ -9,7 +9,6 @@ using Content.Shared.Humanoid;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
-using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared.VoiceMask;
 using Robust.Shared.Containers;
 using Robust.Shared.Enums;
@@ -198,10 +197,8 @@ public sealed partial class IdentitySystem : EntitySystem
     /// </returns>
     private string GetIdentityName(EntityUid target, IdentityRepresentation representation)
     {
-        // Starlight Begin - borgs are always identifiable, chassis shape aside (e.g. Borgi)
-        if (HasComp<BorgChassisComponent>(target))
+        if (IsAlwaysIdentifiable(target)) // Starlight
             return representation.ToStringKnown(true, null);
-        // Starlight End
 
         var ev = new SeeIdentityAttemptEvent();
 

--- a/Content.Shared/_Starlight/IdentityManagement/Components/AlwaysIdentifiableComponent.cs
+++ b/Content.Shared/_Starlight/IdentityManagement/Components/AlwaysIdentifiableComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._Starlight.IdentityManagement.Components;
+
+/// <summary>
+/// The entity's real name always shows, even with an identity-concealing item
+/// worn (masks, helmets). Used for mobs that shouldn't be maskable, like the
+/// security K9. Mirrors the built-in always-identifiable handling for borgs.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AlwaysIdentifiableComponent : Component
+{
+}

--- a/Content.Shared/_Starlight/IdentityManagement/IdentitySystem.Starlight.cs
+++ b/Content.Shared/_Starlight/IdentityManagement/IdentitySystem.Starlight.cs
@@ -1,0 +1,20 @@
+using Content.Shared._Starlight.IdentityManagement.Components;
+using Content.Shared.Silicons.Borgs.Components;
+
+// ReSharper disable once CheckNamespace
+namespace Content.Shared.IdentityManagement;
+
+public sealed partial class IdentitySystem
+{
+    /// <summary>
+    /// Whether this entity's real name should always show, ignoring any
+    /// identity-concealing worn items. Borgs are always identifiable (chassis
+    /// shape aside, e.g. Borgi); anything with <see cref="AlwaysIdentifiableComponent"/>
+    /// opts into the same behavior.
+    /// </summary>
+    private bool IsAlwaysIdentifiable(EntityUid target)
+    {
+        return HasComp<BorgChassisComponent>(target)
+            || HasComp<AlwaysIdentifiableComponent>(target);
+    }
+}

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/k9.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/k9.yml
@@ -51,6 +51,7 @@
   - type: RandomMetadata
     nameSegments:
     - NamesCorgi
+  - type: AlwaysIdentifiable
   - type: Grammar
     attributes:
       gender: epicene


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds an AlwaysIdentifiableComponent to the IdentitySystem to ignore the IdentitySystem's concealment code.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
I added #5816 to allow smart corgis and animals to begin to leverage the identity system.
K9s do NOT have an ID slot and as such immediately fail to identify with their sec mask on.
With this change, K9s will be always identifiable.  

This isn't a permanent solution to the matter; there is an in-flight bit of dev work going on in the 'Security K9' channel in #pr-workshop that is working to add collars in lieu of the existing system for K9s (tracking implanter and bespoke job identification code).  Collars will act as PDAs with suit coordinates.
Until that's done, this will help maintain gameplay-as-intended.  The component is also decent for other situations that might spring up where something may need to be always identifiable.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Fixes this:
<img width="388" height="205" alt="image" src="https://github.com/user-attachments/assets/cd8f4b35-9dd3-4a06-95a7-69a2b84aed37" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: K9s will no longer suffer abject identity concealment issues.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
