### PR TITLE
Fix hunger and thirst rate documentation

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
@@ -36,12 +36,6 @@
       - Tail
       - HeadTop
     - type: Hunger # on 1.8x more
-      thresholds: # 25% higher than defaults
-        Overfed: 250.0
-        Okay: 187.5
-        Peckish: 125.0
-        Starving: 62.5
-        Dead: 0
       baseDecayRate: 0.03
     - type: Icon
       sprite: _FarHorizons/Mobs/Species/Proto-Avali/parts.rsi

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
@@ -35,7 +35,7 @@
       hideLayersOnEquip:
       - Tail
       - HeadTop
-    - type: Hunger # on 2x more
+    - type: Hunger # on 1.8x more
       thresholds: # 25% higher than defaults
         Overfed: 250.0
         Okay: 187.5

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/avali.yml
@@ -36,11 +36,11 @@
       - Tail
       - HeadTop
     - type: Hunger # on 2x more
-      thresholds:
-        Overfed: 250
-        Okay: 200
-        Peckish: 150
-        Starving: 100
+      thresholds: # 25% higher than defaults
+        Overfed: 250.0
+        Okay: 187.5
+        Peckish: 125.0
+        Starving: 62.5
         Dead: 0
       baseDecayRate: 0.03
     - type: Icon

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/vulpkanin.yml
@@ -19,11 +19,11 @@
     - Dog
   - type: Wagging
   - type: Hunger # on 1.5x more
-    thresholds:
-      Overfed: 250
-      Okay: 200
-      Peckish: 150
-      Starving: 100
+    thresholds: # 25% higher than defaults
+      Overfed: 250.0
+      Okay: 187.5
+      Peckish: 125.0
+      Starving: 62.5
       Dead: 0
     baseDecayRate: 0.018
   - type: Thirst # Starlight start, on 1.5x more

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/vulpkanin.yml
@@ -18,21 +18,9 @@
     - Fox
     - Dog
   - type: Wagging
-  - type: Hunger # on 1.5x more
-    thresholds: # 25% higher than defaults
-      Overfed: 250.0
-      Okay: 187.5
-      Peckish: 125.0
-      Starving: 62.5
-      Dead: 0
+  - type: Hunger # on 1.1x more
     baseDecayRate: 0.018
-  - type: Thirst # Starlight start, on 1.5x more
-    thresholds:
-      OverHydrated: 650
-      Okay: 500
-      Thirsty: 350
-      Parched: 200
-      Dead: 0
+  - type: Thirst # Starlight start, on 1.25x more
     baseDecayRate: 0.125
   - type: TemperatureDamage # Ported over from CD. Afterall, it does make sense that something with fur can handle more cold/less heat. Basegame Moths, apparently, have similar resistances.
     heatDamageThreshold: 325

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
@@ -51,11 +51,11 @@
       - Tail
       - HeadTop
     - type: Hunger # on 2x more
-      thresholds:
-        Overfed: 250
-        Okay: 200
-        Peckish: 150
-        Starving: 100
+      thresholds: # 25% higher than defaults
+        Overfed: 250.0
+        Okay: 187.5
+        Peckish: 125.0
+        Starving: 62.5
         Dead: 0
       baseDecayRate: 0.03
     - type: Thirst

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/avali.yml
@@ -50,13 +50,7 @@
       hideLayersOnEquip:
       - Tail
       - HeadTop
-    - type: Hunger # on 2x more
-      thresholds: # 25% higher than defaults
-        Overfed: 250.0
-        Okay: 187.5
-        Peckish: 125.0
-        Starving: 62.5
-        Dead: 0
+    - type: Hunger # on 1.8x more
       baseDecayRate: 0.03
     - type: Thirst
     - type: Icon

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/vulpkanin.yml
@@ -149,21 +149,9 @@
     #        state: hair
   # Starlight end
   # starlight start - temp vulpkanin revert
-  - type: Hunger # on 1.5x more
-    thresholds: # 25% higher than defaults
-      Overfed: 250.0
-      Okay: 187.5
-      Peckish: 125.0
-      Starving: 62.5
-      Dead: 0
+  - type: Hunger # on 1.1x more
     baseDecayRate: 0.018
