### PR TITLE
Add additional cargo bounties

### DIFF
--- a/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
@@ -5,16 +5,16 @@ bounty-item-abyssium-ore = Abyssium Ore
 bounty-item-old-treasure = Old Treasure
 bounty-item-space-bear-hide = Space Bear Hide
 
-bounty-item-salad = Salad
-bounty-item-sausage-bun = Sausage on a bun
-bounty-item-nexus-uplink = Nexus uplink
 bounty-item-cotton-cake = Cotton cake
 bounty-item-cotton-bread = Cotton bread
 bounty-item-coupe-glass = Coupe glass
+bounty-item-nexus-uplink = Nexus uplink
+bounty-item-salad = Salad
+bounty-item-sausage-bun = Sausage on a bun
 
-bounty-description-salad = Our chief medical officer just informed us that some crew aren't eating a varied diet. We figure a few salads could fix the problem.
-bounty-description-sausage-bun = Some assistants are having an eating competition but need cheap food. Some sausages on a bun would do the trick, doesn't matter where they came from.
-bounty-description-nexus-uplink = Avali jealously guard their Nexus technology and refuse to share it with outsiders. Send us one of their uplink implants for study.
-bounty-description-cotton-cake = Moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
 bounty-description-cotton-bread = A cotton shortage has led to cotton bread prices skyrocketing. Ship some cotton bread before the moths start eating our clothes.
+bounty-description-cotton-cake = Moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
 bounty-description-coupe-glass = Tomorrow's cocktail reception is about to be ruined because the host didn't acquire enough glasses for all the guests. Help us make up the shortfall.
+bounty-description-nexus-uplink = An avali officer's Nexus uplink has malfunctioned and they are at risk of developing pack loss. Urgently send a replacement.
+bounty-description-salad = Our chief medical officer just informed us that some crew aren't eating a varied diet. We figure a few salads would fix the problem.
+bounty-description-sausage-bun = Some assistants are having an eating competition but need cheap food. Some sausages on a bun would do the trick, doesn't matter where they came from.

--- a/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
@@ -10,9 +10,11 @@ bounty-item-sausage-bun = Sausage on a bun
 bounty-item-nexus-uplink = Nexus uplink
 bounty-item-cotton-cake = Cotton cake
 bounty-item-cotton-bread = Cotton bread
+bounty-item-coupe-glass = Coupe glass
 
 bounty-description-salad = Our chief medical officer just informed us that some crew aren't eating a varied diet. We figure a few salads could fix the problem.
 bounty-description-sausage-bun = Some assistants are having an eating competition but need cheap food. Some sausages on a bun would do the trick, doesn't matter where they came from.
 bounty-description-nexus-uplink = Avali jealously guard their Nexus technology and refuse to share it with outsiders. Send us one of their uplink implants for study.
 bounty-description-cotton-cake = Moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
 bounty-description-cotton-bread = A cotton shortage has led to cotton bread prices skyrocketing. Ship some cotton bread before the moths start eating our clothes.
+bounty-description-coupe-glass = Tomorrow's cocktail reception is about to be ruined because the host didn't acquire enough glasses for all the guests. Help us make up the shortfall.

--- a/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
@@ -5,3 +5,14 @@ bounty-item-abyssium-ore = Abyssium Ore
 bounty-item-old-treasure = Old Treasure
 bounty-item-space-bear-hide = Space Bear Hide
 
+bounty-item-salad = Salad
+bounty-item-sausage-bun = Sausage on a bun
+bounty-item-nexus-uplink = Nexus uplink
+bounty-item-cotton-cake = Cotton cake
+bounty-item-cotton-bread = Cotton bread
+
+bounty-description-salad = Our chief medical officer just informed us that some crew aren't eating a varied diet. We figure a few salads could fix the problem.
+bounty-description-sausage-bun = Some assistants are having an eating competition but need cheap food. Some sausages on a bun would do the trick, doesn't matter where they came from.
+bounty-description-nexus-uplink = Avali jealously guard their Nexus technology and refuse to share it with outsiders. Send us one of their uplink implants for study.
+bounty-description-cotton-cake = Moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
+bounty-description-cotton-bread = A cotton shortage has led to cotton bread prices skyrocketing. Ship some cotton bread before the moths start eating our clothes.

