### PR TITLE
Robust Vox Do Drugs

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -370,6 +370,9 @@
     Bloodstream:
       effects:
       - !type:HealthChange
+        conditions: # Starlight: Vox immune to frezon. Caw!
+        - !type:MetabolizerTypeCondition
+          type: [ Human, Animal, Rat, Plant, Arachnid, Moth, Neocyte, Slime ] 
         ignoreResistances: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -372,7 +372,7 @@
       - !type:HealthChange
         conditions: # Starlight: Vox immune to frezon damage. Caw!
         - !type:MetabolizerTypeCondition
-          type: [ Human, Animal, Rat, Plant, Arachnid, Moth, Neocyte, Slime ] 
+          type: [ Human, Animal, Rat, Plant, Arachnid, Moth, Neocyte, Slime ]
         ignoreResistances: true
         damage:
           types:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -370,7 +370,7 @@
     Bloodstream:
       effects:
       - !type:HealthChange
-        conditions: # Starlight: Vox immune to frezon. Caw!
+        conditions: # Starlight: Vox immune to frezon damage. Caw!
         - !type:MetabolizerTypeCondition
           type: [ Human, Animal, Rat, Plant, Arachnid, Moth, Neocyte, Slime ] 
         ignoreResistances: true


### PR DESCRIPTION
## Short description
Makes vox immune to the damage caused by frezon.

## Why we need to add this
I thought it would be funny. And theres not much mechanical reason to play vox so lets give em a RP reason to become frezon junkies.

## Media (Video/Screenshots)
<img width="320" height="250" alt="image" src="https://github.com/user-attachments/assets/eb146f6d-e824-4509-8476-e33b88beed4a" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: OJG
- tweak: Vox are now immune to the genetic damage of frezon. Caw!