### PR TITLE
Moved body emotes back to species and prevent overriding of body emotes

### DIFF
--- a/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
@@ -403,11 +403,15 @@ public sealed partial class OrganSystem : EntitySystem
             var emotes = speech.AllowedEmotes.Union(ent.Comp.AllowedEmotes);
             speech.AllowedEmotes = emotes.ToList();
             if (ent.Comp.AllowAllVocalEmotes)
-                speech.AllowedEmotes =
-                [
-                    .. ProtoMan.EnumeratePrototypes<EmotePrototype>().Where(emote => emote.Category.HasFlag(EmoteCategory.Vocal))
-                        .Select(emote => (ProtoId<EmotePrototype>)emote.ID)
-                ];
+            {
+                var allVocalEmotes =
+                    ProtoMan.EnumeratePrototypes<EmotePrototype>()
+                        .Where(emote => emote.Category.HasFlag(EmoteCategory.Vocal))
+                        .Select(emote => (ProtoId<EmotePrototype>)emote.ID).Except(speech.AllowedEmotes);
+                speech.AllowedEmotes = allVocalEmotes.ToList();
+            }
+
+            ;
             Dirty(args.Body, speech);
         }
 
@@ -423,6 +427,14 @@ public sealed partial class OrganSystem : EntitySystem
         {
             var emotes = speech.AllowedEmotes.Except(ent.Comp.AllowedEmotes);
             speech.AllowedEmotes = emotes.ToList();
+            if (ent.Comp.AllowAllVocalEmotes)
+            {
+                var allVocalEmotes =
+                    ProtoMan.EnumeratePrototypes<EmotePrototype>()
+                        .Where(emote => emote.Category.HasFlag(EmoteCategory.Vocal))
+                        .Select(emote => (ProtoId<EmotePrototype>)emote.ID).Except(speech.AllowedEmotes);
+                speech.AllowedEmotes = speech.AllowedEmotes.Except(allVocalEmotes).ToList();
+            }
             Dirty(args.Body, speech);
         }
 

