### PR TITLE
Guildsalv contra fixes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -110,7 +110,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ClothingMaskGas, BaseCargoSalvageContraband]
+  parent: [ClothingMaskGas, BaseCargoSalvageContraband] #starlight
   id: ClothingMaskGasExplorer
   name: explorer gas mask
   description: A military-grade gas mask that can be connected to an air supply.

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -110,7 +110,7 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ClothingMaskGas, BaseCargoContraband]
+  parent: [ClothingMaskGas, BaseCargoSalvageContraband]
   id: ClothingMaskGasExplorer
   name: explorer gas mask
   description: A military-grade gas mask that can be connected to an air supply.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -87,7 +87,7 @@
 
 #Spationaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband]
   id: ClothingOuterHardsuitSpatio
   name: spationaut hardsuit
   description: A lightweight hardsuit designed for industrial EVA in zero gravity.
@@ -165,7 +165,7 @@
 
 #Goliath Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband]
   id: ClothingOuterHardsuitGoliath
   name: goliath hardsuit
   description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -87,7 +87,7 @@
 
 #Spationaut Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband] #starlight
   id: ClothingOuterHardsuitSpatio
   name: spationaut hardsuit
   description: A lightweight hardsuit designed for industrial EVA in zero gravity.
@@ -165,7 +165,7 @@
 
 #Goliath Hardsuit
 - type: entity
-  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband]
+  parent: [ClothingOuterHardsuitBase, BaseCargoSalvageContraband] #starlight
   id: ClothingOuterHardsuitGoliath
   name: goliath hardsuit
   description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.
@@ -205,7 +205,7 @@
 
 # Hardsuit
 - type: entity
-  parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ] #Starlight salvContra
+  parent: [ ClothingOuterHardsuitBase, BaseSalvageContraband ] #Starlight
   id: ClothingOuterHardsuitMaxim
   name: salvager maxim hardsuit
   description: Fire. Heat. These things forge great weapons, they also forge great salvagers. #Has built-in battery-powered energy barrier technology.

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: proto-kinetic accelerator
   id: WeaponProtoKineticAccelerator
-  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoContraband]
+  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoSalvageContraband]
   description: Fires low-damage kinetic bolts at a short range.
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/pka.yml
@@ -1,7 +1,7 @@
 - type: entity
   name: proto-kinetic accelerator
   id: WeaponProtoKineticAccelerator
-  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoSalvageContraband]
+  parent: [WeaponProtoKineticAcceleratorBase, BaseCargoSalvageContraband] #Starlight
   description: Fires low-damage kinetic bolts at a short range.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Misc/identification_cards.yml
@@ -202,7 +202,7 @@
       listNumber: false
 
 - type: entity
-  parent: [ IDCardStandard, BaseCargoContraband ]
+  parent: [ IDCardStandard, BaseSalvageContraband ]
   id: SalvageLeadIDCard
   name: salvage lead ID card
   components:
@@ -1063,7 +1063,7 @@
     listNumber: false
 
 - type: entity
-  parent: [ IDCardStandard, BaseCargoContraband ]
+  parent: [ IDCardStandard, BaseSalvageContraband ]
   id: SalvageMedicIDCard
   name: salvage medic ID card
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/industrial.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/Weapons/Gun/industrial.yml
@@ -3,7 +3,7 @@
   name: exosuit proto-kinetic accelerator
   description: Fires normal-damage kinetic bolts at a short range.
   suffix: Mech Weapon, Gun, Industrial, Kinetic Accelerator
-  parent: [ BaseMechWeaponRange, IndustrialMechEquipment, BaseCargoContraband ]
+  parent: [ BaseMechWeaponRange, IndustrialMechEquipment, BaseCargoSalvageContraband ]
   components:
   - type: Sprite
     sprite: Objects/Specific/Mech/mecha_equipment.rsi

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Specific/Mechs/mechs.yml
@@ -229,7 +229,7 @@
 # Clarke
 - type: entity
   id: MechClarke
-  parent: [ BaseMech, IndustrialMech, BaseCargoContraband ]
+  parent: [ BaseMech, IndustrialMech, BaseCargoSalvageContraband ]
   name: Clarke
   description: A special-purpose mech for heavy-duty mining operations. Outfitted with treads for stable locomotion in hazardous terrain.
   components:

--- a/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
@@ -210,3 +210,11 @@
   components:
   - type: Contraband
     allowedDepartments: [ Security, Science, Command, Representatives ]
+
+- type: entity
+  id: BaseCargoSalvageContraband
+  parent: BaseRestrictedContraband
+  abstract: true
+  components:
+  - type: Contraband
+    allowedDepartments: [ Salvage, Cargo ]

--- a/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
@@ -45,7 +45,7 @@
   abstract: true
   components:
   - type: Contraband
-    allowedJobs: [ SalvageSpecialist, SalvageLead ]
+    allowedDepartments: [ ITG ]
 
 - type: entity
   id: BaseMiningContraband
@@ -61,7 +61,8 @@
   abstract: true
   components:
   - type: Contraband
-    allowedJobs: [ SalvageSpecialist, SalvageLead, MiningSpecialist ]
+    allowedDepartments: [ ITG ]
+    allowedJobs: [ MiningSpecialist ]
 
 - type: entity
   id: BaseSecuritySalvageContraband
@@ -69,8 +70,7 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Security ]
-    allowedJobs: [ SalvageSpecialist, SalvageLead ]
+    allowedDepartments: [ Security, ITG ]
 
 - type: entity
   id: BaseSecuritySalvageMiningContraband
@@ -78,8 +78,8 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Security ]
-    allowedJobs: [ SalvageSpecialist, SalvageLead, MiningSpecialist ]
+    allowedDepartments: [ Security, ITG ]
+    allowedJobs: [ MiningSpecialist ]
 
 - type: entity
   id: BaseEngineeringSalvageContraband
@@ -87,8 +87,7 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Engineering ]
-    allowedJobs: [ SalvageSpecialist, SalvageLead ]
+    allowedDepartments: [ Engineering, ITG ]
 
 # This might look really stupid but it's sadly necessary as conflicting base contra groups tend to be mutually exclusive...
 - type: entity
@@ -97,8 +96,7 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Engineering, Security ]
-    allowedJobs: [ SalvageSpecialist, SalvageLead ]
+    allowedDepartments: [ Engineering, Security, ITG ]
 
 # it got worse
 - type: entity
@@ -107,8 +105,8 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Engineering, Security, Command ]
-    allowedJobs: [ SalvageSpecialist, SalvageLead, MiningSpecialist ]
+    allowedDepartments: [ Engineering, Security, Command, ITG ]
+    allowedJobs: [ MiningSpecialist ]
 
 - type: entity
   id: BaseLawContraband

--- a/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/base_contraband.yml
@@ -217,4 +217,4 @@
   abstract: true
   components:
   - type: Contraband
-    allowedDepartments: [ Salvage, Cargo ]
+    allowedDepartments: [ ITG, Cargo ]


### PR DESCRIPTION
## Short description
Adds a CargoSalvage contra tag

## Why we need to add this
So salvs arent unintentionally carrying contraband onto the station

## Media (Video/Screenshots)
<img width="1270" height="305" alt="image" src="https://github.com/user-attachments/assets/b0fee995-d422-4e76-9671-9bd0e7ef5529" />

## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: Swonki
- fix: Contra tags for salvage equipment.