-  - type: Thirst # on 1.5x more
-    thresholds:
-      OverHydrated: 650
-      Okay: 500
-      Thirsty: 350
-      Parched: 200
-      Dead: 0
+  - type: Thirst # on 1.25x more
     baseDecayRate: 0.125
   - type: TemperatureDamage # Ported over from CD. Afterall, it does make sense that something with fur can handle more cold/less heat. Basegame Moths, apparently, have similar resistances.
     heatDamageThreshold: 325

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/vulpkanin.yml
@@ -150,11 +150,11 @@
   # Starlight end
   # starlight start - temp vulpkanin revert
   - type: Hunger # on 1.5x more
-    thresholds:
-      Overfed: 250
-      Okay: 200
-      Peckish: 150
-      Starving: 100
+    thresholds: # 25% higher than defaults
+      Overfed: 250.0
+      Okay: 187.5
+      Peckish: 125.0
+      Starving: 62.5
       Dead: 0
     baseDecayRate: 0.018
   - type: Thirst # on 1.5x more

--- a/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
+++ b/Resources/ServerInfo/_Starlight/Guidebook/Mobs/Avali.xml
@@ -15,7 +15,7 @@
   - Can stand in tempatures of up to [color=#1e90ff]-50c before taking cold damage[/color].
   - Deal [color=red]6.25[/color] slashing damage with claws.
   - Can fly in Zero-G.
-  - 2x Hunger rate, stay fed!
+  - 1.8x Hunger rate, stay fed!
   - Can only eat meat-related food items (including organs) and pills.
   - Heal airloss from Ammonia and Amoxla but..
   - Saline will burn you, and both Dexalin and Dexalin+ are lethal to you. Remember to remind doctors about it!


### PR DESCRIPTION
## Short description
Hunger and thirst rates for Avali and Vulpkanin does not match their actual rates.
Removes custom Avali and Vulpkanin hunger and thirst thresholds.

## Why we need to add this
#### Hunger Rates
Documentation should be correct, so that incorrect assumptions are not made.

The documentation seems to reflect a baseline hunger rate of `0.015`, however the actual default rate is `0.0166` (1/60).
https://github.com/ss14Starlight/space-station-14/blob/232cd2c30d2bcf8eceb08e7218c1fad74d2628c5/Content.Shared/Nutrition/Components/HungerComponent.cs#L38

The actual default thirst rate is `0.1`.
https://github.com/ss14Starlight/space-station-14/blob/232cd2c30d2bcf8eceb08e7218c1fad74d2628c5/Content.Shared/Nutrition/Components/ThirstComponent.cs#L18

#### Thresholds
The custom thresholds were removed because they were just a flat `+50`. This had no gameplay impact except when trying to recover from the 0 "Death" level of hunger or thirst. One could use modified thresholds to give these species increased margins between different states, but this wasn't done.

Default thirst thresholds:
https://github.com/ss14Starlight/space-station-14/blob/232cd2c30d2bcf8eceb08e7218c1fad74d2628c5/Content.Shared/Nutrition/Components/ThirstComponent.cs#L52-L59

Default hunger thresholds:
https://github.com/ss14Starlight/space-station-14/blob/232cd2c30d2bcf8eceb08e7218c1fad74d2628c5/Content.Shared/Nutrition/Components/HungerComponent.cs#L70-L77

## Media (Video/Screenshots)
Human / Vulpkanin / Avali hunger rates
<img height="500" alt="image" src="https://github.com/user-attachments/assets/271df552-2db4-401f-83d7-29550a02f93b" />

Human / Vulpkanin thirst rates
<img height="500" alt="image" src="https://github.com/user-attachments/assets/0690f627-db65-467f-96c0-43be59bc4470" />

Validated that rates are the same on branch and `starlight-dev`.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

:cl: Xale
- tweak: Avali and Vulpkanin no longer require more food or water to get out of near-dying levels of hunger or thirst.
- fix: Documentation for Avali hunger rate, which is 1.8x rather than the previously stated 2.0x.
- fix: Documentation for Vulpkanin hunger rate, which is 1.1x rather than the previously stated 1.5x.
- fix: Documentation for Vulpkanin thirst rate, which is 1.25x rather than the previously stated 1.5x.