### PR TITLE
Increased Plasma availability to be equal to that of Gold and Silver.

### DIFF
--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -68,9 +68,9 @@
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockPlasma
-      count: 35
-      minGroupSize: 4
-      maxGroupSize: 8
+      count: 40               #Starlight edit: Increased Plasma count to reflect heavy Plasma useage. 35 -> 40
+      minGroupSize: 8         #Starlight edit: 4 -> 8
+      maxGroupSize: 12        #Starlight edit: 8 -> 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockUraniumCrab2 #Starlight - Stay on your toes miners >:3

--- a/Resources/Prototypes/Procedural/vgroid.yml
+++ b/Resources/Prototypes/Procedural/vgroid.yml
@@ -68,9 +68,9 @@
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockPlasma
-      count: 40               #Starlight edit: Increased Plasma count to reflect heavy Plasma useage. 35 -> 40
-      minGroupSize: 8         #Starlight edit: 4 -> 8
-      maxGroupSize: 12        #Starlight edit: 8 -> 12
+      count: 40               #Starlight - Increased Plasma count to reflect heavy Plasma useage. 35 -> 40
+      minGroupSize: 8         #Starlight - 4 -> 8
+      maxGroupSize: 12        #Starlight - 8 -> 12
     - !type:OreDunGen
       replacement: IronRock
       entity: IronRockUraniumCrab2 #Starlight - Stay on your toes miners >:3

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -39,7 +39,7 @@
   minOreYield: 1
   maxOreYield: 3
 
-#Starlight edit: moved plasma from low yield to medium yield
+#Starlight - moved plasma from low yield to medium yield
 - type: ore
   id: OrePlasma
   oreEntity: PlasmaOre1

--- a/Resources/Prototypes/ore.yml
+++ b/Resources/Prototypes/ore.yml
@@ -39,13 +39,14 @@
   minOreYield: 1
   maxOreYield: 3
 
-# Low yields
+#Starlight edit: moved plasma from low yield to medium yield
 - type: ore
   id: OrePlasma
   oreEntity: PlasmaOre1
   minOreYield: 1
-  maxOreYield: 2
+  maxOreYield: 3
 
+# Low yields
 - type: ore
   id: OreUranium
   oreEntity: UraniumOre1


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Make Plasma more available for every department, as Plasma is used in every department and is usually the first material to run out.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
<img width="483" height="299" alt="image" src="https://github.com/user-attachments/assets/af582453-5a2e-4990-9fc6-09b1c66e1098" />

Many recipes require plasma, and a lot of it. However, Plasma is currently one of the rarest materials in the game. Making it on par with Silver and Gold should help resolve the Plasma bottleneck.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: DrNonnoob
- tweak: Plasma ore veins are now larger and more productive following a series of improvements to detection and extraction technologies. 
- tweak: Plasma ore per node increased from 1-2 to 1-3. 
- tweak: The number of plasma ore veins increased from 35 to 40.
- tweak: Minimum and maximum plasma ore vein size increased from 4 and 8 to 8 and 12, respectively.