### PR TITLE
Techfab steal targets count now

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1317,6 +1317,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: DepartmentalTechFabCircuitboard
 
 - type: entity
   id: EngineeringTechFabCircuitboard
@@ -1334,6 +1336,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: DepartmentalTechFabCircuitboard
 
 - type: entity
   id: ServiceTechFabCircuitboard
@@ -1351,6 +1355,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: DepartmentalTechFabCircuitboard
 
 - type: entity
   id: ScienceTechFabCircuitboard
@@ -1368,6 +1374,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: DepartmentalTechFabCircuitboard
 
 - type: entity
   id: CommandTechFabCircuitboard
@@ -1385,6 +1393,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: SecureTechFabCircuitboard
 
 - type: entity
   id: NanoTrasenTechFabCircuitboard
@@ -1403,6 +1413,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: SecureTechFabCircuitboard
 
 - type: entity
   id: CentralCommandTechFabCircuitboard
@@ -1421,6 +1433,8 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
+    - type: StealTarget
+      stealGroup: SecureTechFabCircuitboard
 
 - type: entity
   id: SyndicateTechFabCircuitboard

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -1355,8 +1355,6 @@
         GlassBeaker:
           amount: 2
           defaultPrototype: Beaker
-    - type: StealTarget
-      stealGroup: DepartmentalTechFabCircuitboard
 
 - type: entity
   id: ScienceTechFabCircuitboard


### PR DESCRIPTION
## Short description
Only the medical and security ones counted before.

## Why we need to add this
Bugs are bugs.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Departmental techfabs now actually count towards their steal objectives.
