### PR TITLE
Washing machine can now clean lube, glue, and creampied crew

### DIFF
--- a/Content.Client/_Starlight/Lube/LubedSystem.cs
+++ b/Content.Client/_Starlight/Lube/LubedSystem.cs
@@ -1,0 +1,5 @@
+﻿using Content.Shared._Starlight.Lube;
+
+namespace Content.Client._Starlight.Lube;
+
+public sealed partial class LubedSystem : SharedLubedSystem;

--- a/Content.Server/_Starlight/Lube/LubedSystem.cs
+++ b/Content.Server/_Starlight/Lube/LubedSystem.cs
@@ -1,0 +1,59 @@
+﻿using Content.Shared._Starlight.Lube;
+using Content.Shared.Hands;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Item;
+using Content.Shared.Lube;
+using Content.Shared.Popups;
+using Content.Shared.Throwing;
+using Robust.Shared.Random;
+
+namespace Content.Server._Starlight.Lube;
+
+public sealed partial class LubedSystem : SharedLubedSystem
+{
+    [Dependency] private ThrowingSystem _throwing = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<LubedComponent, BeforeGettingEquippedHandEvent>(OnHandPickUp);
+    }
+
+    /// <remarks>
+    /// Note to whoever makes this predicted—there is a mispredict here that
+    /// would be nice to keep! If this is in shared, the client will predict
+    /// this and not run the pickup animation in <see cref="SharedHandsSystem"/>
+    /// which would (probably) make this effect look less funny. You will
+    /// probably want to either tweak <see cref="BeforeGettingEquippedHandEvent"/>
+    /// to be able to cancel but still run the animation or something—we do want
+    /// the event to run before the animation for stuff like
+    /// <see cref="MultiHandedItemSystem.OnBeforeEquipped"/>.
+    /// </remarks>
+    private void OnHandPickUp(Entity<LubedComponent> ent, ref BeforeGettingEquippedHandEvent args)
+    {
+        if (args.Cancelled)
+            return;
+
+        if (ent.Comp.SlipsLeft <= 0)
+        {
+            RemComp<LubedComponent>(ent);
+            _nameMod.RefreshNameModifiers(ent.Owner);
+            return;
+        }
+
+        ent.Comp.SlipsLeft--;
+        args.Cancelled = true;
+
+        _transform.SetCoordinates(ent, Transform(args.User).Coordinates);
+        _transform.AttachToGridOrMap(ent);
+        _throwing.TryThrow(ent, _random.NextVector2(), ent.Comp.SlipStrength);
+        _popup.PopupEntity(Loc.GetString("lube-slip", ("target", Identity.Entity(ent, EntityManager))),
+            args.User,
+            args.User,
+            PopupType.MediumCaution);
+    }
+}

--- a/Content.Server/_Starlight/Washing/WashingFixtureSystem.cs
+++ b/Content.Server/_Starlight/Washing/WashingFixtureSystem.cs
@@ -1,7 +1,7 @@
-﻿using Content.Server._Starlight.Lube;
-using Content.Server._Starlight.Nutrition.EntitySystems;
+﻿using Content.Server._Starlight.Nutrition.EntitySystems;
 using Content.Server.DoAfter;
 using Content.Server.Popups;
+using Content.Shared._Starlight.Lube;
 using Content.Shared._Starlight.Washing;
 using Content.Shared.DoAfter;
 using Content.Shared.Glue;
@@ -24,7 +24,7 @@ public sealed partial class WashingFixtureSystem : EntitySystem
     [Dependency] private PopupSystem _popupSystem = default!;
     [Dependency] private CreamPieSystem _creamPie = default!;
     [Dependency] private GlueSystem _glueSystem = default!;
