### PR TITLE
Box Shelf Box Deletion Fix

### DIFF
--- a/Resources/Prototypes/_Funkystation/Recipes/Construction/Graphs/storage/boxshelfconstruction.yml
+++ b/Resources/Prototypes/_Funkystation/Recipes/Construction/Graphs/storage/boxshelfconstruction.yml
@@ -21,6 +21,7 @@
     edges:
     - to: start
       completed:
+      - !type:EmptyAllContainers # SL Edit - Don't delete boxes
       - !type:SpawnPrototype
         prototype: SheetSteel1
         amount: 5


### PR DESCRIPTION
## Short description
Resolved a bug with Box Shelves. Box Shelves now drop their contents when deconstructed instead of deleting them.

## Why we need to add this
Bug.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Conflee
- fix: Fixed Box Shelves deleting their contents when deconstructed. Boxes on the shelves now drop properly.
