### PR TITLE
Fix Cosmic Cult entity health examine texts

### DIFF
--- a/Content.Shared/_Starlight/Medical/Body/Components/BloodstreamComponent.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Components/BloodstreamComponent.cs
@@ -187,6 +187,13 @@ public sealed partial class BloodstreamComponent : Component
     public string MetabolitesSolutionName = DefaultMetabolitesSolutionName;
 
     /// <summary>
+    /// Localization prefix for bleeding and low blood level descriptions on health examine.
+    /// Hidden when set to null.
+    /// </summary>
+    [DataField]
+    public string? ExamineLocPrefix = "bloodstream-component";
+
+    /// <summary>
     /// Internal solution for blood storage
     /// </summary>
     [ViewVariables]

--- a/Content.Shared/_Starlight/Medical/Body/Systems/SharedBloodstreamSystem.cs
+++ b/Content.Shared/_Starlight/Medical/Body/Systems/SharedBloodstreamSystem.cs
@@ -265,36 +265,40 @@ public abstract partial class SharedBloodstreamSystem : EntitySystem
     /// </summary>
     private void OnHealthBeingExamined(Entity<BloodstreamComponent> ent, ref HealthBeingExaminedEvent args)
     {
+        var prefix = ent.Comp.ExamineLocPrefix;
+        if (prefix is null)
+            return;
+
         // Shows massively bleeding at 0.75x the max bleed rate.
         if (ent.Comp.BleedAmount > ent.Comp.MaxBleedAmount * 0.75f)
         {
             args.Message.PushNewline();
-            args.Message.AddMarkupOrThrow(Loc.GetString("bloodstream-component-massive-bleeding", ("target", ent.Owner)));
+            args.Message.AddMarkupOrThrow(Loc.GetString($"{prefix}-massive-bleeding", ("target", ent.Owner)));
         }
         // Shows bleeding message when bleeding above half the max rate, but less than massively.
         else if (ent.Comp.BleedAmount > ent.Comp.MaxBleedAmount * 0.5f)
         {
             args.Message.PushNewline();
-            args.Message.AddMarkupOrThrow(Loc.GetString("bloodstream-component-strong-bleeding", ("target", ent.Owner)));
+            args.Message.AddMarkupOrThrow(Loc.GetString($"{prefix}-strong-bleeding", ("target", ent.Owner)));
         }
         // Shows bleeding message when bleeding above 0.25x the max rate, but less than half the max.
         else if (ent.Comp.BleedAmount > ent.Comp.MaxBleedAmount * 0.25f)
         {
             args.Message.PushNewline();
-            args.Message.AddMarkupOrThrow(Loc.GetString("bloodstream-component-bleeding", ("target", ent.Owner)));
+            args.Message.AddMarkupOrThrow(Loc.GetString($"{prefix}-bleeding", ("target", ent.Owner)));
         }
         // Shows bleeding message when bleeding below 0.25x the max cap
         else if (ent.Comp.BleedAmount > 0)
         {
             args.Message.PushNewline();
-            args.Message.AddMarkupOrThrow(Loc.GetString("bloodstream-component-slight-bleeding", ("target", ent.Owner)));
+            args.Message.AddMarkupOrThrow(Loc.GetString($"{prefix}-slight-bleeding", ("target", ent.Owner)));
         }
 
         // If the mob's blood level is below the damage threshhold, the pale message is added.
         if (GetBloodLevel(ent.AsNullable()) < ent.Comp.BloodlossThreshold)
         {
             args.Message.PushNewline();
-            args.Message.AddMarkupOrThrow(Loc.GetString("bloodstream-component-looks-pale", ("target", ent.Owner)));
+            args.Message.AddMarkupOrThrow(Loc.GetString($"{prefix}-looks-pale", ("target", ent.Owner)));
         }
     }
 

