### PR TITLE
Fix actions out of order at roundstart 

### DIFF
--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -56,6 +56,11 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
     private readonly DragDropHelper<ActionButton> _menuDragHelper;
     private readonly TextureRect _dragShadow;
     private ActionsWindow? _window;
+    // Starlight Start
+    private readonly int _resetMargin = 10;
+    private long _nextReset;
+    private bool _didReset;
+    // Starlight End
 
     private ActionsBar? ActionsBar => UIManager.GetActiveUIWidgetOrNull<ActionsBar>();
     private UserInterface.Controls.MenuButton? ActionButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.ActionButton;
@@ -106,6 +111,10 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
             _actionsSystem.OnActionAdded += OnActionAdded;
             _actionsSystem.OnActionRemoved += OnActionRemoved;
             _actionsSystem.ActionsUpdated += OnActionsUpdated;
+            //Starlight Start
+            _nextReset = _timing.CurTick.Value + _resetMargin;
+            _didReset = false;
+            //Starlight End
         }
 
         UpdateFilterLabel();
@@ -745,6 +754,22 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
         _menuDragHelper.Update(args.DeltaSeconds);
         if (_window is {UpdateNeeded: true})
             SearchAndDisplay();
+        //Starlight start
+        // Don't Hack   Open inside
+        // WE LOVE RACE CONDITIONS!! we only sort actions if they're ready at the same time,
+        // then we append so new actions don't override old ones (otherwise we'd reset players dragging them)
+        // problem: roundstart, it takes so long half the actions are ready during different ticks.
+        // so I'm just adding a timer to resort everything 10 ticks after the Ui starts :'3
+        if (_didReset)
+            return;
+        if (_nextReset <= _timing.CurTick.Value && _actionsSystem != null)
+        {
+            LoadDefaultActions();
+            _container?.SetActionData(_actionsSystem, _actions.ToArray());
+            QueueWindowUpdate();
+            _didReset = true;
+        }
+        //Starlight end
     }
 
     private void OnComponentLinked(ActionsComponent component)

--- a/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
+++ b/Content.Client/UserInterface/Systems/Actions/ActionUIController.cs
@@ -56,11 +56,11 @@ public sealed partial class ActionUIController : UIController, IOnStateChanged<G
     private readonly DragDropHelper<ActionButton> _menuDragHelper;
     private readonly TextureRect _dragShadow;
     private ActionsWindow? _window;
-    // Starlight Start
+    #region Starlight
     private readonly int _resetMargin = 10;
     private long _nextReset;
     private bool _didReset;
-    // Starlight End
+    #endregion
 
     private ActionsBar? ActionsBar => UIManager.GetActiveUIWidgetOrNull<ActionsBar>();
     private UserInterface.Controls.MenuButton? ActionButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.ActionButton;


### PR DESCRIPTION
## Short description
Resorts all actions after a player spawns, so that they actually listen to priority.

## Why we need to add this
they used to be somewhat random and dependant on server conditions, it was annoying.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: Kirb
- fix: Fixed hotbar order at roundstart.

