### PR TITLE
Event Announcements Reaudioing

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -354,7 +354,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
         Color? colorOverride = null,
-        EntityUid? speaker = null // Starlight
+        EntityUid? speaker = null, // Starlight
+        bool SuppressTTS = false // Starlight
         )
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
@@ -372,6 +373,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             Receivers = Filter.Broadcast(),
             SpeakerUid = speaker.HasValue ? GetNetEntity(speaker.Value) : null,
             AnnouncementSound = announcementSound,
+            SuppressTTS = SuppressTTS
         });
         // Starlight end
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Global station announcement from {sender}: {message.Text}");// Starlight
@@ -386,7 +388,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
         Color? colorOverride = null,
-        bool recordToReplay = true) // Starlight
+        bool recordToReplay = true,
+        bool SuppressTTS = false) // Starlight
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
 
@@ -401,7 +404,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         {
             AnnouncementSound = announcementSound,
             Message = message,
-            Receivers = filter
+            Receivers = filter,
+            SuppressTTS = SuppressTTS
         });
         // Starlight end
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Station Announcement from {sender}: {message.Text}");
@@ -414,7 +418,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? sender = null,
         bool playDefaultSound = true,
         SoundSpecifier? announcementSound = null,
-        Color? colorOverride = null)
+        Color? colorOverride = null,
+        bool SuppressTTS = false) // Starlight
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
 
@@ -443,7 +448,8 @@ public sealed partial class ChatSystem : SharedChatSystem
         {
             AnnouncementSound = announcementSound,
             Message = message,
-            Receivers = filter
+            Receivers = filter,
+            SuppressTTS = SuppressTTS
         });
         // Starlight end
 

--- a/Content.Server/StationEvents/Components/StationEventComponent.cs
+++ b/Content.Server/StationEvents/Components/StationEventComponent.cs
@@ -98,5 +98,10 @@ public sealed partial class StationEventComponent : Component
     /// Whether to announce globally or only announce on the target station.
     /// </summary>
     [DataField] public bool GlobalAnnouncement = true;
+
+    /// <summary>
+    /// Whether the TTS, if it is enabled, will speak this announcement.
+    /// </summary>
+    [DataField] public bool SuppressTTS = false;
     //Starlight end
 }

--- a/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
+++ b/Content.Server/StationEvents/Events/MeteorSwarmSystem.cs
@@ -30,7 +30,7 @@ public sealed partial class MeteorSwarmSystem : StationEventSystem<MeteorSwarmCo
         //Starlight begin
         if (!TryComp<StationEventComponent>(uid, out var stationEvent)) return;
         if (component.Announcement is { } locId)
-            Announce(stationEvent, locId, false, colorOverride: Color.Gold);
+            Announce(stationEvent, locId, false, colorOverride: Color.Gold, SuppressTTS: stationEvent.SuppressTTS);
         //Starlight end
     }
 

--- a/Content.Server/StationEvents/Events/StationEventSystem.cs
+++ b/Content.Server/StationEvents/Events/StationEventSystem.cs
@@ -49,7 +49,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
             stationEvent.TargetStation = chosenStation;
         //Starlight end stationEvent.TargetStation = station;
 
-        Announce(stationEvent, stationEvent.StartAnnouncement, false, stationEvent.StartAnnouncementColor, stationEvent.StartAudio);
+        Announce(stationEvent, stationEvent.StartAnnouncement, false, stationEvent.StartAnnouncementColor, stationEvent.StartAudio, stationEvent.SuppressTTS);
 
         // we don't want to send to players who aren't in game (i.e. in the lobby)
 
@@ -88,7 +88,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
 
         //Starlight begin
         // we don't want to send to players who aren't in game (i.e. in the lobby)
-        Announce(stationEvent, stationEvent.EndAnnouncement, false, stationEvent.EndAnnouncementColor, stationEvent.EndAudio);
+        Announce(stationEvent, stationEvent.EndAnnouncement, false, stationEvent.EndAnnouncementColor, stationEvent.EndAudio, stationEvent.SuppressTTS);
         //Starlight end
     }
 
