### PR TITLE
Fix Abductor Experimentator return teleport grid parenting

### DIFF
--- a/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
+++ b/Content.Server/_Starlight/Antags/Abductor/EntitySystems/AbductorSystem.Console.cs
@@ -26,6 +26,7 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
     [Dependency] private SharedItemSwitchSystem _itemSwitch = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private VendingMachineSystem _vending = default!;
+    [Dependency] private SharedGridTraversalSystem _gridTraversal = default!;
 
     private readonly SoundSpecifier _sendSound = new SoundPathSpecifier("/Audio/Voice/Human/wilhelm_scream.ogg");
     private readonly SoundSpecifier _alienTeleport = new SoundPathSpecifier("/Audio/_Starlight/Misc/alien_teleport.ogg");
@@ -125,7 +126,14 @@ public sealed partial class AbductorSystem : SharedAbductorSystem
         _audioSystem.PlayPvs(_sendSound, experimentatorId.Value);
 
         if (victimComp.Position is { } position)
+        {
             _xformSys.SetCoordinates(victim, position);
+
+            var xform = Transform(victim);
+
+            if (xform.MapUid is { } map)
+                _gridTraversal.CheckTraversal(victim, xform, map);
+        }
     }
 
     private void TryUpdateObjectiveProgress(EntityUid actor, EntityUid victim, AbductorVictimComponent victimComp, AbductorConsoleComponent component)


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes an issue where Abductor victims were not properly re-parented to the grid when being teleported back with Experimentator. This is most notable when the victim is returned while sleeping, as they are unable to move which cannot trigger grid traversal to fix the issue. This causes them to remain parented to space and possibly die to spacing.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Instead of requiring a grid traversal to update the victim's TransformComponent ParentUid (which is set to space when teleporting back), it does it after teleporting.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
Before:
<img width="2224" height="1231" alt="Content Client_FjO9ijR80c" src="https://github.com/user-attachments/assets/3439add5-c1e8-4049-ba16-162fc81087c0" />
After:
<img width="2217" height="1219" alt="Content Client_BlljKjXFc9" src="https://github.com/user-attachments/assets/258b5454-27ad-4a0f-a711-0ec529f7762c" />

## Checks
<!-- check boxes for faster reviewing of your PR -->
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: qbrx
- fix: Abductor victims are now correctly parented to the appropriate grid when returned from the Experimentator.