### PR TITLE
Adds ShouldMapStation for Departmental Techfabs

### DIFF
--- a/Resources/Prototypes/_Starlight/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Structures/Machines/lathe.yml
@@ -64,7 +64,7 @@
 # Cargo
 - type: entity
   id: CargoTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: cargo techfab
   description: Prints equipment for use by the station's supply department.
@@ -122,7 +122,7 @@
 # Engineering
 - type: entity
   id: EngineeringTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: engineering techfab
   description: Prints equipment for use by the station's engineering department.
@@ -179,7 +179,7 @@
 # Service - Woah, bold statement there...
 - type: entity
   id: ServiceTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: service techfab
   description: Prints equipment for use by the station's service department.
@@ -229,7 +229,7 @@
 
 - type: entity
   id: ScienceTechFab
-#  categories: [ ShouldMapStation ] # Commented out for now, but once it's mapped on every station, un-comment
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: science techfab
   description: Prints equipment for use by the station's research department.
@@ -308,6 +308,7 @@
 # Command, paperwork stuff, mostly
 - type: entity
   id: CommandTechFab
+  categories: [ ShouldMapStation ]
   parent: BaseLatheLube
   name: command techfab
   description: Prints equipment for use by the station's command department.


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds `[ ShouldMapStation ]` to the Cargo, Engineering, Service, Science, and Command techfabs.

The Security and Medical techfabs already had `ShouldMapStation`

## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
- Closes #5458 

More test coverage is good. These should be mapped on all stations now (exceptions of ultra low pop as usual, but they were mapped there too).

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.
