### PR TITLE
Performance: throttle per-tick Update() in 5 hot EntitySystems

### DIFF
--- a/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
@@ -13,8 +13,10 @@ public sealed partial class TempAffectingAnomalySystem : EntitySystem
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private TransformSystem _xform = default!;
 
-    private float _updateAccumulator; // Starlight
-    private const float UpdateInterval = 0.25f; // Starlight
+    #region Starlight
+    private float _updateAccumulator;
+    private const float UpdateInterval = 0.25f;
+    #endregion
 
     public override void Update(float frameTime)
     {

--- a/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
+++ b/Content.Server/Anomaly/Effects/TempAffectingAnomalySystem.cs
@@ -13,9 +13,20 @@ public sealed partial class TempAffectingAnomalySystem : EntitySystem
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private TransformSystem _xform = default!;
 
+    private float _updateAccumulator; // Starlight
+    private const float UpdateInterval = 0.25f; // Starlight
+
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+
+        #region Starlight
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateInterval)
+            return;
+
+        _updateAccumulator -= UpdateInterval;
+        #endregion
 
         var query = EntityQueryEnumerator<TempAffectingAnomalyComponent, AnomalyComponent, TransformComponent>();
         while (query.MoveNext(out var ent, out var comp, out var anom, out var xform))
@@ -27,7 +38,7 @@ public sealed partial class TempAffectingAnomalySystem : EntitySystem
 
             if (mixture is { })
             {
-                mixture.Temperature += comp.TempChangePerSecond * anom.Severity * frameTime;
+                mixture.Temperature += comp.TempChangePerSecond * anom.Severity * UpdateInterval; // Starlight-edit: was frameTime
             }
 
             if (grid != null && anom.Severity > comp.AnomalyHotSpotThreshold)

--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -7,11 +7,20 @@ public sealed partial class IgnitionSourceSystem : SharedIgnitionSourceSystem
 {
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    private float _updateAccumulator; // Starlight
+    private const float UpdateInterval = 0.25f; // Starlight
 
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
 
+        #region Starlight
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateInterval)
+            return;
+
+        _updateAccumulator -= UpdateInterval;
+        #endregion
         // Starlight - most ignition sources (every welder, lighter, anything that burned once) are off,
         // only fetch the transform for lit ones.
         var query = EntityQueryEnumerator<IgnitionSourceComponent>();

