### PR TITLE
Makes Eeeps obviously hostile

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
@@ -251,7 +251,7 @@
     startingCharge: 1000
     # Starlight-start - Resistance so Eeeps don't kill themselves when their lightning arcs blow up electronics
   - type: ExplosionResistance
-    damageCoefficient: 0.95
+    damageCoefficient: 0.2
     # Starlight-end
   - type: LightningArcShooter
     arcDepth: 2

--- a/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/NPCs/eeep.yml
@@ -249,14 +249,17 @@
   - type: Battery
     maxCharge: 3000 #Starlight 1000 -> 3000
     startingCharge: 1000
-#Starlight Removed, let the eep use their attacks to blow stuff up instead
-#  - type: LightningArcShooter
-#    arcDepth: 2
-#    maxLightningArc: 3
-#    shootMinInterval: 10
-#    shootMaxInterval: 15
-#    shootRange: 5
-#    lightningPrototype: Lightning
+    # Starlight-start - Resistance so Eeeps don't kill themselves when their lightning arcs blow up electronics
+  - type: ExplosionResistance
+    damageCoefficient: 0.95
+    # Starlight-end
+  - type: LightningArcShooter
+    arcDepth: 2
+    maxLightningArc: 3
+    shootMinInterval: 10
+    shootMaxInterval: 15
+    shootRange: 5
+    lightningPrototype: Lightning
   - type: AnnounceOnSpawn
     message: eeep-spawn
     sender: eeep-spawn-sender
@@ -271,7 +274,7 @@
     disableDuration: 20
   - type: Perishable
     rotAfter: 2000
-#region Starlight
+  # Starlight-start - Balance pass, PR #5171
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 7
@@ -296,4 +299,4 @@
     speedModifier: 8
     useSound:
       path: /Audio/Effects/tesla_consume.ogg
-#regionend Starlight
+  # Starlight-end


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Eeeps are supposed to be an antagonist, but because #5171 removed their "randomly strike stuff with lightning" trait, a lot of players are playing adult eeps as entirely friendly.

#5171 did raise a valid point - adult Eeeps consuming power could blow up their consumption target and hurt themselves. I've given adult Eeeps a substantial 80% resistance to explosives to mitigate that.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Eeeps should be a living dangerous ball of electricity, not something that just chills with the crew half of the time.

This is less a fault of players and more the fault of removing something that made them obviously dangerous / hazardous to the station. Just like how dragons spawn carps, Eeeps _need_ to have this random lightning to pose an obvious threat to the station.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="776" height="477" alt="image" src="https://github.com/user-attachments/assets/fba66839-85c7-4df7-abec-237ee1adc7b0" />

fig. 1 - Demo of a worst-case scenario - standing next to a fuel tank as an APC explosion blows it up. Before this PR, an adult Eeep would take about 90 damage (heat/blunt/pierce). Now they take about 21 damage, which is regenerated pretty quickly. Bullets still remain very effective against Eeeps, as usual.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Eeeps now randomly lightning strike machines and mobs again. This is to clarify their status an antagonist and as dangerous, destructive fauna. Eeeps are not your friend.
- tweak: Eeeps now have 80% explosive resistance so that they don't die from exploding machines with their random lightning strikes.