@@ -128,7 +128,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
     }
 
     //Starlight begin
-    public void Announce(StationEventComponent stationEvent, LocId? announcementLocId, bool dispatchSound, Color? colorOverride = null, SoundSpecifier? soundOverride = null)
+    public void Announce(StationEventComponent stationEvent, LocId? announcementLocId, bool dispatchSound, Color? colorOverride = null, SoundSpecifier? soundOverride = null, bool SuppressTTS = false)
     {
         if (announcementLocId is null) return;
         if (stationEvent.GlobalAnnouncement)
@@ -137,7 +137,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
 
             ChatSystem.DispatchFilteredAnnouncement(allPlayersInGame,
                 Loc.GetString(announcementLocId), playSound: dispatchSound,
-                colorOverride: colorOverride);
+                colorOverride: colorOverride, SuppressTTS:SuppressTTS);
 
             if(soundOverride is not null) Audio.PlayGlobal(soundOverride, allPlayersInGame, true);
         }
@@ -153,7 +153,7 @@ public abstract partial class StationEventSystem<T> : GameRuleSystem<T> where T 
 
             ChatSystem.DispatchFilteredAnnouncement(allPlayersOnStation,
                 Loc.GetString(announcementLocId), playSound: dispatchSound,
-                colorOverride: colorOverride);
+                colorOverride: colorOverride, SuppressTTS:SuppressTTS);
 
             if(soundOverride is not null) Audio.PlayGlobal(soundOverride, allPlayersOnStation, true);
         }

--- a/Content.Server/_Starlight/GameTicking/Rules/NightShiftRule.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/NightShiftRule.cs
@@ -88,13 +88,13 @@ public sealed partial class NightShiftRule : StationEventSystem<NightShiftRuleCo
             {
                 // If the alert level is permitted, enable night shift dimming, and announce if that changed anything.
                 if (EnableNightShiftDimming(ev.Station, nightShift))
-                    Announce(stationEvent, Loc.GetString(nightShift.EnableAnnouncement), true);
+                    Announce(stationEvent, Loc.GetString(nightShift.EnableAnnouncement), true, SuppressTTS: stationEvent.SuppressTTS);
             }
             else
             {
                 // If the alert level is not permitted, disable night shift dimming, and announce if that changed anything.
                 if (DisableNightShiftDimming(ev.Station))
-                    Announce(stationEvent, Loc.GetString(nightShift.DisableAnnouncement), true);
+                    Announce(stationEvent, Loc.GetString(nightShift.DisableAnnouncement), true, SuppressTTS: stationEvent.SuppressTTS);
             }
         }
     }

--- a/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
+++ b/Content.Server/_Starlight/StationEvents/Events/WreckSwarmSystem.cs
@@ -107,7 +107,7 @@ public sealed partial class WreckSwarmSystem : StationEventSystem<WreckSwarmComp
         _mapSystem.DeleteMap(wreckMapXform.MapID);
 
         if (component.Announcement is { } locId)
-            Announce(stationEvent, Loc.GetString(locId), false, null, component.AnnouncementSound);
+            Announce(stationEvent, Loc.GetString(locId), false, null, component.AnnouncementSound, stationEvent.SuppressTTS);
 
         // Done processing, don't recur on next tick
         ForceEndSelf(uid, gameRule);

--- a/Content.Server/_Starlight/TextToSpeech/AnnouncementSpokeEvent.cs
+++ b/Content.Server/_Starlight/TextToSpeech/AnnouncementSpokeEvent.cs
@@ -11,4 +11,5 @@ public sealed class AnnouncementSpokeEvent : EntityEventArgs
     public NetEntity? SpeakerUid { get; set; }
     public SpeechMessage Message { get; set; } = null!;
     public SoundSpecifier? AnnouncementSound { get; set; } = null!;
+    public bool SuppressTTS { get; set; } = false;
 }