-    [Dependency] private LubedSystem _lubedSystem = default!;
+    [Dependency] private SharedLubedSystem _lubedSystem = default!;
 
     public override void Initialize()
     {

--- a/Content.Shared/_Funkystation/WashingMachine/SharedWashingMachineSystem.cs
+++ b/Content.Shared/_Funkystation/WashingMachine/SharedWashingMachineSystem.cs
@@ -1,15 +1,7 @@
-﻿using Content.Shared.Interaction;
-using Content.Shared.Popups;
-using Content.Shared.Power.EntitySystems;
-using Content.Shared.Storage.Components;
-using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Verbs;
-using Robust.Shared.Audio.Systems;
-using Robust.Shared.Timing;
-using Robust.Shared.Utility;
-using System.Linq;
+﻿using System.Linq;
 using Content.Shared._Funkystation.Stains.Components;
 using Content.Shared._Funkystation.Stains.Systems;
+using Content.Shared._Starlight.Lube;
 using Content.Shared.Chemistry;
 using Content.Shared.Chemistry.Components;
 using Content.Shared.Chemistry.EntitySystems;
@@ -18,9 +10,22 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Destructible;
+using Content.Shared.Glue;
+using Content.Shared.Interaction;
+using Content.Shared.Lube;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+using Content.Shared.Popups;
+using Content.Shared.Power.EntitySystems;
 using Content.Shared.Random.Helpers;
+using Content.Shared.Storage.Components;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Verbs;
+using Robust.Shared.Audio.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Shared._Funkystation.WashingMachine;
 
@@ -37,6 +42,9 @@ public abstract partial class SharedWashingMachineSystem : EntitySystem
     [Dependency] private ReactiveSystem _reactive = null!;
     [Dependency] private SharedSolutionContainerSystem _solution = default!;
     [Dependency] private SharedStainSystem _stains = default!;
+    [Dependency] private SharedCreamPieSystem _creamPie = default!;
+    [Dependency] private GlueSystem _glueSystem = default!;
+    [Dependency] private SharedLubedSystem _lubedSystem = default!;
 
     public override void Initialize()
     {
@@ -195,6 +203,15 @@ public abstract partial class SharedWashingMachineSystem : EntitySystem
 
             foreach (var item in items)
             {
+                // Starlight Start - Clean lube, glue, and any creampied crew
+                if (TryComp<CreamPiedComponent>(item, out var creamPiedComp))
+                    _creamPie.SetCreamPied(item, creamPiedComp, false);
+                if (HasComp<LubedComponent>(item))
+                    _lubedSystem.RemoveLubed(item);
+                if (HasComp<GluedComponent>(item))
+                    _glueSystem.RemoveGlued(item);
+                // Starlight End
+
                 if (TryComp<StainableComponent>(item, out var stain) && _solution.TryGetSolution(item, stain.SolutionName, out var sol))
                 {
                     _solution.RemoveAllSolution(sol.Value);

--- a/Content.Shared/_Starlight/Lube/SharedLubedSystem.cs
+++ b/Content.Shared/_Starlight/Lube/SharedLubedSystem.cs
@@ -1,33 +1,20 @@
-using Content.Shared.Hands;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.IdentityManagement;
-using Content.Shared.Item;
 using Content.Shared.Lube;
 using Content.Shared.NameModifier.EntitySystems;
-using Content.Shared.Popups;
-using Content.Shared.Throwing;
-using Robust.Shared.Random;
 
 namespace Content.Shared._Starlight.Lube;
 
-public sealed partial class SharedLubedSystem : EntitySystem
+public abstract partial class SharedLubedSystem : EntitySystem
 {
-    [Dependency] private ThrowingSystem _throwing = default!;
-    [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private SharedPopupSystem _popup = default!;
-    [Dependency] private NameModifierSystem _nameMod = default!;
+    [Dependency] protected NameModifierSystem _nameMod = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<LubedComponent, ComponentInit>(OnInit);
-        SubscribeLocalEvent<LubedComponent, BeforeGettingEquippedHandEvent>(OnHandPickUp);
         SubscribeLocalEvent<LubedComponent, RefreshNameModifiersEvent>(OnRefreshNameModifiers);
     }
 
-    // Starlight Start
     /// <summary>
     /// Removes the lubed condition from the target.
     /// </summary>
@@ -36,45 +23,10 @@ public sealed partial class SharedLubedSystem : EntitySystem
         if (RemComp<LubedComponent>(uid))
             _nameMod.RefreshNameModifiers(uid);
     }
-    // Starlight End
 
     private void OnInit(EntityUid uid, LubedComponent component, ComponentInit args)
     {
         _nameMod.RefreshNameModifiers(uid);
-    }
-
-    /// <remarks>
-    /// Note to whoever makes this predicted—there is a mispredict here that
-    /// would be nice to keep! If this is in shared, the client will predict
-    /// this and not run the pickup animation in <see cref="SharedHandsSystem"/>
-    /// which would (probably) make this effect look less funny. You will
-    /// probably want to either tweak <see cref="BeforeGettingEquippedHandEvent"/>
-    /// to be able to cancel but still run the animation or something—we do want
-    /// the event to run before the animation for stuff like
-    /// <see cref="MultiHandedItemSystem.OnBeforeEquipped"/>.
-    /// </remarks>
-    private void OnHandPickUp(Entity<LubedComponent> ent, ref BeforeGettingEquippedHandEvent args)
-    {
-        if (args.Cancelled)
-            return;
-
-        if (ent.Comp.SlipsLeft <= 0)
-        {
-            RemComp<LubedComponent>(ent);
-            _nameMod.RefreshNameModifiers(ent.Owner);
-            return;
-        }
-
-        ent.Comp.SlipsLeft--;
-        args.Cancelled = true;
-
-        _transform.SetCoordinates(ent, Transform(args.User).Coordinates);
-        _transform.AttachToGridOrMap(ent);
-        _throwing.TryThrow(ent, _random.NextVector2(), ent.Comp.SlipStrength);
-        _popup.PopupEntity(Loc.GetString("lube-slip", ("target", Identity.Entity(ent, EntityManager))),
-            args.User,
-            args.User,
-            PopupType.MediumCaution);
     }
 
     private void OnRefreshNameModifiers(Entity<LubedComponent> entity, ref RefreshNameModifiersEvent args)

--- a/Content.Shared/_Starlight/Lube/SharedLubedSystem.cs
+++ b/Content.Shared/_Starlight/Lube/SharedLubedSystem.cs
@@ -8,9 +8,9 @@ using Content.Shared.Popups;
 using Content.Shared.Throwing;
 using Robust.Shared.Random;
 
-namespace Content.Server._Starlight.Lube;
+namespace Content.Shared._Starlight.Lube;
 
-public sealed partial class LubedSystem : EntitySystem
+public sealed partial class SharedLubedSystem : EntitySystem
 {
     [Dependency] private ThrowingSystem _throwing = default!;
     [Dependency] private IRobustRandom _random = default!;


### PR DESCRIPTION
## Short description
Washing machine washes away "contaminants" on contained objects. This includes crew.

## Why we need to add this
There are both practical and silly uses of this.
Practical use is to remove lube/glue on items.
Silly use is forcing other crew to clean themselves.

Crew should still preferably use the Wash verb on sinks to clean themselves safely.

## Technical
Note that for this to work, I had to move some `LubedSystem` logic over to `Content.Shared`. While it is fully functional with no issues that I could discern if everything was shared, there is a comment referencing some form of mispredict and that being a reason to keep `OnHandPickUp` server only. I could not however figure out what that desired mispredict is, but nevertheless left the pickup logic server-only.

## Media (Video/Screenshots)
#### Crew:
https://github.com/user-attachments/assets/1ba2bf2c-60b7-4359-a359-8fdad0131055

Note: Removal of name prefixes may require placing or removing an item in hands to fully update.

#### Item:
https://github.com/user-attachments/assets/4f132fe7-afbf-454b-bfb3-69445e0cf089

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- add: Washing machine now removes lube and glue from items.
- add: Washing machine now cleans any crewmember that happens to find themselves inside. Crew are still advised to use sinks to safely to wash themselves.