### PR TITLE
Fix being able to continually rev borgis

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -388,6 +388,11 @@ public sealed partial class RevolutionaryRuleSystem : GameRuleSystem<Revolutiona
         if (!_mind.TryGetMind(ev.Target, out var mindId, out var mind) && !alwaysConvertible)
             return;
 
+        // Starlight Begin
+        if (IsAlreadyRevolutionary(ev.Target))
+            return;
+        // Starlight End
+
         if (!_whitelistSystem.CheckBoth(ev.Target, comp.Blacklist, comp.Whitelist) && // Starlight-edit: rework all has comp to whitelist & blacklist.
             !alwaysConvertible ||
             !_mobState.IsAlive(ev.Target))

--- a/Content.Server/_Starlight/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -1,0 +1,12 @@
+using Content.Shared.Revolutionary.Components;
+
+namespace Content.Server.GameTicking.Rules;
+
+public sealed partial class RevolutionaryRuleSystem
+{
+    /// <summary>
+    /// Blocks re-conversion of already-converted targets. Needed separately from the
+    /// blacklist below since that's skipped for AlwaysRevolutionaryConvertible mobs (e.g. borgis).
+    /// </summary>
+    private bool IsAlreadyRevolutionary(EntityUid target) => HasComp<RevolutionaryComponent>(target) || HasComp<HeadRevolutionaryComponent>(target);
+}

--- a/Content.Server/_Starlight/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/_Starlight/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -1,3 +1,5 @@
+//ReSharper disable CheckNamespace
+
 using Content.Shared.Revolutionary.Components;
 
 namespace Content.Server.GameTicking.Rules;


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Fixes a bug wherein borgis could be infinitely flashed for free rev currency and rev count.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
FIxing bugs is good.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Sparlight
- fix: Fixed a bug where borgis could be repeatedly flashed for telebonds as a revolutionary.
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
