### PR TITLE
Colossus-lategame-balancepatch-and-more

### DIFF
--- a/Content.Server/_Starlight/Dragon/DragonRiftSystem.cs
+++ b/Content.Server/_Starlight/Dragon/DragonRiftSystem.cs
@@ -99,7 +99,7 @@ public sealed partial class DragonRiftSystem
                 {
 
                     var totalCrewCount = _crewCount.GetTotalCrewCount();
-                    comp.SharkMinnowLimit = totalCrewCount / 2;
+                    comp.SharkMinnowLimit = totalCrewCount / 8;
                     Dirty(uid, comp);
 
                     var canSpawnSharkminnow = true;

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
@@ -149,7 +149,7 @@
         sound:
           collection: MeatLaserImpact
   - type: CosmicRiftHealth
-    healthPerCorpse: 25
+    healthPerCorpse: 20
   - type: Bloodstream
     bloodReferenceSolution:
       reagents:

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
@@ -14,8 +14,8 @@
     factions:
     - CosmicCult
   - type: CosmicMalignantHealing
-    healInterval: 1s
-    healAmount: 0.2
+    healInterval: 5s
+    healAmount: 0.5
   - type: StaminaResistance
     damageCoefficient: 0 # No more stunning colossi
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/colossus.yml
@@ -14,8 +14,8 @@
     factions:
     - CosmicCult
   - type: CosmicMalignantHealing
-    healInterval: 5s
-    healAmount: 0.5
+    healInterval: 10s
+    healAmount: 1
   - type: StaminaResistance
     damageCoefficient: 0 # No more stunning colossi
   - type: Sprite

--- a/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/Mobs/hostiles.yml
@@ -48,8 +48,8 @@
     factions:
     - CosmicCult
   - type: CosmicMalignantHealing
-    healInterval: 1s
-    healAmount: 0.1
+    healInterval: 10s
+    healAmount: 0.5
   - type: GhostRole
     allowMovement: true
     allowSpeech: true
@@ -76,7 +76,7 @@
     damageContainer: StructuralInorganic
     damageModifierSet: Malignstone
   - type: CosmicRiftHealth
-    healthPerCorpse: 5
+    healthPerCorpse: 2
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/_Starlight/CosmicCult/events.yml
+++ b/Resources/Prototypes/_Starlight/CosmicCult/events.yml
@@ -4,9 +4,9 @@
   components:
   - type: StationEvent
     weight: 2
-    earliestStart: 30
+    earliestStart: 45
     reoccurrenceDelay: 20
-    minimumPlayers: 30
+    minimumPlayers: 40
     duration: null
   - type: SpaceSpawnRule
   - type: AntagSpawner

--- a/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Mobs/NPCs/carp.yml
@@ -123,6 +123,12 @@
     - type: GhostTakeoverAvailable
     - type: Damageable
       damageModifierSet: DragonCarpResistances
+    - type: Prying
+      pryPowered: true
+      force: true
+      speedModifier: 2
+      useSound:
+        path: /Audio/Items/crowbar.ogg
 
 - type: entity
   name: holocarp
@@ -143,4 +149,10 @@
       mindRoles:
       - MindRoleGhostRoleTeamAntagonistFlock
     - type: GhostTakeoverAvailable
+    - type: Prying
+      pryPowered: true
+      force: true
+      speedModifier: 1
+      useSound:
+        path: /Audio/Items/crowbar.ogg
 

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Projectiles/hitscan.yml
@@ -1011,7 +1011,7 @@
   categories: [ HideSpawnMenu ]
   components:
   - type: HitscanBasicDamage
-    armorPenetration: 0.3
+    armorPenetration: 0.2
     damage:
       types:
         Piercing: 40


### PR DESCRIPTION
## Short description
Adjust some stats of the lategame addtion of the colossus.

## Why we need to add this
Tweak it an bit more to prevent lowpop issues, and general balance.

## Media (Video/Screenshots)
N/A

i did test the prying of doors with sharkminnow.

## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: SirLutz
- tweak: Colossus and Malign Minion passive regeneration on tiles has been halved.
- tweak: Colossus and minions gain less maxhealth per occupied rift, C: 25->20, M: 5->2.
- tweak: LoneColossus now spawns after 45 minutes and an population above 40.
- tweak: Colossus now only gets 25% Maxhp boost from antagscaling instead of 50%.
- tweak: Dragon Shark limit is now crewcount/8 instead of crewcount/2.
- tweak: Shotgun Slugshots reduced from 0.3 to 0.2.
- add: Dragon Sharkminnows and Holocarps can now pry doors.