--- a/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
+++ b/Content.Server/IgnitionSource/IgnitionSourceSystem.cs
@@ -7,8 +7,11 @@ public sealed partial class IgnitionSourceSystem : SharedIgnitionSourceSystem
 {
     [Dependency] private AtmosphereSystem _atmosphere = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    private float _updateAccumulator; // Starlight
-    private const float UpdateInterval = 0.25f; // Starlight
+
+    #region Starlight
+    private float _updateAccumulator;
+    private const float UpdateInterval = 0.25f;
+    #endregion
 
     public override void Update(float frameTime)
     {

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -35,6 +35,9 @@ namespace Content.Server.Light.EntitySystems
 
         private static readonly ProtoId<TagPrototype> TrashTag = "Trash";
 
+        private float _updateAccumulator; // Starlight
+        private const float UpdateInterval = 0.25f; // Starlight
+
         public override void Initialize()
         {
             base.Initialize();
@@ -48,10 +51,22 @@ namespace Content.Server.Light.EntitySystems
 
         public override void Update(float frameTime)
         {
+            #region Starlight
+            _updateAccumulator += frameTime;
+            if (_updateAccumulator < UpdateInterval)
+                return;
+
+            var elapsed = _updateAccumulator;
+            _updateAccumulator -= UpdateInterval;
+            #endregion
+
             var query = EntityQueryEnumerator<ExpendableLightComponent>();
             while (query.MoveNext(out var uid, out var light))
             {
-                UpdateLight((uid, light), frameTime);
+                if (!light.Activated) // Starlight
+                    continue;
+
+                UpdateLight((uid, light), elapsed); // Starlight-edit: was frameTime
             }
         }
 

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -57,7 +57,7 @@ namespace Content.Server.Light.EntitySystems
                 return;
 
             var elapsed = _updateAccumulator;
-            _updateAccumulator -= UpdateInterval;
+            _updateAccumulator = 0f;
             #endregion
 
             var query = EntityQueryEnumerator<ExpendableLightComponent>();

--- a/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
+++ b/Content.Server/Light/EntitySystems/ExpendableLightSystem.cs
@@ -35,8 +35,10 @@ namespace Content.Server.Light.EntitySystems
 
         private static readonly ProtoId<TagPrototype> TrashTag = "Trash";
 
-        private float _updateAccumulator; // Starlight
-        private const float UpdateInterval = 0.25f; // Starlight
+        #region Starlight
+        private float _updateAccumulator;
+        private const float UpdateInterval = 0.25f;
+        #endregion
 
         public override void Initialize()
         {

--- a/Content.Server/Pinpointer/PinpointerSystem.cs
+++ b/Content.Server/Pinpointer/PinpointerSystem.cs
@@ -14,6 +14,9 @@ public sealed partial class PinpointerSystem : SharedPinpointerSystem
 
     private EntityQuery<TransformComponent> _xformQuery;
 
+    private float _updateAccumulator; // Starlight
+    private const float UpdateInterval = 0.25f; // Starlight
+
     public override void Initialize()
     {
         base.Initialize();
@@ -93,11 +96,19 @@ public sealed partial class PinpointerSystem : SharedPinpointerSystem
     {
         base.Update(frameTime);
 
-        // because target or pinpointer can move
-        // we need to update pinpointers arrow each frame
+        // Starlight: only active pinpointers need their arrow refreshed, and not every single tick
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateInterval)
+            return;
+
+        _updateAccumulator -= UpdateInterval;
+
         var query = EntityQueryEnumerator<PinpointerComponent>();
         while (query.MoveNext(out var uid, out var pinpointer))
         {
+            if (!pinpointer.IsActive) // Starlight
+                continue;
+
             UpdateDirectionToTarget(uid, pinpointer);
         }
     }

--- a/Content.Server/Pinpointer/PinpointerSystem.cs
+++ b/Content.Server/Pinpointer/PinpointerSystem.cs
@@ -14,8 +14,10 @@ public sealed partial class PinpointerSystem : SharedPinpointerSystem
 
     private EntityQuery<TransformComponent> _xformQuery;
 
-    private float _updateAccumulator; // Starlight
-    private const float UpdateInterval = 0.25f; // Starlight
+    #region Starlight
+    private float _updateAccumulator;
+    private const float UpdateInterval = 0.25f;
+    #endregion
 
     public override void Initialize()
     {

--- a/Content.Server/_Starlight/Xenoborgs/IntrinsicPinpointerSystem.cs
+++ b/Content.Server/_Starlight/Xenoborgs/IntrinsicPinpointerSystem.cs
@@ -15,6 +15,9 @@ public sealed partial class IntrinsicPinpointerSystem : EntitySystem
 
     private EntityQuery<TransformComponent> _xformQuery;
 
+    private float _updateAccumulator;
+    private const float UpdateInterval = 0.25f;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -23,6 +26,12 @@ public sealed partial class IntrinsicPinpointerSystem : EntitySystem
 
     public override void Update(float frameTime)
     {
+        _updateAccumulator += frameTime;
+        if (_updateAccumulator < UpdateInterval)
+            return;
+
+        _updateAccumulator -= UpdateInterval;
+
         var query = EntityQueryEnumerator<IntrinsicPinpointerComponent, TransformComponent>();
         while (query.MoveNext(out var uid, out var comp, out var xform))
         {


### PR DESCRIPTION
## Short description

Reduces the Update() interval from per-simulation-tick to 4 Hz in the following systems:
(UpdateInterval = 0.25f) 

* **PinpointerSystem:** UpdateDirectionToTarget refresh, now limited to IsActive pinpointers.
* **IntrinsicPinpointerSystem:** nearest-target search for borg/intrinsic pinpointers.
* **IgnitionSourceSystem:** lit-source sweep (transform lookup and hotspot expose).
* **ExpendableLightSystem:** light state updates, with !light.Activated entities excluded from the query.
* **TempAffectingAnomalySystem:** atmosphere-mixture temperature update; the delta is computed against UpdateInterval rather than frameTime so it is not under-applied between throttled ticks.

## Why we need to add this

Each of these systems performs per-entity work every simulation tick without
requiring that resolution. The cost scales with player count (pinpointers,
borgs) and map state (lit welders, burning flares, anomalies). 

Updating four times per second instead of ~30–60 removes that overhead with no user-visible
change in behaviour.

## Media (Video/Screenshots)

N/A... Server-side performance change, no gameplay or UI differences.

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [X] I do not require assistance to complete the PR.
- [X] Before posting/requesting review of a PR, I have verified that the changes work.
- [X] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [X] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Kamila, wonderfulnewworld
- tweak: Reduced server CPU cost of pinpointers, ignition sources, expendable lights, and temperature-affecting anomalies by throttling their update rate.

