### PR TITLE
Wizard RGB Staff

### DIFF
--- a/Resources/Locale/en-US/_Starlight/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/_Starlight/store/spellbook-catalog.ftl
@@ -1,6 +1,9 @@
 spellbook-staff-healing-name = Staff of Healing
 spellbook-staff-healing-description = You don't foresee having to use this in your quest for carnage too often.
 
+spellbook-staff-rgb-name = Staff of Rainbows
+spellbook-staff-rgb-description = Someone is ready for a party!
+
 spellbook-event-summon-cheese-name = Summon Cheese
 spellbook-event-summon-cheese-description = Reach into the void and pluck out... a single piece of cheese!
 

--- a/Resources/Prototypes/_Starlight/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/spellbook_catalog.yml
@@ -12,6 +12,19 @@
     stock: 1
 
 - type: listing
+  id: SpellbookStaffRGB
+  name: spellbook-staff-rgb-name
+  description: spellbook-staff-rgb-description
+  productEntity: RGBStaff
+  cost:
+    WizCoin: 0 # :godo:
+  categories:
+  - SpellbookEquipment
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
   id: SpellbookSpellSummonCheese
   name: spellbook-event-summon-cheese-name
   description: spellbook-event-summon-cheese-description


### PR DESCRIPTION
## Short description
Putting the rgb staff in the spellbook as another option for wizards to mess about with.

## Why we need to add this
RGB Staff is funny. https://discord.com/channels/1272545509562777621/1545883371631284314

## Media (Video/Screenshots)
<img width="505" height="147" alt="image" src="https://github.com/user-attachments/assets/d0f18cdf-23ed-4cb5-9cc9-441f7391ccc2" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Johnny
- add: Added RGB staff to wizard.