--- a/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
+++ b/Resources/Locale/en-US/_Starlight/cargo/bounties.ftl
@@ -13,7 +13,7 @@ bounty-item-salad = Salad
 bounty-item-sausage-bun = Sausage on a bun
 
 bounty-description-cotton-bread = A cotton shortage has led to cotton bread prices skyrocketing. Ship some cotton bread before the moths start eating our clothes.
-bounty-description-cotton-cake = Moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
+bounty-description-cotton-cake = Our moth friend's birthday is tomorrow, but we don't know how to bake them a cake. Help us!
 bounty-description-coupe-glass = Tomorrow's cocktail reception is about to be ruined because the host didn't acquire enough glasses for all the guests. Help us make up the shortfall.
 bounty-description-nexus-uplink = An avali officer's Nexus uplink has malfunctioned and they are at risk of developing pack loss. Urgently send a replacement.
 bounty-description-salad = Our chief medical officer just informed us that some crew aren't eating a varied diet. We figure a few salads would fix the problem.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -71,6 +71,9 @@
     sprite: Objects/Consumable/Drinks/glass_coupe_shape.rsi
   - type: SolutionContainerVisuals
     inHandsMaxFillLevels: 1
+  - type: Tag
+    tags:
+    - CoupeGlass # Starlight
 
 - type: entity
   parent: [DrinkBaseMaterialCardboard, DrinkBaseCup, DrinkBaseEmptyTrash, DrinkVisualsFill]

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/bread.yml
@@ -141,6 +141,7 @@
     tags:
     - ClothMade
     - Bread
+    - CottonBread # Starlight
   - type: Solution
     solution:
       reagents:
@@ -169,6 +170,7 @@
     - ClothMade
     - Bread
     - Slice
+    - CottonBread # Starlight
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -1214,6 +1214,7 @@
     tags:
     - Cake
     - ClothMade
+    - CottonCake # Starlight
   - type: Solution
     solution:
       reagents:
@@ -1241,6 +1242,7 @@
     - Cake
     - ClothMade
     - Slice
+    - CottonCake # Starlight
   - type: Solution
     solution:
       reagents:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/meals.yml
@@ -570,6 +570,7 @@
   - type: Tag
     tags:
     - Fruit
+    - Salad #Starlight
 
 - type: entity
   parent: FoodMealBase

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -119,6 +119,7 @@
     tags:
     - Soup
     - Fruit # I don't know what this is but its' a salad so sure
+    - Salad #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -153,6 +154,7 @@
     tags:
     - Fruit
     - Soup
+    - Salad #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -192,6 +194,7 @@
     - Meat
     - Fruit
     - Soup
+    - Salad #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -227,6 +230,11 @@
     utensil:
     - Fork
     - Spoon
+      - type: Tag
+  - type: Tag
+    tags:
+    - Soup
+    - Salad #Starlight
 
 - type: entity
   name: caesar salad
@@ -259,6 +267,10 @@
     utensil:
     - Fork
     - Spoon
+  - type: Tag
+    tags:
+    - Soup
+    - Salad #Starlight
 
 - type: entity
   name: kimchi salad
@@ -294,6 +306,10 @@
     utensil:
     - Fork
     - Spoon
+  - type: Tag
+    tags:
+    - Soup
+    - Salad #Starlight
 
 - type: entity
   name: fruit salad
@@ -329,6 +345,7 @@
     tags:
     - Fruit
     - Soup
+    - Salad  #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -369,6 +386,7 @@
     tags:
     - Fruit
     - Soup
