### PR TITLE
Corrected Firing Pin for Cold Case

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -655,6 +655,10 @@
       ballistic-ammo: !type:Container
         ents: []
       firing_pin: !type:Container
+  - type: ContainerFill
+    containers:
+      firing_pin:
+      - FiringPinPistol
   - type: CanDualWield
     dualWieldInaccuracyPenalty: 30
   - type: FiringPinHolder


### PR DESCRIPTION
## Short description
The Cold Case pistol uses the sniper template which sets its firing pin to a standard one instead of a pistol one. This PR corrects this.

## Why we need to add this
Removing the fire pin will soft brick it until you can acquire another pistol firing pin. The likelihood of something doing this in game is near zero at the moment as there's not really a NEED to do it yet, but in the case of a curious player messing with stuff this could be a really bad user experience.

## Checks
- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: STARLIGHT TEAM
- fix: Cold Case pistol now uses the correct firing pin.
