### PR TITLE
Match sticks and torches can ignite fires now

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/torch.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/torch.yml
@@ -44,7 +44,7 @@
       energy: 5.0
       netsync: false
     - type: IgnitionSource
-      temperature: 400
+      temperature: 500 # Starlight
       ignited: false
     - type: LightBehaviour
       behaviours:

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -37,7 +37,7 @@
         variation: 0.125
   - type: IgnitionSource
     ignited: false
-    temperature: 400.0
+    temperature: 500.0 # Starlight
   - type: PointLight
     enabled: false
     radius: 1.1


### PR DESCRIPTION
## Short description
Match sticks and torches can ignite fires now.

## Why we need to add this
Immersion, why can't the thing that's literally on fire ignite fires?

## Media (Video/Screenshots)
<img width="290" height="233" alt="image" src="https://github.com/user-attachments/assets/110c7cff-3812-4c46-a3e5-ca713e440ac5" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- tweak: Match sticks and torches can ignite fires now.