+    - Salad  #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -405,6 +423,7 @@
     tags:
     - Fruit
     - Soup
+    - Salad  #Starlight
   - type: Edible #Starlight
     utensil:
     - Fork
@@ -437,6 +456,10 @@
     utensil:
     - Fork
     - Spoon
+  - type: Tag
+    tags:
+    - Soup
+    - Salad #Starlight
 
 # Rice
 

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -230,7 +230,6 @@
     utensil:
     - Fork
     - Spoon
-      - type: Tag
   - type: Tag
     tags:
     - Soup

--- a/Resources/Prototypes/_Starlight/Body/Implants/brain.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/brain.yml
@@ -68,6 +68,7 @@
       keySlots: 4
       canBeExamined: false
 
+
 - type: entity
   id: BrainImplantNexus
   name: Nexus uplink

--- a/Resources/Prototypes/_Starlight/Body/Implants/brain.yml
+++ b/Resources/Prototypes/_Starlight/Body/Implants/brain.yml
@@ -68,7 +68,6 @@
       keySlots: 4
       canBeExamined: false
 
-
 - type: entity
   id: BrainImplantNexus
   name: Nexus uplink
@@ -84,3 +83,6 @@
       - Nexus
       understood:
       - Nexus
+  - type: Tag
+    tags:
+      - NexusUplink

--- a/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
@@ -10,6 +10,17 @@
       - OvenMachineBoard
 
 - type: cargoBounty
+  id: BountyNexusUplink
+  reward: 21500
+  description: bounty-description-nexus-uplink
+  entries:
+  - name: bounty-item-nexus-uplink
+    amount: 1
+    whitelist:
+      tags:
+      - NexusUplink
+
+- type: cargoBounty
   id: BountySalad
   reward: 10500
   description: bounty-description-salad
@@ -32,15 +43,18 @@
       - SausageBun
 
 - type: cargoBounty
-  id: BountyNexusUplink
-  reward: 21500
-  description: bounty-description-nexus-uplink
+  id: BountyCottonBread
+  reward: 2000
+  description: bounty-description-cotton-bread
   entries:
-  - name: bounty-item-nexus-uplink
+  - name: bounty-item-cotton-bread
     amount: 1
     whitelist:
       tags:
-      - NexusUplink
+      - CottonBread
+    blacklist:
+      tags:
+      - Slice
 
 - type: cargoBounty
   id: BountyCottonCake
@@ -57,15 +71,12 @@
       - Slice
 
 - type: cargoBounty
-  id: BountyBread
-  reward: 2000
-  description: bounty-description-cotton-bread
+  id: BountyCoupeGlass
+  reward: 800
+  description: bounty-description-coupe-glass
   entries:
-  - name: bounty-item-cotton-bread
-    amount: 1
+  - name: bounty-item-coupe-glass
+    amount: 4
     whitelist:
       tags:
-      - CottonBread
-    blacklist:
-      tags:
-      - Slice
+      - CoupeGlass

--- a/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
@@ -8,3 +8,64 @@
     whitelist:
       tags:
       - OvenMachineBoard
+
+- type: cargoBounty
+  id: BountySalad
+  reward: 10500
+  description: bounty-description-salad
+  entries:
+  - name: bounty-item-salad
+    amount: 3
+    whitelist:
+      tags:
+      - Salad
+
+- type: cargoBounty
+  id: BountySausageBun
+  reward: 2100
+  description: bounty-description-sausage-bun
+  entries:
+  - name: bounty-item-sausage-bun
+    amount: 6
+    whitelist:
+      tags:
+      - SausageBun
+
+- type: cargoBounty
+  id: BountyNexusUplink
+  reward: 21500
+  description: bounty-description-nexus-uplink
+  entries:
+  - name: bounty-item-nexus-uplink
+    amount: 1
+    whitelist:
+      tags:
+      - NexusUplink
+
+- type: cargoBounty
+  id: BountyCottonCake
+  reward: 2800
+  description: bounty-description-cotton-cake
+  entries:
+  - name: bounty-item-cotton-cake
+    amount: 1
+    whitelist:
+      tags:
+      - CottonCake
+    blacklist:
+      tags:
+      - Slice
+
+- type: cargoBounty
+  id: BountyBread
+  reward: 2000
+  description: bounty-description-cotton-bread
+  entries:
+  - name: bounty-item-cotton-bread
+    amount: 1
+    whitelist:
+      tags:
+      - CottonBread
+    blacklist:
+      tags:
+      - Slice

