### PR TITLE
Fixes NPCs drinking toilet water until they die

### DIFF
--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -179,6 +179,10 @@ public sealed partial class NPCUtilitySystem : EntitySystem
                 if (!_ingestion.CanConsume(owner, targetUid))
                     return 0f;
 
+                // Starlight - do not drink liquids to attempt to satiate hunger
+                if (_ingestion.GetEdibleType(targetUid) == IngestionSystem.Drink)
+                    return 0f;
+
                 var avoidBadFood = !HasComp<IgnoreBadFoodComponent>(owner);
 
                 // only eat when hungry or if it will eat anything


### PR DESCRIPTION
## Short description
Port of my own Blimpuf-Station/BlimpufStation#145

ss14Starlight/space-station-14#4735 added nutrition values to any variant of water which only apply to Diona, but NPC logic saw these as valid food sources now and caused them to drink liquids that restore 0 hunger endlessly until the liquid is consumed or, if they found themselves a toilet, until drinking poisonous toilet water kills them.

Fix makes it so that hungry NPCs like station pets, mice, and mothroaches no longer see liquids as a valid way to satiate hunger. Thirst logic is unaffected.

Bug reported and documented on the SL Discord [here](https://discord.com/channels/1272545509562777621/1544831332889268224/1544831332889268224).

## Why we need to add this
Janitors have it hard enough without every toilet stall being surrounded by dead mice and mothroaches.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Limerent-Sun
- fix: NPCs will no longer seek out liquids to satisfy hunger.