### PR TITLE
Fix Sodas and footprints/fire spam

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/PressurizedSolutionSystem.cs
@@ -179,7 +179,7 @@ public sealed partial class PressurizedSolutionSystem : EntitySystem
 
         // Spray the solution onto the ground and anyone nearby
         var coordinates = Transform(entity).Coordinates;
-        _puddle.TrySplashSpillAt(entity.Owner, coordinates, out _, out _, sound: false);
+        _puddle.TrySplashSpillAt(entity.Owner, coordinates, solution, out _, sound: false);
 
         var drinkName = Identity.Entity(entity, EntityManager);
 

--- a/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Effects/reagent_fire.yml
@@ -15,6 +15,7 @@
   - type: Tag # Persistence: Firebots can target reagent fires
     tags:
     - ReagentFire
+    - HideContextMenu # Starlight
 
 - type: particleEffect
   id: ReagentFireContinuous

--- a/Resources/Prototypes/_Starlight/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Effects/puddle.yml
@@ -45,3 +45,4 @@
   - type: Tag
     tags:
     - DNASolutionScannable
+    - HideContextMenu


### PR DESCRIPTION
## Short description
Ports this wizden pr https://github.com/space-wizards/space-station-14/pull/44033 and also hides footprints/fires from the context menu.

## Why we need to add this
Right click menu full of things.

## Media
<img width="415" height="136" alt="image" src="https://github.com/user-attachments/assets/824a0cf7-e5d6-43b8-a54c-860cfa75b0d1" />

<img width="374" height="194" alt="image" src="https://github.com/user-attachments/assets/e5f80ed2-2dd4-4647-ab09-5884650affeb" />

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: wonderfulnewworld, ThatGuyUSA
- fix: a sealed fizzy soda's contents will no longer disappear when bursting.
- fix: You will no longer see every footprint and fire with a right click.