--- a/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
+++ b/Content.Server/_Starlight/TextToSpeech/TTSSystem.cs
@@ -116,7 +116,8 @@ public sealed partial class TTSSystem : EntitySystem
     private async void OnAnnouncementSpoke(AnnouncementSpokeEvent args)
     {
         if (!_isEnabled
-            || args.Message.Text.Length > MaxChars * 2)
+            || args.Message.Text.Length > MaxChars * 2
+            || args.SuppressTTS)
             return;
 
         await Task.Yield();

--- a/Content.Shared/Chat/SharedChatSystem.cs
+++ b/Content.Shared/Chat/SharedChatSystem.cs
@@ -565,13 +565,15 @@ public abstract partial class SharedChatSystem : EntitySystem
     /// <param name="playSound">Play the announcement sound.</param>
     /// <param name="announcementSound">Sound to play.</param>
     /// <param name="colorOverride">Optional color for the announcement message.</param>
+    /// <param name="SuppressTTS">Prevents TTS from speaking this</param>
     public virtual void DispatchGlobalAnnouncement(
         SpeechMessage message,
         string? sender = null,
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
         Color? colorOverride = null,
-        EntityUid? speaker = null // Starlight
+        EntityUid? speaker = null, // Starlight
+        bool SuppressTTS = false // Starlight
         )
     { }
 
@@ -585,6 +587,7 @@ public abstract partial class SharedChatSystem : EntitySystem
     /// <param name="playSound">Play the announcement sound.</param>
     /// <param name="announcementSound">Sound to play.</param>
     /// <param name="colorOverride">Optional color for the announcement message.</param>
+    /// <param name="SuppressTTS">Prevents TTS from speaking this</param>
     public virtual void DispatchFilteredAnnouncement(
         Filter filter,
         SpeechMessage message, // Starlight
@@ -593,7 +596,9 @@ public abstract partial class SharedChatSystem : EntitySystem
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
         Color? colorOverride = null,
-        bool recordToReplay = true) // Starlight
+        bool recordToReplay = true, // Starlight
+        bool SuppressTTS = false) // Starlight
+
     { }
 
     /// <summary>
@@ -605,13 +610,15 @@ public abstract partial class SharedChatSystem : EntitySystem
     /// <param name="playDefaultSound">Play the announcement sound.</param>
     /// <param name="announcementSound">Sound to play.</param>
     /// <param name="colorOverride">Optional color for the announcement message.</param>
+    /// <param name="SuppressTTS">Prevents TTS from speaking this</param>
     public virtual void DispatchStationAnnouncement(
         EntityUid source,
         SpeechMessage message, // Starlight
         string? sender = null,
         bool playDefaultSound = true,
         SoundSpecifier? announcementSound = null,
-        Color? colorOverride = null)
+        Color? colorOverride = null,
+        bool SuppressTTS = false) // Starlight
     { }
 }
 


### PR DESCRIPTION
## Short description
Edits all Station Event Announcements to use pre-recorded audio files instead of TTS, using the original TTS Voice from SS13 (Welcome to the station crew, enjoy your stay.)


## Why we need to add this
More cohesive soundscape. Currently like 1/5th of the announcements use the original voice, or short snips of the original voice followed by our TTS. In some worse cases, the old audio file and the new TTS overlap and are noisy.

This brings it all back to one standard, while still preserving functionality for our TTS to catch any new announcements added to the game, cover comms console announcements, etc.

## Media (Video/Screenshots)
Pending

## Checks

- [ ] I do not require assistance to complete the PR.
- [ ] Before posting/requesting review of a PR, I have verified that the changes work.
- [ ] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: kirb, Conflee
- add: Added SuppressTTS to several SharedChatSystems, AnnouncementSpokeEvent, etc so devs can choose to have an announcement not be read by the TTS system. Inc DispatchGlobalAnnouncement, DispatchFilteredAnnouncement, and DispatchStationAnnouncement. (All kirb).
- add: Added new audio files in the original SS13 TTS voice (Welcome to the station crew, enjoy your stay) for all mid-round/gamerule events.

