### PR TITLE
Firebots put out Reagent Fires

### DIFF
--- a/Content.Server/NPC/Queries/Queries/ComponentQuery.cs
+++ b/Content.Server/NPC/Queries/Queries/ComponentQuery.cs
@@ -10,3 +10,14 @@ public sealed partial class ComponentQuery : UtilityQuery
     [DataField("components", required: true)]
     public ComponentRegistry Components = default!;
 }
+
+/// Persistence Start
+/// <summary>
+/// Persistence: Returns nearby entities that match any of the specified components
+/// </summary>
+public sealed partial class ComponentQueryAny : UtilityQuery
+{
+    [DataField("components", required: true)]
+    public ComponentRegistry Components = default!;
+}
+/// Persistence End

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -373,7 +373,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
                     // Persistence Start: Firebots can target reagent fires
                     if (TryComp(targetUid, out TagComponent? tags) && tags.Tags.AsReadOnly().Contains((_proto.Index<TagPrototype>("ReagentFire"))))
                         return 1f;
-					// Persistence End
+                    // Persistence End
 
                     return 0f;
                 }

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -528,7 +528,7 @@ public sealed partial class NPCUtilitySystem : EntitySystem
 
                     break;
                 }
-			// Persistence End
+            // Persistence End
 
             default:
                 throw new NotImplementedException();

--- a/Content.Server/NPC/Systems/NPCUtilitySystem.cs
+++ b/Content.Server/NPC/Systems/NPCUtilitySystem.cs
@@ -34,6 +34,7 @@ using Content.Shared.Damage.Components;
 using Content.Shared.Temperature.Components;
 using Content.Server._Starlight.NPC.Queries.Considerations;
 using Content.Shared.Projectiles;
+using Content.Shared.Tag; // Persistence: Firebots can target reagent fires
 
 namespace Content.Server.NPC.Systems;
 
@@ -368,6 +369,12 @@ public sealed partial class NPCUtilitySystem : EntitySystem
                 {
                     if (TryComp(targetUid, out FlammableComponent? fire) && fire.OnFire)
                         return 1f;
+
+                    // Persistence Start: Firebots can target reagent fires
+                    if (TryComp(targetUid, out TagComponent? tags) && tags.Tags.AsReadOnly().Contains((_proto.Index<TagPrototype>("ReagentFire"))))
+                        return 1f;
+					// Persistence End
+
                     return 0f;
                 }
             case TargetIsStunnedCon:
@@ -501,6 +508,28 @@ public sealed partial class NPCUtilitySystem : EntitySystem
                 }
                 break;
             }
+
+            // Persistence Start: Firebots can target reagent fires
+            case ComponentQueryAny compQueryAny:
+                {
+                    if (compQueryAny.Components.Count == 0)
+                        return;
+
+                    var mapPos = _transform.GetMapCoordinates(owner, xform: _xformQuery.GetComponent(owner));
+                    _compTypes.Clear();
+                    _entitySet.Clear();
+                    foreach (var comp in compQueryAny.Components.Values)
+                    {
+                        _lookup.GetEntitiesInRange(comp.Component.GetType(), mapPos, vision, _entitySet);
+                    }
+
+                    foreach (var ent in _entitySet)
+                        entities.Add(ent);
+
+                    break;
+                }
+			// Persistence End
+
             default:
                 throw new NotImplementedException();
         }

--- a/Resources/Prototypes/NPCs/utility_queries.yml
+++ b/Resources/Prototypes/NPCs/utility_queries.yml
@@ -168,13 +168,14 @@
 - type: utilityQuery
   id: NearbyOnFire
   query:
-    - !type:ComponentQuery
+    - !type:ComponentQueryAny # Persistence: Firebots can target reagent fires
       components:
         - type: Flammable
           # why does Flammable even have a required damage
           damage:
             types:
               burn: 0
+        - type: ReagentPuddleFireEffect # Persistence: Firebots put out reagent fires
   considerations:
     - !type:TargetDistanceCon
       curve: !type:PresetCurve

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
@@ -12,6 +12,9 @@
     drawdepth: Overlays
   - type: Appearance
   - type: ReagentPuddleFireEffect
+  - type: Tag # Persistence: Firebots can target reagent fires
+    tags:
+    - ReagentFire
 
 - type: particleEffect
   id: ReagentFireContinuous

--- a/Resources/Prototypes/_Funkystation/tags.yml
+++ b/Resources/Prototypes/_Funkystation/tags.yml
@@ -42,3 +42,6 @@
 
 - type: Tag
   id: CardboardboxLarge
+
+- type: Tag # Persistence: Firebots can target reagent fires
+  id: ReagentFire


### PR DESCRIPTION
## Short description
Ports parts of https://github.com/michaelchessall/SS14-Persistence/pull/602 from Persistence.

Firebots will now correctly target and extinguish Reagent Fires.

Did not port Wall Stain fire fighting as it is buggy and results in bots getting stuck often I hear.

## Why we need to add this
Firebots fight fire.

## Media (Video/Screenshots)
N/A

## Checks

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: stinkiestdog, Conflee
- tweak: Firebots will now correctly target and attempt to extinguish Reagent Fires (but not Wall Stain fires as they get stuck and bug out if you have them target those).