--- a/Resources/Locale/en-US/_Starlight/cosmiccult/health-examinable-cosmic.ftl
+++ b/Resources/Locale/en-US/_Starlight/cosmiccult/health-examinable-cosmic.ftl
@@ -1,0 +1,19 @@
+health-examinable-cosmic-none = The entity appears to be intact.
+
+health-examinable-cosmic-Blunt-15 = [color=#4cabb3]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } minor deformations in { POSS-ADJ($target) } form.[/color]
+health-examinable-cosmic-Blunt-50 = [color=#15939e]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } major deformations in { POSS-ADJ($target) } form.[/color]
+health-examinable-cosmic-Blunt-100 = [color=#15939e]Severe deformation makes { POSS-ADJ($target) } form difficult to recognize.[/color]
+
+health-examinable-cosmic-Slash-8 = [color=#4cabb3]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } shallow gouges running across { POSS-ADJ($target) } surface.[/color]
+health-examinable-cosmic-Slash-30 = [color=#4cabb3]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } deep gouges and tears in { POSS-ADJ($target) } surface.[/color]
+health-examinable-cosmic-Slash-100 = [color=#15939e]{ CAPITALIZE(POSS-ADJ($target)) } surface is torn apart by deep gashes.[/color]
+
+health-examinable-cosmic-Piercing-50 = [color=#15939e]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-HAVE($target) } large holes through { POSS-ADJ($target) } form.[/color]
+
+health-examinable-cosmic-Heat-15 = [color=#3d89f2]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-BASIC($target, "appear", "appears") } scorched.[/color]
+health-examinable-cosmic-Heat-50 = [color=#3d89f2]{ CAPITALIZE(SUBJECT($target)) } { CONJUGATE-BASIC($target, "appear", "appears") } charred.[/color]
+health-examinable-cosmic-Heat-75 = [color=#3d89f2]{ CAPITALIZE(POSS-ADJ($target)) } form is partially melted.[/color]
+
+health-examinable-cosmic-Cold-50 = [color=#3d89f2]Large portions of { POSS-ADJ($target) } form appear frozen.[/color]
+
+health-examinable-cosmic-Caustic-50 = [color=#7b38f5]{ CAPITALIZE(POSS-ADJ($target)) } form is dissolving.[/color]

--- a/Resources/Locale/en-US/_Starlight/cosmiccult/health-examinable-cosmic.ftl
+++ b/Resources/Locale/en-US/_Starlight/cosmiccult/health-examinable-cosmic.ftl
@@ -17,3 +17,9 @@ health-examinable-cosmic-Heat-75 = [color=#3d89f2]{ CAPITALIZE(POSS-ADJ($target)
 health-examinable-cosmic-Cold-50 = [color=#3d89f2]Large portions of { POSS-ADJ($target) } form appear frozen.[/color]
 
 health-examinable-cosmic-Caustic-50 = [color=#7b38f5]{ CAPITALIZE(POSS-ADJ($target)) } form is dissolving.[/color]
+
+cosmic-bloodstream-slight-bleeding = [color=#4cabb3]Small amounts of entropy seep from { POSS-ADJ($target) } form.[/color]
+cosmic-bloodstream-bleeding = [color=#4cabb3]Entropy leaks from { POSS-ADJ($target) } form.[/color]
+cosmic-bloodstream-strong-bleeding = [color=#15939e]Large amounts of entropy flow freely from { POSS-ADJ($target) } form.[/color]
+cosmic-bloodstream-massive-bleeding = [color=#15939e]Entropy pours from { POSS-ADJ($target) } form![/color]
+cosmic-bloodstream-looks-pale = [color=#a0cefa]{ CAPITALIZE(POSS-ADJ($target)) } inner glow appears diminished.[/color]

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/astralforms.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/astralforms.yml
@@ -125,6 +125,8 @@
        enabled: true
        isLooped: true
        reverseWhenFinished: true
+  - type: HealthExaminable
+    locPrefix: cosmic
   #region Starlight languages
   - type: UniversalLanguageSpeaker
   #endregion

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
@@ -155,6 +155,7 @@
       reagents:
       - ReagentId: Entropy
         Quantity: 1300
+    examineLocPrefix: cosmic-bloodstream
     maxBleedAmount: 0.1
     bleedReductionAmount: 0.1
     bloodlossDamage:

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
@@ -278,6 +278,8 @@
     understands:
     - Cosmic
   - type: UniversalLanguageSpeaker
+  - type: HealthExaminable
+    locPrefix: cosmic
 
 - type: entity
   parent: [ MobCosmicColossusBase ]

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
@@ -98,6 +98,7 @@
       reagents:
       - ReagentId: Entropy
         Quantity: 200
+    examineLocPrefix: cosmic-bloodstream
     maxBleedAmount: 10.75
     bleedReductionAmount: 0.1
     bloodlossDamage:

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
@@ -129,6 +129,8 @@
        enabled: true
        isLooped: true
        reverseWhenFinished: true
+  - type: HealthExaminable
+    locPrefix: cosmic
 
 - type: entity
   parent: [ BaseMobCosmicHostile, MobCosmicCustodian ]

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/wisp.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/wisp.yml
@@ -63,6 +63,8 @@
        enabled: true
        isLooped: true
        reverseWhenFinished: true
+  - type: HealthExaminable
+    locPrefix: cosmic
 
 - type: entity
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds custom damage examine text to cosmic cult entities.

Made bloodstream examine text customizable with a prefix system similar to HealthExaminable's locPrefix.
Added a health-examinable-cosmic damage examine set similar to the silicon damage set. I'm not familiar with cosmic cult balancing, so let me know if some of the damage thresholds do not make sense here.

Like the silicon damage set, not all damage levels from every damage type have texts. I think what I made is fine, but let me know if I should expand them.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Previously you could examine a cosmic cult entity and see things like "It looks pale" and other various references to skin, which they do not have. This fixes that.

It also makes sense to me that it is hard to accurately judge the health status of a strange entity. As such, the health descriptions are not as detailed as for playable species.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

Images are before -> after.

### Healthy
<img width="346" height="80" alt="image" src="https://github.com/user-attachments/assets/1757fb6a-4cd9-45d9-b9e5-7f710adce4cb" />
<img width="321" height="77" alt="image" src="https://github.com/user-attachments/assets/51c4b4f2-dc29-42b2-ac7b-3cdeeb265ff1" />


### 1
<img width="379" height="235" alt="image" src="https://github.com/user-attachments/assets/5f70cd5b-ba14-4084-94e7-f21b62a85a74" />
<img width="406" height="144" alt="image" src="https://github.com/user-attachments/assets/1ad4451f-e404-4923-bddd-a57ab9b48706" />


### 2
<img width="409" height="247" alt="image" src="https://github.com/user-attachments/assets/23e84626-ecd1-4274-b67d-55cc2eed1765" />
<img width="360" height="209" alt="image" src="https://github.com/user-attachments/assets/b79fb19e-b16e-4026-a164-f7bffc8fbfb0" />


### 3
<img width="407" height="275" alt="image" src="https://github.com/user-attachments/assets/bc92b52d-3805-4a38-8f88-396bfc42860e" />
<img width="403" height="262" alt="image" src="https://github.com/user-attachments/assets/6ad73c7c-c93b-4645-b887-47dfed6705b9" />


### 4
<img width="350" height="233" alt="image" src="https://github.com/user-attachments/assets/ce50cbdb-f65d-4886-95e1-50267d79e0b1" />
<img width="392" height="238" alt="image" src="https://github.com/user-attachments/assets/3416084b-ed2f-4bca-8f77-794dbb6306e4" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.


## AI disclaimer
I used AI to write and format the fluent file to save myself from some pain. And grammar fixes.

**Changelog**
:cl: STARLIGHT TEAM
- fix: Fixed the health examine texts for Cosmic Cult entities.
