### PR TITLE
Mind command update + Cryo Pod bugfix

### DIFF
--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -1,4 +1,5 @@
-using System.Linq;// Starlight
+using System.Linq;
+using Content.Server.Silicons.StationAi; // Starlight
 using Content.Shared.Administration;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
@@ -7,7 +8,6 @@ using Content.Shared.Silicons.Borgs.Components;// Starlight
 using Content.Shared.Silicons.StationAi; //Starlight
 using Robust.Server.Player;
 using Robust.Shared.Console;
-using Robust.Shared.Containers;// Starlight
 
 namespace Content.Server.Administration.Commands
 {
@@ -16,7 +16,7 @@ namespace Content.Server.Administration.Commands
     {
         [Dependency] private IPlayerManager _playerManager = default!;
         [Dependency] private SharedMindSystem _mindSystem = default!;
-        [Dependency] private SharedContainerSystem _containers = default!;// Starlight
+        [Dependency] private StationAiSystem _ai = default!; // Starlight
 
         public override string Command => "setmind";
 
@@ -72,21 +72,7 @@ namespace Content.Server.Administration.Commands
             var metadata = EntityManager.GetComponent<MetaDataComponent>(eUid.Value);
 
             var mind = playerCData.Mind ?? _mindSystem.CreateMind(session.UserId, metadata.EntityName);
-            // Starlight-start
-            if (EntityManager.HasComponent<StationAiCoreComponent>(eUid))
-            {
-
-                foreach (var entity in _containers.GetAllContainers((EntityUid)eUid).SelectMany(container => container.ContainedEntities))
-                {
-                    if (!EntityManager.HasComponent<BorgBrainComponent>(entity)) continue;
-                    _mindSystem.TransferTo(mind, entity);
-                    return;
-                }
-                var brain = EntityManager.SpawnInContainerOrDrop("StationAiBrainConstructed", (EntityUid)eUid, StationAiCoreComponent.Container);
-                _mindSystem.TransferTo(mind, brain);
-                return;
-            }
-            // Starlight-end
+            _ai.TryControlAI(mind, eUid.Value); // Starlight
 
             _mindSystem.TransferTo(mind, eUid, ghostOverride);
         }

--- a/Content.Server/Administration/Commands/SetMindCommand.cs
+++ b/Content.Server/Administration/Commands/SetMindCommand.cs
@@ -72,7 +72,7 @@ namespace Content.Server.Administration.Commands
             var metadata = EntityManager.GetComponent<MetaDataComponent>(eUid.Value);
 
             var mind = playerCData.Mind ?? _mindSystem.CreateMind(session.UserId, metadata.EntityName);
-            _ai.TryControlAI(mind, eUid.Value); // Starlight
+            if (_ai.TryControlAI(mind, eUid.Value)) return; // Starlight
 
             _mindSystem.TransferTo(mind, eUid, ghostOverride);
         }

--- a/Content.Server/Mind/Toolshed/MindCommand.cs
+++ b/Content.Server/Mind/Toolshed/MindCommand.cs
@@ -2,7 +2,10 @@
 using Robust.Shared.Player;
 using Robust.Shared.Toolshed;
 using Robust.Shared.Toolshed.Errors;
-using System.Linq; // Starlight
+using System.Linq;
+using System.Runtime.InteropServices;
+using Content.Server.Silicons.StationAi;
+using Content.Shared._Starlight.Commands;
 
 namespace Content.Server.Mind.Toolshed;
 
