### PR TITLE
Salvage medic can no longer be antag

### DIFF
--- a/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
+++ b/Resources/Prototypes/_Starlight/Roles/Antags/base.yml
@@ -31,6 +31,7 @@
   jobBlacklist:
   - SalvageLead
   - SalvageSpecialist
+  - SalvageMedic
   - Paramedic
   - AssistantManager
 
@@ -104,6 +105,7 @@
   - SecurityCadet
   - SalvageLead
   - SalvageSpecialist
+  - SalvageMedic
   - AssistantManager
 
 # Cosmic Cult


### PR DESCRIPTION
## Short description
Name on the title.

## Why we need to add this
They are a member of salvage, unlimited access to guns.

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld
- fix: Salvage medic can no longer be antag.