--- a/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
+++ b/Content.Server/_Starlight/Medical/Surgery/OrganSystem.cs
@@ -400,7 +400,8 @@ public sealed partial class OrganSystem : EntitySystem
     {
         if (TryComp<SpeechComponent>(args.Body, out var speech))
         {
-            speech.AllowedEmotes = ent.Comp.AllowedEmotes;
+            var emotes = speech.AllowedEmotes.Union(ent.Comp.AllowedEmotes);
+            speech.AllowedEmotes = emotes.ToList();
             if (ent.Comp.AllowAllVocalEmotes)
                 speech.AllowedEmotes =
                 [
@@ -410,7 +411,7 @@ public sealed partial class OrganSystem : EntitySystem
             Dirty(args.Body, speech);
         }
 
-        if (TryComp<VocalComponent>(args.Body, out var vocal))
+        if (TryComp<VocalComponent>(args.Body, out var vocal) && vocal.EmoteSounds == null)
             _vocal.SetSounds((args.Body, vocal), ent.Comp.Sounds);
         if (HasComp<AbductorComponent>(args.Body) || !ent.Comp.IsMuted) return;
         RemComp<MutedComponent>(args.Body);
@@ -420,11 +421,12 @@ public sealed partial class OrganSystem : EntitySystem
     {
         if (TryComp<SpeechComponent>(args.Body, out var speech))
         {
-            speech.AllowedEmotes = new();
+            var emotes = speech.AllowedEmotes.Except(ent.Comp.AllowedEmotes);
+            speech.AllowedEmotes = emotes.ToList();
             Dirty(args.Body, speech);
         }
 
-        if (TryComp<VocalComponent>(args.Body, out var vocal))
+        if (TryComp<VocalComponent>(args.Body, out var vocal) && ent.Comp.Sounds != null)
             _vocal.SetSounds((args.Body, vocal), null);
 
         ent.Comp.IsMuted = HasComp<MutedComponent>(args.Body);

--- a/Resources/Prototypes/_Starlight/Body/Organs/Neocyte/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Neocyte/moth.yml
@@ -36,7 +36,7 @@
   suffix: Neo-Moth
   components:
   - type: OrganTongue
-    allowedEmotes: ['Chirp', 'Hisses', 'Squish', 'Bubble', 'Pop', 'Purr', 'Growl', 'Trill', 'Scree', 'Call', 'Squawk', 'Bark', 'Snarl', 'Whine', 'Howl', 'Yip', 'Mew', 'Meow', 'Liss', 'Lurr', 'Rattle', "Marr", "Wurble", 'Chitter', 'Squeak', 'Flap', 'Click', 'Beep', 'Ping', 'Buzz', 'Buzz-Two', 'Chime', 'Honk', 'ThavenHum', 'ThavenGlub', 'Squee', 'Snort', 'Sneeze', 'LagomorphSnore']
+    allowedEmotes: ['Chirp', 'Hisses', 'Squish', 'Bubble', 'Pop', 'Purr', 'Growl', 'Trill', 'Scree', 'Call', 'Squawk', 'Bark', 'Snarl', 'Whine', 'Howl', 'Yip', 'Mew', 'Meow', 'Liss', 'Lurr', 'Rattle', "Marr", "Wurble", 'Chitter', 'Squeak', 'Click', 'Beep', 'Ping', 'Buzz', 'Buzz-Two', 'Chime', 'Honk', 'ThavenHum', 'ThavenGlub', 'Squee', 'Snort', 'Sneeze', 'LagomorphSnore']
     sounds:
       Male: NeoMothMSounds
       Female: NeoMothFSounds

--- a/Resources/Prototypes/_Starlight/Body/Organs/Neocyte/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/Neocyte/reptilian.yml
@@ -4,7 +4,7 @@
   suffix: Neo-Reptilian
   components:
   - type: OrganTongue
-    allowedEmotes: ['Chirp', 'Hisses', 'Squish', 'Bubble', 'Pop', 'Purr', 'Growl', 'Trill', 'Scree', 'Call', 'Squawk', 'Bark', 'Snarl', 'Whine', 'Howl', 'Yip', 'Mew', 'Meow','Thump', 'Liss', 'Lurr', 'Rattle', "Marr", "Wurble", 'Chitter', 'Squeak', 'Flap', 'Click', 'Beep', 'Ping', 'Buzz', 'Buzz-Two', 'Chime', 'Honk', 'ThavenHum', 'ThavenGlub', 'Squee', 'Snort', 'Sneeze', 'LagomorphSnore']
+    allowedEmotes: ['Chirp', 'Hisses', 'Squish', 'Bubble', 'Pop', 'Purr', 'Growl', 'Trill', 'Scree', 'Call', 'Squawk', 'Bark', 'Snarl', 'Whine', 'Howl', 'Yip', 'Mew', 'Meow', 'Liss', 'Lurr', 'Rattle', "Marr", "Wurble", 'Chitter', 'Squeak', 'Click', 'Beep', 'Ping', 'Buzz', 'Buzz-Two', 'Chime', 'Honk', 'ThavenHum', 'ThavenGlub', 'Squee', 'Snort', 'Sneeze', 'LagomorphSnore']
     sounds:
       Male: NeoReptilianMSounds
       Female: NeoReptilianFSounds

--- a/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/moth.yml
@@ -41,7 +41,7 @@
   suffix: Moth
   components:
   - type: OrganTongue
-    allowedEmotes: ['Chitter', 'Squeak', 'Flap']
+    allowedEmotes: ['Chitter', 'Squeak']
     sounds:
       Male: UnisexMoth
       Female: UnisexMoth

--- a/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Body/Organs/reptilian.yml
@@ -26,7 +26,7 @@
   suffix: Reptilian
   components:
   - type: OrganTongue
-    allowedEmotes: ['Thump', 'Liss', 'Lurr', 'Rattle']
+    allowedEmotes: ['Liss', 'Lurr', 'Rattle']
     sounds:
       Male: MaleReptilian
       Female: FemaleReptilian

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/moth.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/moth.yml
@@ -131,6 +131,7 @@
   - type: Speech
     speechVerb: Robotic
     speechSounds: Borg
+    allowedEmotes: ['Flap']
   - type: BodyEmotes
     soundsId: MothBodyEmotes
   - type: Inventory

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/Neocyte/reptilian.yml
@@ -33,6 +33,7 @@
   - type: Speech
     speechVerb: Robotic
     speechSounds: Borg
+    allowedEmotes: ['Thump', 'Flap']
   - type: BodyEmotes
     soundsId: ReptilianBodyEmotes
   - type: Butcherable

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/moth.yml
@@ -39,6 +39,7 @@
   - type: Speech
     speechVerb: Moth
     speechSounds: UnisexMoth # Starlight: Add talk sounds
+    allowedEmotes: ['Flap']
   - type: TypingIndicator
     proto: moth
   - type: Butcherable

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/Species/reptilian.yml
@@ -42,6 +42,7 @@
   - type: Speech
     speechSounds: Lizard
     speechVerb: Reptilian
+    allowedEmotes: ['Thump']
   - type: TypingIndicator
     proto: lizard
   - type: Vocal


### PR DESCRIPTION
## Short description
Moves the body or "hands" emotes back to the species files and prevent override them 

## Why we need to add this
Few mistakes were made

## Media (Video/Screenshots)
<!--
If your PR contains in-game changes you must provide screenshots/videos of the changes.
-->

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- fix: Fixed Tongue containing body emotes and it overriding existing emotes.

