### PR TITLE
Restore AI camera light toggle and fix observation sprite jitter

### DIFF
--- a/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.Starlight.cs
+++ b/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.Starlight.cs
@@ -1,0 +1,34 @@
+using Content.Shared.SurveillanceCamera;
+using Robust.Client.GameObjects;
+
+namespace Content.Client.SurveillanceCamera;
+
+// When the camera sprite changes between the observed and unobserved sprites, it resets the animation.
+// This is intended to make it so that instead of resetting, it smoothly switches between sprites without resetting the animation.
+
+public sealed partial class SurveillanceCameraVisualsSystem
+{
+    private void SetStatePreserveTime(Entity<SpriteComponent?> ent, int layer, string state)
+    {
+        int oldFrame = 0;
+        float oldTime = 0f;
+        float oldTimeLeft = 0f;
+        bool hasOld = false;
+        if (_sprite.TryGetLayer(ent, layer, out var oldLayer, false) && oldLayer != null)
+        {
+            oldFrame = oldLayer.AnimationFrame;
+            oldTime = oldLayer.AnimationTime;
+            oldTimeLeft = oldLayer.AnimationTimeLeft;
+            hasOld = true;
+        }
+
+        _sprite.LayerSetRsiState(ent, layer, state);
+
+        if (hasOld && _sprite.TryGetLayer(ent, layer, out var newLayer, false) && newLayer != null)
+        {
+            newLayer.AnimationFrame = oldFrame;
+            newLayer.AnimationTime = oldTime;
+            newLayer.AnimationTimeLeft = oldTimeLeft;
+        }
+    }
+}

--- a/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.cs
+++ b/Content.Client/SurveillanceCamera/SurveillanceCameraVisualsSystem.cs
@@ -26,6 +26,7 @@ public sealed partial class SurveillanceCameraVisualsSystem : EntitySystem
             return;
         }
 
-        _sprite.LayerSetRsiState((uid, args.Sprite), layer, state);
+        // _sprite.LayerSetRsiState((uid, args.Sprite), layer, state);
+        SetStatePreserveTime((uid, args.Sprite), layer, state); // Starlight
     }
 }

--- a/Content.Shared/_Starlight/Light/Components/LightOnCollideColliderComponent.cs
+++ b/Content.Shared/_Starlight/Light/Components/LightOnCollideColliderComponent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Light.Components;
+
+/// <summary>
+/// Can activate <see cref="LightOnCollideComponent"/> when collided with.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LightOnCollideColliderComponent : Component
+{
+    [DataField]
+    public string FixtureId = "illuminationTrigger";
+}

--- a/Content.Shared/_Starlight/Light/Components/LightOnCollideColliderComponent.cs
+++ b/Content.Shared/_Starlight/Light/Components/LightOnCollideColliderComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Light.Components;
+namespace Content.Shared._Starlight.Light.Components;
 
 /// <summary>
 /// Can activate <see cref="LightOnCollideComponent"/> when collided with.

--- a/Content.Shared/_Starlight/Light/Components/LightOnCollideComponent.cs
+++ b/Content.Shared/_Starlight/Light/Components/LightOnCollideComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Light.Components;
+
+/// <summary>
+/// Enables / disables pointlight whenever entities are contacting with it
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class LightOnCollideComponent : Component
+{
+}

--- a/Content.Shared/_Starlight/Light/Components/LightOnCollideComponent.cs
+++ b/Content.Shared/_Starlight/Light/Components/LightOnCollideComponent.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.GameStates;
 
-namespace Content.Shared.Light.Components;
+namespace Content.Shared._Starlight.Light.Components;
 
 /// <summary>
 /// Enables / disables pointlight whenever entities are contacting with it

--- a/Content.Shared/_Starlight/Light/EntitySystems/LightCollideSystem.cs
+++ b/Content.Shared/_Starlight/Light/EntitySystems/LightCollideSystem.cs
@@ -1,8 +1,9 @@
-using Content.Shared.Light.Components;
+using Content.Shared._Starlight.Light.Components;
+using Content.Shared.Light.EntitySystems;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Physics.Systems;
 