--- a/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
+++ b/Resources/Prototypes/_Starlight/Catalog/Bounties/bounties.yml
@@ -11,7 +11,7 @@
 
 - type: cargoBounty
   id: BountyNexusUplink
-  reward: 21500
+  reward: 12500
   description: bounty-description-nexus-uplink
   entries:
   - name: bounty-item-nexus-uplink

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/Baked/cake.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/Baked/cake.yml
@@ -66,6 +66,7 @@
       tags:
         - Cake
         - ClothMade
+        - CottonCake # Starlight
     - type: Edible
       requiresSpecialDigestion: true
 
@@ -100,6 +101,7 @@
         - Cake
         - Slice
         - ClothMade
+        - CottonCake # Starlight
     - type: Edible
       requiresSpecialDigestion: true
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/organmeats.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Consumable/Food/organmeats.yml
@@ -157,3 +157,4 @@
       tags:
         - Meat
         - Cooked
+        - SausageBun

--- a/Resources/Prototypes/_Starlight/tags.yml
+++ b/Resources/Prototypes/_Starlight/tags.yml
@@ -198,6 +198,15 @@
   id: ConstructionComment
 
 - type: Tag
+  id: CottonBread # BountyCottonBread
+
+- type: Tag
+  id: CottonCake # BountyCottonCake
+
+- type: Tag
+  id: CoupeGlass # BountyCoupeGlass
+
+- type: Tag
   id: CrispyRiceBar
 
 - type: Tag
@@ -577,6 +586,9 @@
   id: Nexus
 
 - type: Tag
+  id: NexusUplink # BountyNexusUplink
+
+- type: Tag
   id: NonLethalMech # Used to allow nonlethal mech equipment on a mech.
 
 - type: Tag
@@ -660,10 +672,16 @@
   id: RollerBed
 
 - type: Tag
+  id: Salad # BountySalad
+
+- type: Tag
   id: SalvageTicket
 
 - type: Tag
   id: Sausage # MetamorphRecipe: FoodSausageBun
+
+- type: Tag
+  id: SausageBun # BountySausageBun
 
 - type: Tag
   id: ScanGateMachineBoard


### PR DESCRIPTION
## Short description
Adds a small amount of additional cargo bounties, mainly in underutilized or Starlight specific areas.

## Why we need to add this
Bigger variation in bounty types to encourage seeking or making specific items.

### Specific bounties
1. **Cotton Bread** - A duplicate of the existing Bread bounty, but cotton. Encourages chefs to prepare cotton food.
2. **Cotton Cake** - A weaker cotton variant of the existing pie bounty. Encourages chefs to prepare cotton food.
3. **Coupe Glass** - Low-value but easy bounty for an item rarely used by bartenders. Can be fabricated.
4. **Salad** - Each salad requires 3-5 different botany products _and_ involvement of the chef to make. Requires roughly the same amount of produce and yields the same rewards as the lemon/lime bounties. Encourages chefs to prepare vegetarian/vegan foods.
5. **Sausage on a bun** - Starlight specific recipe with diverse cooking steps. Easy to mass produce after some initial setup. Encourages chefs to prepare Starlight recipes.

## Media (Video/Screenshots)
https://github.com/user-attachments/assets/280e93f9-1e35-4ad7-9c69-f45ee4930ebb

## Checks
- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
:cl: Xale
- add: Added 5 new cargo bounties.