### PR TITLE
ZXA Anti-Rot

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -405,7 +405,7 @@
       - id: BZCanister
         weight: 0.3
       - id: ZXACanister
-        weight: 0.05  # Starlight: .2 -> .05 Starlight marker requested by rinary despite already being within starlight start and end
+        weight: 0.05
       - id: PluoxiumCanister
         weight: 0.35
       - id: UlnitraniumCanister

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -405,7 +405,7 @@
       - id: BZCanister
         weight: 0.3
       - id: ZXACanister
-        weight: 0.05
+        weight: 0.05  # Starlight: .2 -> .05 Starlight marker requested by rinary despite already being within starlight start and end
       - id: PluoxiumCanister
         weight: 0.35
       - id: UlnitraniumCanister

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -405,7 +405,7 @@
       - id: BZCanister
         weight: 0.3
       - id: ZXACanister
-        weight: 0.2
+        weight: 0.05
       - id: PluoxiumCanister
         weight: 0.35
       - id: UlnitraniumCanister

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -576,10 +576,12 @@
   reactants:
     ZXA:
       amount: 10
+    Salt:
+      amount: 10
     Doxarubixadone:
       amount: 1
   products:
-    Opporozidone: 1
+    Opporozidone: 3
 
 - type: reaction
   id: Arcryox

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -570,19 +570,6 @@
   products:
     Opporozidone: 3
 
-- type: reaction # Starlight: Alternate recipe to give atmos a way to help chemistry.
-  id: OpporozidoneAlt
-  minTemp: 400
-  reactants:
-    ZXA:
-      amount: 10
-    TableSalt:
-      amount: 10
-    Doxarubixadone:
-      amount: 1
-  products:
-    Opporozidone: 3
-
 - type: reaction
   id: Arcryox
   minTemp: 370

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -572,7 +572,7 @@
 
 - type: reaction # Starlight: Alternate recipe to give atmos a way to help chemistry.
   id: OpporozidoneAlt
-  minTemp: 400 
+  minTemp: 400
   reactants:
     ZXA:
       amount: 10

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -570,6 +570,17 @@
   products:
     Opporozidone: 3
 
+- type: reaction # Starlight: Alternate recipe to give atmos a way to help chemistry.
+  id: OpporozidoneAlt
+  minTemp: 400 
+  reactants:
+    ZXA:
+      amount: 10
+    Doxarubixadone:
+      amount: 1
+  products:
+    Opporozidone: 1
+
 - type: reaction
   id: Arcryox
   minTemp: 370

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -576,7 +576,7 @@
   reactants:
     ZXA:
       amount: 10
-    Salt:
+    TableSalt:
       amount: 10
     Doxarubixadone:
       amount: 1

--- a/Resources/Prototypes/_Starlight/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Cargo/cargo_atmospherics.yml
@@ -8,16 +8,6 @@
   category: cargoproduct-category-name-atmospherics
   group: market
 
-- type: cargoProduct
-  id: AtmosphericsZXA
-  icon:
-    sprite: _Starlight/Structures/Storage/canister-ui.rsi
-    state: zxa
-  product: ZXACanister
-  cost: 8200 # PR #5127
-  category: cargoproduct-category-name-atmospherics
-  group: market
-
 # Bulk gases BEGIN
 
 ## Oxygen
@@ -151,19 +141,6 @@
   gasType: BZ
   gasMoles: 1000
   cost: 1800
-  category: cargoproduct-category-name-atmospherics
-  group: market
-
-## ZXA
-- type: cargoProduct
-  id: AtmosphericsZXABulk
-  nameLoc: cargo-product-gas-zxa
-  icon:
-    sprite: _Starlight/Structures/Storage/canister-ui.rsi
-    state: zxa
-  gasType: ZXA
-  gasMoles: 1000
-  cost: 2400
   category: cargoproduct-category-name-atmospherics
   group: market
 

--- a/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
@@ -138,7 +138,7 @@
   products:
     Necrosol: 2
 
-- type: reaction # Starlight: Alternate recipe to give atmos a way to help chemistry.
+- type: reaction
   id: OpporozidoneAlt
   minTemp: 400
   reactants:

--- a/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_Starlight/Recipes/Reactions/medicine.yml
@@ -138,3 +138,15 @@
   products:
     Necrosol: 2
 
+- type: reaction # Starlight: Alternate recipe to give atmos a way to help chemistry.
+  id: OpporozidoneAlt
+  minTemp: 400
+  reactants:
+    ZXA:
+      amount: 10
+    TableSalt:
+      amount: 10
+    Doxarubixadone:
+      amount: 1
+  products:
+    Opporozidone: 3


### PR DESCRIPTION
## Short description
Makes ZXA useful as an alternative means to make opporozidone 
Makes ZXA a rarer find on salvage magnets.

## Why we need to add this
Gives chemistry an alternate way of making oppo that is reliant on cooperation with atmos rather than botany.

## Media (Video/Screenshots)
<img width="324" height="240" alt="image" src="https://github.com/user-attachments/assets/d8cd08a7-56d8-4d8f-b5d5-2beb6866cdbc" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: OJG
- add: Added a new alternate recipe for oppo that uses ZXA instead of cogni and plasma.
- tweak: Reduced the chances of finding ZXA cans on salvage magnet pulls.
- tweak: Removed cargo ZXA purchase options.
