### PR TITLE
Subfloor fixes

### DIFF
--- a/Content.Shared/Maps/TurfSystem.cs
+++ b/Content.Shared/Maps/TurfSystem.cs
@@ -123,7 +123,8 @@ public sealed partial class TurfSystem : EntitySystem
         CollisionGroup mask,
         MapGridComponent? grid = null,
         TransformComponent? gridXform = null,
-        float minIntersectionArea = 0.1f)
+        float minIntersectionArea = 0.1f,
+        Predicate<EntityUid>? ignored = null) // Starlight
     {
         if (!Resolve(gridUid, ref grid, ref gridXform))
             return false;
@@ -145,6 +146,9 @@ public sealed partial class TurfSystem : EntitySystem
         foreach (var ent in _entityLookup.GetEntitiesIntersecting(gridUid, worldBox, LookupFlags.Dynamic | LookupFlags.Static))
         {
             if (!fixtureQuery.TryGetComponent(ent, out var fixtures))
+                continue;
+
+            if (ignored != null && ignored(ent)) // Starlight
                 continue;
 
             // get grid local coordinates

--- a/Content.Shared/SubFloor/SubFloorHideComponent.Starlight.cs
+++ b/Content.Shared/SubFloor/SubFloorHideComponent.Starlight.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.SubFloor;
+
+public sealed partial class SubFloorHideComponent
+{
+    /// <summary>
+    ///     Whether this entity can be anchored and unanchored while a floor tile covers it.
+    /// </summary>
+    [DataField]
+    public bool AllowAnchoringUnderCover { get; set; }
+}

--- a/Content.Shared/SubFloor/SubFloorHideComponent.cs
+++ b/Content.Shared/SubFloor/SubFloorHideComponent.cs
@@ -28,14 +28,6 @@ namespace Content.Shared.SubFloor
         [DataField]
         public bool BlockInteractions { get; set; } = true;
 
-        // Starlight begin
-        /// <summary>
-        ///     Whether this entity can be anchored and unanchored while a floor tile covers it.
-        /// </summary>
-        [DataField]
-        public bool AllowAnchoringUnderCover { get; set; }
-        // Starlight end
-
         /// <summary>
         /// Whether this entity's ambience should be disabled when underneath the floor.
         /// </summary>

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.Starlight.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.Starlight.cs
@@ -1,0 +1,13 @@
+using Content.Shared.SubFloor;
+
+namespace Content.Shared.Tools.Systems;
+
+public abstract partial class SharedToolSystem
+{
+    /// <summary>
+    /// Whether an entity is a subfloor device that a floor tile is currently covering. Such entities neither block
+    /// modification of the tile above them nor stop a tile tool from targeting it.
+    /// </summary>
+    public bool IsSubfloorCovered(EntityUid uid)
+        => TryComp<SubFloorHideComponent>(uid, out var hide) && hide.IsUnderCover;
+}

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.Starlight.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.Starlight.cs
@@ -8,6 +8,6 @@ public abstract partial class SharedToolSystem
     /// Whether an entity is a subfloor device that a floor tile is currently covering. Such entities neither block
     /// modification of the tile above them nor stop a tile tool from targeting it.
     /// </summary>
-    public bool IsSubfloorCovered(EntityUid uid)
-        => TryComp<SubFloorHideComponent>(uid, out var hide) && hide.IsUnderCover;
+    private bool IsSubfloorCovered(Entity<SubFloorHideComponent?> ent)
+        => Resolve(ent, ref ent.Comp, false) && ent.Comp.IsUnderCover;
 }

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -23,7 +23,7 @@ public abstract partial class SharedToolSystem
 
     private void OnToolTileAfterInteract(Entity<ToolTileCompatibleComponent> ent, ref AfterInteractEvent args)
     {
-        if (args.Handled || args.Target != null && !HasComp<PuddleComponent>(args.Target))
+        if (args.Handled || args.Target != null && !HasComp<PuddleComponent>(args.Target) && !IsSubfloorCovered(args.Target.Value)) // Starlight
             return;
 
         args.Handled = UseToolOnTile((ent, ent, null), args.User, args.ClickLocation);
@@ -47,7 +47,7 @@ public abstract partial class SharedToolSystem
 
         var tileRef = _maps.GetTileRef(gridUid, grid, args.GridTile);
         var coords = _maps.ToCoordinates(tileRef, grid);
-        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask))
+        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: IsSubfloorCovered)) // Starlight
             return;
 
         if (!TryDeconstructWithToolQualities(tileRef, tool.Qualities))
@@ -80,7 +80,7 @@ public abstract partial class SharedToolSystem
         if (string.IsNullOrWhiteSpace(tileDef.BaseTurf))
             return false;
 
-        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask))
+        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: IsSubfloorCovered)) // Starlight
             return false;
 
         var coordinates = _maps.GridTileToLocal(gridUid, mapGrid, tileRef.GridIndices);

--- a/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.Tile.cs
@@ -47,7 +47,7 @@ public abstract partial class SharedToolSystem
 
         var tileRef = _maps.GetTileRef(gridUid, grid, args.GridTile);
         var coords = _maps.ToCoordinates(tileRef, grid);
-        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: IsSubfloorCovered)) // Starlight
+        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: uid => IsSubfloorCovered(uid))) // Starlight
             return;
 
         if (!TryDeconstructWithToolQualities(tileRef, tool.Qualities))
@@ -80,7 +80,7 @@ public abstract partial class SharedToolSystem
         if (string.IsNullOrWhiteSpace(tileDef.BaseTurf))
             return false;
 
-        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: IsSubfloorCovered)) // Starlight
+        if (comp.RequiresUnobstructed && _turfs.IsTileBlocked(gridUid, tileRef.GridIndices, CollisionGroup.MobMask, ignored: uid => IsSubfloorCovered(uid))) // Starlight
             return false;
 
         var coordinates = _maps.GridTileToLocal(gridUid, mapGrid, tileRef.GridIndices);


### PR DESCRIPTION
## Short description
there was an issue with plumbing components not being able to be unanchored when placed on a tile, this fixes that by allowing you to remove the tile of any prototype with subfloor hide by using a pry tool on the actual entity.

## Why we need to add this
bugfixes.

## Media (Video/Screenshots)

https://github.com/user-attachments/assets/03604c6f-d4e3-4b09-9dfd-cc9c6e169400

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Mack
- fix: Fixed issue when trying to pry the a tile when something ontop is blocking it.