### PR TITLE
Universal drobe restock

### DIFF
--- a/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Service/vending_machine_restock.yml
+++ b/Resources/Prototypes/_Starlight/Partials/Entities/Objects/Specific/Service/vending_machine_restock.yml
@@ -1,0 +1,27 @@
+﻿- type: !PartialOnly entity
+  id: VendingMachineRestockCostumes
+  name: Drobe restock box
+  description: A restock box for any Drobe machine. Made out of 100% Synthetic fibers
+  components:
+    - type: VendingMachineRestock
+      canRestock:
+        - AutoDrobeInventory
+        - CargoDrobeInventory
+        - AtmosDrobeInventory
+        - BarDrobeInventory
+        - ChefDrobeInventory
+        - ChemDrobeInventory
+        - CuraDrobeInventory
+        - DetDrobeInventory
+        - EngiDrobeInventory
+        - GeneDrobeInventory
+        - HyDrobeInventory
+        - JaniDrobeInventory
+        - LawDrobeInventory
+        - MagiVendInventory
+        - MediDrobeInventory
+        - RoboDrobeInventory
+        - SciDrobeInventory
+        - SecDrobeInventory
+        - ViroDrobeInventory
+        - WinterDrobeInventory


### PR DESCRIPTION
## Short description
Currently drobe machines like engi or sec drobe cannot be restocked this aims to make the autodrobe restock work on all drobe machines so they can be restocked

## Why we need to add this
Allows for restocking of all drobes machine so they can be restocked when they run out

## Media (Video/Screenshots)
N/A

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: RedSpeeds
- tweak: Changed AutoDrobe Restock to work on all drobe machines.


