### PR TITLE
cyber welder fix

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -159,7 +159,7 @@
 
 - type: entity
   name: welding tool
-  parent: [ SolutionToolWelderIndsutrial, BaseItem ]
+  parent: [ SolutionToolWelder, BaseItem ]
   id: WelderCyber
   description: "Melts anything as long as it's fueled, don't forget your eye protection!"
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -159,7 +159,7 @@
 
 - type: entity
   name: welding tool
-  parent: BaseItem
+  parent: [ SolutionToolWelderIndsutrial, BaseItem ]
   id: WelderCyber
   description: "Melts anything as long as it's fueled, don't forget your eye protection!"
   components:
@@ -234,13 +234,6 @@
       collection: MetalThud
   - type: RefillableSolution
     solution: Welder
-  - type: Solution
-    id: Welder
-    solution:
-      reagents:
-      - ReagentId: WeldingFuel
-        Quantity: 100
-      maxVol: 100
   - type: Tool
     speedModifier: 1.75
     useSound:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Tools/cyberlimb.yml
@@ -233,7 +233,7 @@
     soundHit:
       collection: MetalThud
   - type: RefillableSolution
-    solution: Welder
+    solution: welder
   - type: Tool
     speedModifier: 1.75
     useSound:


### PR DESCRIPTION
## Short description
Fixes cyberwelders

## Why we need to add this
They were apparently forgotten when solutions were done so they had 0/0 fuel storage. Now they inherit from the industrial welder they are clearly based on.


## Media (Video/Screenshots)
<img width="466" height="19" alt="image" src="https://github.com/user-attachments/assets/973804ed-08d1-4de9-95de-1c4514e2addb" />
<img width="192" height="73" alt="image" src="https://github.com/user-attachments/assets/ca006ec2-9ee8-479d-aafd-8cca098d864e" />


## Checks
<!-- check boxes for faster reviewing of your PR -->


- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Cybernetic Welding Tools have a fuel tank again.