-namespace Content.Shared.Light.EntitySystems;
+namespace Content.Shared._Starlight.Light.EntitySystems;
 
 public sealed partial class LightCollideSystem : EntitySystem
 {

--- a/Content.Shared/_Starlight/Light/EntitySystems/LightCollideSystem.cs
+++ b/Content.Shared/_Starlight/Light/EntitySystems/LightCollideSystem.cs
@@ -1,0 +1,77 @@
+using Content.Shared.Light.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared.Light.EntitySystems;
+
+public sealed partial class LightCollideSystem : EntitySystem
+{
+    [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SlimPoweredLightSystem _lights = default!;
+
+    private EntityQuery<LightOnCollideComponent> _lightQuery;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _lightQuery = GetEntityQuery<LightOnCollideComponent>();
+
+        SubscribeLocalEvent<LightOnCollideColliderComponent, PreventCollideEvent>(OnPreventCollide);
+        SubscribeLocalEvent<LightOnCollideColliderComponent, StartCollideEvent>(OnStart);
+        SubscribeLocalEvent<LightOnCollideColliderComponent, EndCollideEvent>(OnEnd);
+        SubscribeLocalEvent<LightOnCollideColliderComponent, ComponentShutdown>(OnCollideShutdown);
+    }
+
+    private void OnCollideShutdown(Entity<LightOnCollideColliderComponent> ent, ref ComponentShutdown args)
+    {
+        // TODO: Check this on the event.
+        if (TerminatingOrDeleted(ent.Owner))
+            return;
+
+        // Regenerate contacts for everything we were colliding with.
+        var contacts = _physics.GetContacts(ent.Owner);
+        while (contacts.MoveNext(out var contact))
+        {
+            if (!contact.IsTouching)
+                continue;
+
+            var other = contact.OtherEnt(ent.Owner);
+            if (_lightQuery.HasComp(other))
+                _physics.RegenerateContacts(other);
+        }
+    }
+
+    // You may be wondering what de fok this is doing here.
+    // At the moment there's no easy way to do collision whitelists based on components.
+    private void OnPreventCollide(Entity<LightOnCollideColliderComponent> ent, ref PreventCollideEvent args)
+    {
+        if (!_lightQuery.HasComp(args.OtherEntity))
+            args.Cancelled = true;
+    }
+
+    private void OnEnd(Entity<LightOnCollideColliderComponent> ent, ref EndCollideEvent args)
+    {
+        if (args.OurFixtureId != ent.Comp.FixtureId)
+            return;
+        if (!_lightQuery.HasComp(args.OtherEntity))
+            return;
+
+        // TODO: Engine bug IsTouching box2d yay.
+        var contacts = _physics.GetTouchingContacts(args.OtherEntity) - 1;
+        if (contacts > 0)
+            return;
+
+        _lights.SetEnabled(args.OtherEntity, false);
+    }
+
+    private void OnStart(Entity<LightOnCollideColliderComponent> ent, ref StartCollideEvent args)
+    {
+        if (args.OurFixtureId != ent.Comp.FixtureId)
+            return;
+        if (!_lightQuery.HasComp(args.OtherEntity))
+            return;
+
+        _lights.SetEnabled(args.OtherEntity, true);
+    }
+}

--- a/Resources/Prototypes/Actions/station_ai.yml
+++ b/Resources/Prototypes/Actions/station_ai.yml
@@ -14,34 +14,6 @@
   - type: InstantAction
     event: !type:JumpToCoreEvent
 
-# Starlight: Restored removed surveillance camera lights from upstream
-- type: entity
-  parent: BaseAction
-  id: ActionSurvCameraLights
-  name: Toggle camera lights
-  description: Enable surveillance camera lights near wherever you're viewing.
-  components:
-  - type: Action
-    priority: -5
-    itemIconStyle: BigAction
-    icon:
-      sprite: Interface/Actions/actions_ai.rsi
-      state: camera_light
-  - type: InstantAction
-    event: !type:RelayedActionComponentChangeEvent
-      components:
-      - type: LightOnCollideCollider
-      - type: FixturesChange
-        fixtures:
-          illuminationTrigger:
-            shape:
-              !type:PhysShapeCircle
-              radius: 5
-            density: 80
-            hard: false
-            layer:
-            - GhostImpassable
-
 - type: entity
   parent: BaseMentalAction
   id: ActionAIViewLaws

--- a/Resources/Prototypes/Actions/station_ai.yml
+++ b/Resources/Prototypes/Actions/station_ai.yml
@@ -14,6 +14,34 @@
   - type: InstantAction
     event: !type:JumpToCoreEvent
 
+# Starlight: Restored removed surveillance camera lights from upstream
+- type: entity
+  parent: BaseAction
+  id: ActionSurvCameraLights
+  name: Toggle camera lights
+  description: Enable surveillance camera lights near wherever you're viewing.
+  components:
+  - type: Action
+    priority: -5
+    itemIconStyle: BigAction
+    icon:
+      sprite: Interface/Actions/actions_ai.rsi
+      state: camera_light
+  - type: InstantAction
+    event: !type:RelayedActionComponentChangeEvent
+      components:
+      - type: LightOnCollideCollider
+      - type: FixturesChange
+        fixtures:
+          illuminationTrigger:
+            shape:
+              !type:PhysShapeCircle
+              radius: 5
+            density: 80
+            hard: false
+            layer:
+            - GhostImpassable
+
 - type: entity
   parent: BaseMentalAction
   id: ActionAIViewLaws

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -39,6 +39,7 @@
   - type: ActionGrant
     actions:
     - ActionJumpToCore
+    - ActionSurvCameraLights # Starlight: Restored removed surveillance camera lights from upstream
     - ActionAIViewLaws
     - ActionAIShunt # Starlight AI Shunt ability
     - ActionAIReconnectShunt # Starlight AI Shunt reconnect ability

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/surveillance_camera.yml
@@ -26,6 +26,7 @@
         - TabletopMachineLayer
   - type: CameraActiveOnCollide
     requiresPower: false # TODO: Change this when AI can no longer see via unpowered cameras
+  - type: LightOnCollide # Starlight: Restored removed surveillance camera lights from upstream
   - type: PointLight
     enabled: false
     radius: 5

--- a/Resources/Prototypes/_Starlight/Actions/station_ai.yml
+++ b/Resources/Prototypes/_Starlight/Actions/station_ai.yml
@@ -1,0 +1,27 @@
+# Restored removed surveillance camera lights from upstream
+- type: entity
+  parent: BaseAction
+  id: ActionSurvCameraLights
+  name: Toggle camera lights
+  description: Enable surveillance camera lights near wherever you're viewing.
+  components:
+  - type: Action
+    priority: -5
+    itemIconStyle: BigAction
+    icon:
+      sprite: Interface/Actions/actions_ai.rsi
+      state: camera_light
+  - type: InstantAction
+    event: !type:RelayedActionComponentChangeEvent
+      components:
+      - type: LightOnCollideCollider
+      - type: FixturesChange
+        fixtures:
+          illuminationTrigger:
+            shape:
+              !type:PhysShapeCircle
+              radius: 5
+            density: 80
+            hard: false
+            layer:
+            - GhostImpassable


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Partially reverts a change made in #5854 that removes the AI's ability to toggle camera lights when their view is near a camera. Feedback regarding this removal was lukewarm at best from what I saw and a few people including myself wanted it back. This took a little bit of doing because a decent portion of the code used for it was actually repurposed for the indicator light toggling when the AI is near a camera. Any files that were deleted from upstream that I restored as part of this are now in a Starlight path.

While testing this I also noticed an issue where the camera sprite resets its animation when it switches from unobserved (green light) to observed (red light), so that's been fixed and the animation now has proper continuity when switching sprites.

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
It's an unpopular change that was bundled with a desired change from upstream. It's easy enough to restore downstream and isn't explicitly harmful to have. An argument can be made that a better system should eventually replace this (like proper night vision) but short of that, restoring what we've had is good enough for now.

The animation fix is good because it makes it less jarring looking if you were looking at the camera when it switched from unobserved to observed or vice versa and looks nicer as a result.

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->
https://i.imgur.com/TlWNvuj.mp4

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: Rhapsody (Pepta Vismahl)
- add: Re-added AI's ability to toggle camera lights when their view is near a camera.
- fix: Fixed sprite jittering when moving in and out of range of a camera as AI.