### PR TITLE
Adding Department Techfabs to Shard Test

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/lathe.yml
@@ -64,7 +64,7 @@
 # Cargo
 - type: entity
   id: CargoTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: cargo techfab
   description: Prints equipment for use by the station's supply department.
@@ -122,7 +122,7 @@
 # Engineering
 - type: entity
   id: EngineeringTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: engineering techfab
   description: Prints equipment for use by the station's engineering department.
@@ -179,7 +179,7 @@
 # Service - Woah, bold statement there...
 - type: entity
   id: ServiceTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: service techfab
   description: Prints equipment for use by the station's service department.
@@ -229,7 +229,7 @@
 
 - type: entity
   id: ScienceTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: science techfab
   description: Prints equipment for use by the station's research department.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adding the Department Techfabs to autotest.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->

In the file, it was left commented until every station has them. As far as I'm aware, this [chore](https://github.com/ss14Starlight/space-station-14/issues/5458#issue-5040718103) is fully complete, and thus, we can include them into the Shard Tests.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Hot Mic
- tweak: Department Techfabs are now included in the Shard Tests (now fails if the mapper forgot to map them in).
