### PR TITLE
Jet injector hotfix

### DIFF
--- a/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Chemistry/chemistry.yml
+++ b/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Chemistry/chemistry.yml
@@ -1,0 +1,5 @@
+- type: !PartialOnly entity
+  id: BaseSyringe
+  components:
+  - type: RefillableSolution
+    solution: injector

--- a/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Medical/hypospray.yml
@@ -1,0 +1,5 @@
+- type: !PartialOnly entity
+  id: BaseHypospray
+  components:
+  - type: RefillableSolution
+    solution: hypospray


### PR DESCRIPTION
## Short description
Re-adds the refillable solution comp to jet injectors

## Why we need to add this
That comp got lost from basehypo some where in the solution mess, so jet injectors cannot currently be refilled by a smart dispenser. This breaks functionality of the medbay in general, and medtak in particular as their jet injector is also affected.

## Media (Video/Screenshots)


## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Citrea
- fix: Jet injectors can be refilled at smart dispensers again.
