### PR TITLE
Add warming effect to hot drinks

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -607,6 +607,13 @@
       effects:
       - !type:SatiateHunger
         factor: 4
+      # Starlight start, add drink temperature adjustment
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 500
+      # Starlight end
 
 - type: reagent
   id: ArnoldPalmer

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -23,7 +23,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 1600
+        amount: 500
       # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
@@ -53,7 +53,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 1600
+        amount: 500
       # Starlight end
 
 - type: reagent
@@ -131,7 +131,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 1600
+        amount: 500
       # Starlight end
 
 - type: reagent
@@ -158,7 +158,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 1600
+        amount: 500
   # Starlight end
 
 - type: reagent
@@ -450,7 +450,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 1600
+        amount: 500
       # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/teaglass.rsi

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -428,6 +428,13 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      # Starlight start, add drink temperature adjustment
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 500
+      # Starlight end
 
 - type: reagent
   id: Tea

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -18,6 +18,11 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 2000
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
     state: icon_empty
@@ -38,6 +43,14 @@
     Digestion:
       metabolites:
         Theobromine: 0.1
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 2000
 
 - type: reagent
   id: Cream
@@ -109,6 +122,11 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 2000
 
 - type: reagent
   id: GreenTea
@@ -124,6 +142,16 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  metabolisms:
+    Digestion:
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 2000
 
 - type: reagent
   id: Grenadine
@@ -406,6 +434,14 @@
     Digestion:
       metabolites:
         Theobromine: 0.1
+      effects:
+      - !type:SatiateThirst
+        factor: 3
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          max: 323.15
+        amount: 2000
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/teaglass.rsi
     state: icon_empty
@@ -516,6 +552,11 @@
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Plant ]
+      - !type:AdjustTemperature
+        conditions:
+        - !type:TemperatureCondition
+          min: 248.15
+        amount: -2000
       # Starlight end
   plantMetabolism:
   - !type:PlantAdjustWater

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -565,8 +565,8 @@
       - !type:AdjustTemperature # Starlight, add drink temperature adjustment
         conditions:
         - !type:TemperatureCondition
-          min: 248.15
-        amount: -2000
+          min: 253.15
+        amount: -1900
       # Starlight end
   plantMetabolism:
   - !type:PlantAdjustWater

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -566,7 +566,7 @@
         conditions:
         - !type:TemperatureCondition
           min: 253.15
-        amount: -1900
+        amount: -1800
       # Starlight end
   plantMetabolism:
   - !type:PlantAdjustWater

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -18,11 +18,13 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      # Starlight start, add drink temperature adjustment
       - !type:AdjustTemperature
         conditions:
         - !type:TemperatureCondition
           max: 323.15
         amount: 2000
+      # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
     state: icon_empty
@@ -43,6 +45,7 @@
     Digestion:
       metabolites:
         Theobromine: 0.1
+      # Starlight start, add drink temperature adjustment
       effects:
       - !type:SatiateThirst
         factor: 3
@@ -51,6 +54,7 @@
         - !type:TemperatureCondition
           max: 323.15
         amount: 2000
+      # Starlight end
 
 - type: reagent
   id: Cream
@@ -122,11 +126,13 @@
         effectProto: StatusEffectDrowsiness
         time: 2
         type: Remove
+      # Starlight start, add drink temperature adjustment
       - !type:AdjustTemperature
         conditions:
         - !type:TemperatureCondition
           max: 323.15
         amount: 2000
+      # Starlight end
 
 - type: reagent
   id: GreenTea
@@ -142,6 +148,7 @@
   metamorphicMaxFillLevels: 4
   metamorphicFillBaseName: fill-
   metamorphicChangeColor: false
+  # Starlight start, add drink temperature adjustment
   metabolisms:
     Digestion:
       effects:
@@ -152,6 +159,7 @@
         - !type:TemperatureCondition
           max: 323.15
         amount: 2000
+  # Starlight end
 
 - type: reagent
   id: Grenadine
@@ -434,6 +442,7 @@
     Digestion:
       metabolites:
         Theobromine: 0.1
+      # Starlight start, add drink temperature adjustment
       effects:
       - !type:SatiateThirst
         factor: 3
@@ -442,6 +451,7 @@
         - !type:TemperatureCondition
           max: 323.15
         amount: 2000
+      # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/teaglass.rsi
     state: icon_empty
@@ -552,7 +562,7 @@
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Plant ]
-      - !type:AdjustTemperature
+      - !type:AdjustTemperature # Starlight, add drink temperature adjustment
         conditions:
         - !type:TemperatureCondition
           min: 248.15

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -23,7 +23,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 2000
+        amount: 1600
       # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/coffeeglass.rsi
@@ -53,7 +53,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 2000
+        amount: 1600
       # Starlight end
 
 - type: reagent
@@ -131,7 +131,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 2000
+        amount: 1600
       # Starlight end
 
 - type: reagent
@@ -158,7 +158,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 2000
+        amount: 1600
   # Starlight end
 
 - type: reagent
@@ -450,7 +450,7 @@
         conditions:
         - !type:TemperatureCondition
           max: 323.15
-        amount: 2000
+        amount: 1600
       # Starlight end
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/teaglass.rsi
@@ -562,11 +562,6 @@
         conditions:
         - !type:MetabolizerTypeCondition
           type: [ Plant ]
-      - !type:AdjustTemperature # Starlight, add drink temperature adjustment
-        conditions:
-        - !type:TemperatureCondition
-          min: 253.15
-        amount: -1800
       # Starlight end
   plantMetabolism:
   - !type:PlantAdjustWater


### PR DESCRIPTION
## Short description
Hot drinks will now have a moderate warming / temperature adjustment effect.

## Why we need to add this
Allows crew to consume several hot beverages to fight off cold.

## Details
With a value of 500, it is not strong enough to prevent cold slowdowns with only a jacket on Novo lobster. It is enough however to significantly speed up _restoring_ temperature to good levels if wearing a jacket + hat.

This hopefully incentivizes warm drinks for recovery (which is also good RP), without enabling 'binging' as a meta strategy.

This warming effect is not strong enough to kill critters. (~1750 will do that)

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

:cl: Xale
- add: Hot drinks now slightly raise body temperature. This affects coffee, cafe latte, soy latte, tea, green tea, hot chocolate, and hot ramen.