### PR TITLE
Crate fix

### DIFF
--- a/Content.Shared/Wires/SharedWiresSystem.cs
+++ b/Content.Shared/Wires/SharedWiresSystem.cs
@@ -70,7 +70,7 @@ public abstract partial class SharedWiresSystem : EntitySystem
 
         AdminLogger.Add(LogType.Action, LogImpact.Low,
             $"{ToPrettyString(args.User):user} is screwing {ToPrettyString(ent):target}'s {(ent.Comp.Open ? "open" : "closed")} maintenance panel at {Transform(ent).Coordinates:targetlocation}");
-        args.Handled = true;
+        //args.Handled = true; #Starlight not cancelling it here is required to make constructions with wire panels work.
     }
 
     private void OnExamine(EntityUid uid, WiresPanelComponent component, ExaminedEvent args)

--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/base_structurecrates.yml
@@ -42,7 +42,7 @@
         density: 50
         mask:
         - CrateMask #this is so they can go under plastic flaps
-        - SovietLayer #Starlight: make generics collide with soviet crates
+        #- SovietLayer #Starlight: make generics collide with soviet crates #It also makes them entirely impassable to everything else
         layer:
         - MachineLayer
   - type: EntityStorage


### PR DESCRIPTION
## Short description
Fixes crates not being pathable, and secure crates not being deconstructable.

## Why we need to add this
Hotfixes current issues with crates.
Partially reverts https://github.com/ss14Starlight/space-station-14/pull/5921
@RedSpeeds please make sure you can still walk over crates before you reenable that collision layer.
Diables wire panels from setting the interaction event as handled. That doesn't *seem* to break anything else, but it's also not a recent addition, so I am not sure why it broke now...

## Media (Video/Screenshots)
<img width="222" height="324" alt="image" src="https://github.com/user-attachments/assets/940f4c54-02f1-409a-944e-62b00dd4161b" />

<img width="177" height="228" alt="image" src="https://github.com/user-attachments/assets/0a77683c-e0c6-4d99-80b9-91ac20889ba7" />

Can stand on and deconstruct secure crates.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- remove: Soviet crates do *not* collide anymore, until collision issues are fixed.
- fix: Secure crates can be deconstructed again.
- fix: Crates are once again passable when open.
