### PR TITLE
Typo fix (how did I not notice that at all?)

### DIFF
--- a/Resources/Prototypes/_Starlight/Body/Organs/doll.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/doll.yml
@@ -276,7 +276,7 @@
 - type: entity
   id: ShellFragmentDoll
   parent: [BaseKnife]
-  name: doll shell fragement
+  name: doll shell fragment
   description: A shell piece, broken off of a doll. Sharp, and looks quite sturdy.
   components:
   - type: Sprite


### PR DESCRIPTION
## Short description
Fixes the Fragement typo

## Why we need to add this
Typo fix (I could swear it wasn't there in development >-<)

## Media (Video/Screenshots)
<img width="391" height="79" alt="image" src="https://github.com/user-attachments/assets/f188a3d4-93a4-457d-b47d-f92db2de3a72" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Shell Fragements have lost their surplus e.
