### PR TITLE
Shotgun Slugshot rebalance hotfix.

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1011,7 +1011,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
-    armorPenetration: 0.6
+    armorPenetration: 0.3
     damage:
       types:
         Piercing: 40


### PR DESCRIPTION
## Short description
My shotgun ammotype addtion might have been too strong.
Lowering the coeffiecent an bit.

## Why we need to add this
Raidsuits and jugsuit just takes an bit too much damage
currently **4 slugs** takes down an jugsuit, tested with riotshotgun, but senitel can shoot faster.

With .3 pen 6 shots for an raidsuit
With .3 pen 7 shots of an jugsuit



## Media (Video/Screenshots)
0 armor pen
<img width="703" height="1034" alt="grafik" src="https://github.com/user-attachments/assets/f18351c4-1292-4641-b22b-cbaf263173df" />


0.3 armor pen
<img width="652" height="852" alt="grafik" src="https://github.com/user-attachments/assets/55a002e9-710f-4d50-b04d-a5c31be01585" />

0.2 armor pen
<img width="753" height="868" alt="grafik" src="https://github.com/user-attachments/assets/94a2ac4a-d1b8-4290-bab3-f6d4aea172bf" />


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: SirLutz
- tweak: lowered Slug armorpen from 60% to 30%.
