### PR TITLE
Fix excessively slippery puddles

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -183,7 +183,6 @@
   - type: EdgeSpreader
     id: Puddle
   - type: StepTrigger
-    stepOn: true
   - type: Edible
     edible: Drink
     delay: 3


### PR DESCRIPTION
## Short description
Fixes puddles being excessively slippery.

## Why we need to add this
Regression introduced by the footprints system. Traversal speed over puddles was not checked, causing all puddles capable of slipping to always slip.
This change was not reverted by https://github.com/ss14Starlight/space-station-14/pull/6084 so doing that here instead.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/add17c4a-230c-46a0-9c46-80e2423f4cb8

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- fix: Puddles are no longer extra slippery, and can now usually be safely traversed by walking.