### PR TITLE
Reverts "Disposals whacks you"

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Disposal/pipes.yml
@@ -76,12 +76,6 @@
     traversalSpeed: 10
     exitDistanceMultiplier: 1.5
     exitSpeedMultiplier: 1
-    # Starlight Start
-    damageOnTurn:
-      types:
-        Blunt: 1
-    maxAllowedDamage: 100
-    # Starlight End
     container:
       occludes: true
       showEnts: false


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Reverts #5361

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
This damage system is not ready for actual use.
- Breakable entities that break while inside of disposals will suddenly appear on top of disposals pipes. This results in felinoids and diona being bombarded with glass shard landmines everywhere, which pop up frequently because common items like broken light tubes will always break in disposals. Any map that routes disposal tubes along hallways (like Starboard) has a chance of just instantly stunning you out of nowhere.
- Chemistry jugs, beakers will break when shipped to the Bar, Brigmedic, Botany, etc. This is obviously awful and forces people to load jugs into duffelbags which is cumbersome and silly.
- When people bleed from taking damage from disposals, their blood appears on top of whatever tile they're currently on - meaning their blood will randomly show up in places they weren't actually inside of (like secure areas). This absolutely coats the hallways on Alpha.

The _whole_ point of Disposals is to keep the station tidy.

Damage in disposals, instead, breaks jugs, glasses, litters glass shards and blood all over the place.

_Additionally:_
- Maps like Cluster, Manor, etc. use disposal tubes for transport to and from the AI Core.
- No consideration were made for these maps when damage-on-disposal-bends was added.

The idea of disposals hurting people (specifically) can be revisited with proper code support.
- e.g. Mobs being hurt when they go through disposals, but not inanimate objects.

The upstream implementation is not ready yet and it's breaking a bunch of stuff that did not need to be broken.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- remove: Disposal pipes no longer damage entities travelling through them. This means that chemistry jugs will no longer randomly break when being mailed to departments, glass shards will no longer appear randomly on the floor, and there should be less random blood/slime/oil patches along disposals tubes from people bleeding while inside the tubes.