@@ -13,6 +16,7 @@ namespace Content.Server.Mind.Toolshed;
 public sealed class MindCommand : ToolshedCommand
 {
     private SharedMindSystem? _mind;
+    private StationAiSystem? _ai;
 
     // Starlight begin: I can't find any reason to get component instead of entity, so changed it to return entity.
     [CommandImplementation("get")]
@@ -31,17 +35,17 @@ public sealed class MindCommand : ToolshedCommand
     // Starlight end
 
     [CommandImplementation("control")]
-    public EntityUid Control(IInvocationContext ctx, [PipedArgument] EntityUid target, ICommonSession player)
+    public EntityUid Control(IInvocationContext ctx, [PipedArgument] EntityUid target, ICommonSession player, [Optional] [DefaultParameterValue(true)] bool tryAi) // Starlight edit
     {
         _mind ??= GetSys<SharedMindSystem>();
-
-
+        _ai ??= GetSys<StationAiSystem>(); // Starlight
         if (!_mind.TryGetMind(player, out var mindId, out var mind))
         {
             ctx.ReportError(new SessionHasNoEntityError(player));
             return target;
         }
 
+        if (tryAi && _ai.TryControlAI(mindId, target)) return target; // Starlight
         _mind.TransferTo(mindId, target, mind: mind);
         return target;
     }
@@ -49,9 +53,14 @@ public sealed class MindCommand : ToolshedCommand
     #region Starlight
 
     [CommandImplementation("takeover")]
-    public EntityUid Takeover(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    public EntityUid Takeover(IInvocationContext ctx, [PipedArgument] EntityUid uid, [Optional] [DefaultParameterValue(true)] bool tryAi)
     {
         _mind ??= GetSys<SharedMindSystem>();
+        _ai ??= GetSys<StationAiSystem>();
+        if (CommandHelpers.NoSession(ctx) ||
+            (tryAi && _mind.TryGetMind(ctx.Session, out var mindId, out _) &&
+             _ai.TryControlAI(mindId, uid))) return uid;
+
         _mind.ControlMob(ctx.Session!.UserId, uid);
         return uid;
     }
@@ -60,9 +69,9 @@ public sealed class MindCommand : ToolshedCommand
     public EntityUid Wipe(IInvocationContext ctx, [PipedArgument] EntityUid uid)
     {
         _mind ??= GetSys<SharedMindSystem>();
-        if (!_mind.TryGetMind(uid, out var mindId, out var mind))
+        if (!_mind.TryGetMind(uid, out var mindId, out _))
         {
-            ctx.WriteLine("Entity has no mind to wipe.");
+            CommandMarkup.Error(ctx, "Entity has no mind to wipe.");
             return uid;
         }
 
@@ -74,7 +83,7 @@ public sealed class MindCommand : ToolshedCommand
     public ICommonSession Wipe(IInvocationContext ctx, [PipedArgument] ICommonSession player)
     {
         _mind ??= GetSys<SharedMindSystem>();
-        if (!_mind.TryGetMind(player, out var mindId, out var mind))
+        if (!_mind.TryGetMind(player, out var mindId, out _))
         {
             ctx.ReportError(new SessionHasNoEntityError(player));
             return player;
@@ -85,19 +94,38 @@ public sealed class MindCommand : ToolshedCommand
     }
 
     [CommandImplementation("takeoverwipe")]
-    public EntityUid TakeoverWipe(IInvocationContext ctx, [PipedArgument] EntityUid uid)
+    public EntityUid TakeoverWipe(IInvocationContext ctx, [PipedArgument] EntityUid uid, [Optional] [DefaultParameterValue(true)] bool tryAi)
     {
         _mind ??= GetSys<SharedMindSystem>();
-        _mind.WipeMind(ctx.Session!);
+        _ai ??= GetSys<StationAiSystem>();
+        if (CommandHelpers.NoSession(ctx)) return uid;
+
+        if (!_mind.TryGetMind(uid, out var mindId, out _))
+        {
+            CommandMarkup.Error(ctx, "Entity has no mind to wipe.");
+            return uid;
+        }
+
+        if (tryAi && _ai.TryControlAI(mindId, uid)) return uid;
         _mind.ControlMob(ctx.Session!.UserId, uid);
         return uid;
     }
 
     [CommandImplementation("controlwipe")]
-    public EntityUid ControlWipe(IInvocationContext ctx, [PipedArgument] EntityUid uid, ICommonSession player)
+    public EntityUid ControlWipe(IInvocationContext ctx, [PipedArgument] EntityUid uid, ICommonSession player, [Optional] [DefaultParameterValue(true)] bool tryAi)
     {
         _mind ??= GetSys<SharedMindSystem>();
+        _ai ??= GetSys<StationAiSystem>();
+
+        if (!_mind.TryGetMind(uid, out var mindId, out _))
+        {
+            CommandMarkup.Error(ctx, "Entity has no mind to wipe.");
+            return uid;
+        }
+
         _mind.WipeMind(player);
+
+        if (tryAi && _ai.TryControlAI(mindId, uid)) return uid;
         _mind.ControlMob(player.UserId, uid);
         return uid;
     }

--- a/Content.Server/Mind/Toolshed/MindCommand.cs
+++ b/Content.Server/Mind/Toolshed/MindCommand.cs
@@ -16,7 +16,6 @@ namespace Content.Server.Mind.Toolshed;
 public sealed class MindCommand : ToolshedCommand
 {
     private SharedMindSystem? _mind;
-    private StationAiSystem? _ai;
 
     // Starlight begin: I can't find any reason to get component instead of entity, so changed it to return entity.
     [CommandImplementation("get")]
@@ -51,6 +50,8 @@ public sealed class MindCommand : ToolshedCommand
     }
 
     #region Starlight
+
+    private StationAiSystem? _ai;
 
     [CommandImplementation("takeover")]
     public EntityUid Takeover(IInvocationContext ctx, [PipedArgument] EntityUid uid, [Optional] [DefaultParameterValue(true)] bool tryAi)
@@ -104,7 +105,13 @@ public sealed class MindCommand : ToolshedCommand
             return uid;
         }
 
-        if (tryAi && _ai.TryControlAI(mindId, uid)) return uid;
+        _mind.WipeMind(ctx.Session!);
+
+        if (tryAi)
+        {
+            mindId = _mind.GetOrCreateMind(ctx.Session!.UserId);
+            if (_ai.TryControlAI(mindId, uid)) return uid;
+        }
         _mind.ControlMob(ctx.Session!.UserId, uid);
         return uid;
     }

--- a/Content.Server/Mind/Toolshed/MindCommand.cs
+++ b/Content.Server/Mind/Toolshed/MindCommand.cs
@@ -57,9 +57,7 @@ public sealed class MindCommand : ToolshedCommand
     {
         _mind ??= GetSys<SharedMindSystem>();
         _ai ??= GetSys<StationAiSystem>();
-        if (CommandHelpers.NoSession(ctx) ||
-            (tryAi && _mind.TryGetMind(ctx.Session, out var mindId, out _) &&
-             _ai.TryControlAI(mindId, uid))) return uid;
+        if (CommandHelpers.NoSession(ctx) || (tryAi && _mind.TryGetMind(ctx.Session, out var mindId, out _) && _ai.TryControlAI(mindId, uid))) return uid;
 
         _mind.ControlMob(ctx.Session!.UserId, uid);
         return uid;

--- a/Content.Server/_Starlight/Administration/Systems/Commands/KillSignCommand.cs
+++ b/Content.Server/_Starlight/Administration/Systems/Commands/KillSignCommand.cs
@@ -1,6 +1,5 @@
 using System.Linq;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Components;

--- a/Content.Server/_Starlight/Atmos/AtmosCommand.cs
+++ b/Content.Server/_Starlight/Atmos/AtmosCommand.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Server.Atmos.Components;
 using Content.Server.Atmos.EntitySystems;

--- a/Content.Server/_Starlight/Devil/DevilCommand.cs
+++ b/Content.Server/_Starlight/Devil/DevilCommand.cs
@@ -1,5 +1,5 @@
 using System.Linq;
-using Content.Server._Starlight.Commands;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Shared._Starlight.Devil;
 using Content.Shared.Administration;

--- a/Content.Server/_Starlight/GameTicking/RuleCommand.cs
+++ b/Content.Server/_Starlight/GameTicking/RuleCommand.cs
@@ -1,6 +1,5 @@
 using System.Linq;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Shared.Administration;

--- a/Content.Server/_Starlight/Grid/GridCommand.cs
+++ b/Content.Server/_Starlight/Grid/GridCommand.cs
@@ -1,6 +1,5 @@
 using System.Linq;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Content.Shared.Ghost;

--- a/Content.Server/_Starlight/Map/GameMapCommand.cs
+++ b/Content.Server/_Starlight/Map/GameMapCommand.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using System.Numerics;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Shared.Administration;
 using Robust.Server.GameObjects;

--- a/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
+++ b/Content.Server/_Starlight/NameConfusion/NameConfusionCommand.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Shared._Starlight.NameConfusion;
 using Content.Shared.Administration;

--- a/Content.Server/_Starlight/Roles/RoleCommand.cs
+++ b/Content.Server/_Starlight/Roles/RoleCommand.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using System.Runtime.InteropServices;
-using Content.Server._Starlight.Commands;
-using Content.Server._Starlight.Toolshed;
+using Content.Shared._Starlight.Commands;
 using Content.Server.Administration;
 using Content.Server.Mind;
 using Content.Server.Roles;

--- a/Content.Server/_Starlight/Voting/VoteCommand.cs
+++ b/Content.Server/_Starlight/Voting/VoteCommand.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
-using Content.Server._Starlight.Commands;
+using Content.Shared._Starlight.Commands;
 using Content.Server._Starlight.Toolshed;
 using Content.Server.Administration;
 using Content.Server.Administration.Logs;

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -261,14 +261,14 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
     public bool InsertBody(EntityUid uid, EntityUid target, CryoPodComponent cryoPodComponent)
     {
-        if (cryoPodComponent.BodyContainer.ContainedEntity != null)
+        if (cryoPodComponent.BodyContainer.ContainedEntity != null && cryoPodComponent.BodyContainer.ContainedEntity != target) // Starlight edit
             return false;
 
         if (!HasComp<MobStateComponent>(target))
             return false;
 
         var xform = Transform(target);
-        _container.Insert((target, xform), cryoPodComponent.BodyContainer);
+        if (!HasComp<InsideCryoPodComponent>(target)) _container.Insert((target, xform), cryoPodComponent.BodyContainer); // Starlight edit
 
         EnsureComp<InsideCryoPodComponent>(target);
         _standingState.Stand(target, force: true); // Force-stand the mob so that the cryo pod sprite overlays it fully
@@ -501,6 +501,8 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
     private void OnBodyInserted(Entity<CryoPodComponent> cryoPod, ref EntInsertedIntoContainerMessage args)
     {
+        if (args.Container == cryoPod.Comp.BodyContainer && !HasComp<InsideCryoPodComponent>(args.Entity)) InsertBody(cryoPod, args.Entity, cryoPod);
+
         if (args.Container.ID == CryoPodComponent.BodyContainerName)
         {
             UI.CloseUi(cryoPod.Owner, CryoPodUiKey.Key, args.Entity);

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -501,7 +501,11 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
     private void OnBodyInserted(Entity<CryoPodComponent> cryoPod, ref EntInsertedIntoContainerMessage args)
     {
-        if (args.Container == cryoPod.Comp.BodyContainer && !HasComp<InsideCryoPodComponent>(args.Entity)) InsertBody(cryoPod, args.Entity, cryoPod);
+        if (args.Container == cryoPod.Comp.BodyContainer && !HasComp<InsideCryoPodComponent>(args.Entity))
+        {
+            EnsureComp<InsideCryoPodComponent>(args.Entity); // Ensure here to avoid reinsert attempt. Unsure if that actually affects anything but better to be safe IMHO.
+            InsertBody(cryoPod, args.Entity, cryoPod);
+        }
 
         if (args.Container.ID == CryoPodComponent.BodyContainerName)
         {

--- a/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
+++ b/Content.Shared/Medical/Cryogenics/SharedCryoPodSystem.cs
@@ -501,11 +501,13 @@ public abstract partial class SharedCryoPodSystem : EntitySystem
 
     private void OnBodyInserted(Entity<CryoPodComponent> cryoPod, ref EntInsertedIntoContainerMessage args)
     {
+        // Starlight begin
         if (args.Container == cryoPod.Comp.BodyContainer && !HasComp<InsideCryoPodComponent>(args.Entity))
         {
             EnsureComp<InsideCryoPodComponent>(args.Entity); // Ensure here to avoid reinsert attempt. Unsure if that actually affects anything but better to be safe IMHO.
             InsertBody(cryoPod, args.Entity, cryoPod);
         }
+        // Starlight end
 
         if (args.Container.ID == CryoPodComponent.BodyContainerName)
         {

--- a/Content.Shared/_Starlight/Commands/CommandHelpers.cs
+++ b/Content.Shared/_Starlight/Commands/CommandHelpers.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.Toolshed;
+
+namespace Content.Shared._Starlight.Commands;
+
+public static class CommandHelpers
+{
+    // Literally just sick and tired of checking for this manually ngl.
+    public static bool NoSession(IInvocationContext ctx)
+    {
+        if (ctx.Session is not null) return false;
+        CommandMarkup.Error(ctx, "Cannot be called from server.");
+        return true;
+    }
+}

--- a/Content.Shared/_Starlight/Commands/CommandMarkup.cs
+++ b/Content.Shared/_Starlight/Commands/CommandMarkup.cs
@@ -1,6 +1,6 @@
 using Robust.Shared.Toolshed;
 
-namespace Content.Server._Starlight.Commands;
+namespace Content.Shared._Starlight.Commands;
 
 /// Helper class to streamline doing color markup when outputting to console
 public static class CommandMarkup

--- a/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
+++ b/Content.Shared/_Starlight/Silicons/StationAi/SharedStationAiSystem.cs
@@ -1,6 +1,10 @@
+using System.Linq;
 using Content.Shared.Intellicard;
+using Content.Shared.Mind;
 using Content.Shared.PAI;
 using Content.Shared.Popups;
+using Robust.Shared.Containers;
+using Robust.Shared.Network;
 //ReSharper disable CheckNamespace
 using Content.Shared.Silicons.Borgs.Components;
 using Content.Shared._Starlight.Silicons.Borgs;
@@ -64,5 +68,19 @@ public abstract partial class SharedStationAiSystem
         _mind.TransferTo(paiMindId, brain, ghostCheckOverride: true, mind: paiMind);
         ResetNameToPrototype(pai);
         args.Handled = true;
+    }
+
+    public bool TryControlAI(EntityUid mindId, EntityUid uid)
+    {
+        if (!HasComp<StationAiCoreComponent>(uid)) return false;
+        foreach (var entity in _containers.GetAllContainers(uid).SelectMany(container => container.ContainedEntities))
+        {
+            if (!HasComp<BorgBrainComponent>(entity)) continue;
+            _mind.TransferTo(mindId, entity);
+            return true;
+        }
+        var brain = SpawnInContainerOrDrop("StationAiBrainConstructed", uid, StationAiCoreComponent.Container);
+        _mind.TransferTo(mindId, brain);
+        return true;
     }
 }


### PR DESCRIPTION
## Short description
<!-- What do you propose to change with your PR? -->
Adds support for AI takeover to all `mind:...` control/takeover commands.
Moves the code that was used for `setmind` to do that to `SharedStationAISystem` to avoid duplicated code.
Begins `CommandHelpers` class which is intended for commonly used things in toolshed commands. Right now is just used to quickly check that executing context has a session (aka server executor check)
Moves `CommandMarkup` to shared.
Fixes a slight bug with cryo pods where inserting an entity via any means other than click+drag (such as `container:insert`/`container:insertentity`) would not call the correct code required for the cryo pod to affect the entity (e.g. no cold damage, no offset, forced stand, etc). Accomplishes this via doing an additional check on `EntInsertedIntoContainerMessage` to see if the target container is the scanner body container, and that the inserted entity lacks the component that drag inserting would do.
## Why we need to add this
<!-- What is the reason for adding these changes? Please post links to Discussions as well as Bug Reports here. Please describe how this will change the game balance. -->
Speedmerge this. Last thing mentioned above is needed for an event setup planned for tomorrow. Would save literally 20 minutes of manually spawning and dragging bodies into cryo pods.
## Checks
<!-- check boxes for faster reviewing of your PR -->

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**
<!--
If you want the players to know about changes made in this PR, specify them using the template outside the comment. Short and informative.

:cl: STARLIGHT TEAM
- add: Added Starlight.
- remove: Removed SS13.
- tweak: Changed SS14.
- fix: Fixed Rinary.
-->
:cl: neomoth
- fix: Fix a bug regarding the insertion of entities into Cryo Pods where depending on the method of insertion, the inserted entity would be unaffected by the Cryo Pod.