### PR TITLE
Groupchat limit

### DIFF
--- a/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
+++ b/Content.Server/_CD/CartridgeLoader/Cartridges/NanoChatCartridgeSystem.cs
@@ -881,7 +881,7 @@ public sealed partial class NanoChatCartridgeSystem : EntitySystem
             return;
 
         var members = recipient.Value.Members ?? new HashSet<uint>();
-        if (members.Contains(inviteeNumber))
+        if (members.Contains(inviteeNumber) || members.Count >= recipient.Value.MaxMembers) //Starlight edit - Member limit
             return;
 
         // Add member to group

--- a/Content.Shared/_CD/CartridgeLoader/Cartridges/NanoChatUiMessageEvent.cs
+++ b/Content.Shared/_CD/CartridgeLoader/Cartridges/NanoChatUiMessageEvent.cs
@@ -98,6 +98,11 @@ public partial struct NanoChatRecipient
     public HashSet<uint>? Members; // Funky Station - Group Chats
 
     /// <summary>
+    ///     For group chats: Max amount of members allowed in the group.
+    /// </summary>
+    public int MaxMembers = 30; // Starlight edit - Max members in group
+
+    /// <summary>
     ///     For group chats: the NanoChat number of the creator.
     /// </summary>
     public uint? CreatorId; // Funky Station - Group Chats


### PR DESCRIPTION
## Short description
Nanochat uses some expensive calls so limit group chat to avoid blowing out ticking budget

## Why we need to add this
Bad bad lag

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- tweak: Changed Groupchat to have a member limit of 30 to combat lag.
