### PR TITLE
Brigmedic airlocks are Brig access now

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
@@ -105,7 +105,7 @@
   suffix: Brigmed, Locked
   components:
     - type: AccessReader
-      access: [["Security"], ["Cadet"], ["Command"]]
+      access: [["Brig"]]
 
 #Brigmedic/Paramed
 - type: entity
@@ -114,7 +114,7 @@
   suffix: Brigmed/Paramedic, Locked
   components:
     - type: AccessReader
-      access: [["Security"], ["Cadet"], ["Command"], ["Paramedic"]]
+      access: [["Brig"], ["Paramedic"]]
 
 #Solgov
 - type: entity

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Devices/Electronics/door_access.yml
@@ -105,7 +105,7 @@
   suffix: Brigmed, Locked
   components:
     - type: AccessReader
-      access: [["Brig"]]
+      access: [["Brig"], ["Brigmedic"]]
 
 #Brigmedic/Paramed
 - type: entity
@@ -114,7 +114,7 @@
   suffix: Brigmed/Paramedic, Locked
   components:
     - type: AccessReader
-      access: [["Brig"], ["Paramedic"]]
+      access: [["Brig"], ["Brigmedic"], ["Paramedic"]]
 
 #Solgov
 - type: entity


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Brigmedic doors before this PR were:
- `[["Security"], ["Cadet"], ["Command"]]`

Brigmedic airlocks as of this PR are now:
- `[["Brig"], ["Brigmedic"]]`

The Brigmedic+Paramedic combination airlocks were similarly changed, and obviously have Paramedic access on top of the above.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
1) It's in the name. **Brig**medic. It's in the Brig.

2) It's simpler and achieves the same thing.
- K9s, Blueshields, IAAs, Magistrates, NTRs, Brigmedics, Duty Officers, Detectives, Security Officers, Security Cadets, and Warden all already have Brig access.
- Every Command role (HOP, CE, RD, QM, HOS, Captain) all already have Brig access.
- NTR, Magistrate, and IAAs already have Brig access.

3) This fixes an issue where IAAs could no longer walk into Brigmedic after they lost `Command` access in #5744.

Q&A: **Why have both Brig _and_ Brigmedic access on the doors if Brigmedic has Brig access?**
- Someone will inevitably microwave their ID, score Brigmedic access (but not Brig access) on said ID, and then be disappointed that they couldn't sneak into Brigmedic and report it as a bug. It's redundant to have both Brigmedic and Brig access on the door but I'm not taking any chances.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
<img width="470" height="285" alt="image" src="https://github.com/user-attachments/assets/ea77f062-0272-4ced-a76b-7593c4963f13" />

fig. 1 - IAA can enter Brigmedic doors now. Tested Security Cadets, too, just to be safe.

<img width="493" height="289" alt="image" src="https://github.com/user-attachments/assets/c2ddd120-b5ff-4600-9d45-e996ed651821" />

fig. 2 - Paramedic can still enter combination Brigmedic+Paramedic airlocks.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Caws
- tweak: Brigmedic doors are now "Brig, Brigmedic" access instead of "Security, Cadet, Command" access. This allows IAAs to walk into Brigmedic on their own (note: Command, all Security roles, Magistrate/NTR/BSO already have Brig access).
- tweak: Brigmedic/Para doors are now "Brig, Brigmedic, Paramedic" access instead of "Security, Cadet, Command, and Paramedic" access.