### PR TITLE
Xenosocialized Trait

### DIFF
--- a/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitComponent.cs
@@ -10,10 +10,6 @@ namespace Content.Server._Starlight.Traits.Assorted;
 [RegisterComponent]
 public sealed partial class XenosocializedTraitComponent : Component
 {
-    [DataField]
-    public ProtoId<LanguagePrototype> BaseLanguage = SharedLanguageSystem.FallbackLanguagePrototype;
-
-
     /// <summary>
     ///     The language added by being a Neocyte.
     ///     This language is ignored when checking for base languages, unless no other languages could be found.
@@ -21,3 +17,4 @@ public sealed partial class XenosocializedTraitComponent : Component
     [DataField]
     public ProtoId<LanguagePrototype> NeocyteLanguage = "Machine";
 }
+// Derived from ForeignerTraitComponent.cs

--- a/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitComponent.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitComponent.cs
@@ -1,0 +1,23 @@
+using Content.Shared._Starlight.Language;
+using Content.Shared._Starlight.Language.Systems;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Starlight.Traits.Assorted;
+
+/// <summary>
+///     When applied to a not-yet-spawned player entity, removes the species specific language from the lists of their languages
+/// </summary>
+[RegisterComponent]
+public sealed partial class XenosocializedTraitComponent : Component
+{
+    [DataField]
+    public ProtoId<LanguagePrototype> BaseLanguage = SharedLanguageSystem.FallbackLanguagePrototype;
+
+
+    /// <summary>
+    ///     The language added by being a Neocyte.
+    ///     This language is ignored when checking for base languages, unless no other languages could be found.
+    /// </summary>
+    [DataField]
+    public ProtoId<LanguagePrototype> NeocyteLanguage = "Machine";
+}

--- a/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitSystem.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitSystem.cs
@@ -47,7 +47,6 @@ public sealed partial class XenosocializedTraitSystem : EntitySystem // Talita h
         var prototypeLanguages = ((LanguageKnowledgeComponent)component).Speaks;
 
         var nativeLanguage = prototypeLanguages.Find(it => it != SharedLanguageSystem.FallbackLanguagePrototype && it != entity.Comp.NeocyteLanguage);
-        if (nativeLanguage == default) prototypeLanguages.Find(it => it != SharedLanguageSystem.FallbackLanguagePrototype); // Try again (IPC, I don't see any other case where this happens and nativeLanguage changes.)
         if (nativeLanguage == default)
         {
             Log.Warning($"Entity {entity.Owner} does not have an native language to choose from (must have at least one non-GC for XenosocializedTrait!");
@@ -57,3 +56,4 @@ public sealed partial class XenosocializedTraitSystem : EntitySystem // Talita h
         _languages.RemoveLanguage(entity.Owner, nativeLanguage, true, true);
     }
 }
+// Derived from ForeignerTraitSystem.cs

--- a/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitSystem.cs
+++ b/Content.Server/_Starlight/Traits/Assorted/XenosocializedTraitSystem.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Content.Server.Hands.Systems;
+using Content.Server._Starlight.Language;
+using Content.Server.Storage.EntitySystems;
+using Content.Shared.Clothing.Components;
+using Content.Shared.Inventory;
+using Content.Shared._Starlight.Language;
+using Content.Shared._Starlight.Language.Systems;
+using Content.Shared._Starlight.Language.Components;
+using Content.Shared.Storage;
+using Robust.Shared.Prototypes;
+using NetCord;
+
+namespace Content.Server._Starlight.Traits.Assorted;
+
+public sealed partial class XenosocializedTraitSystem : EntitySystem // Talita heartlocket gif
+{
+    [Dependency] private EntityManager _entMan = default!;
+    [Dependency] private LanguageSystem _languages = default!;
+
+    public override void Initialize()
+        => SubscribeLocalEvent<XenosocializedTraitComponent, ComponentInit>(OnSpawn); // TraitSystem adds it after PlayerSpawnCompleteEvent so it's fine.
+
+    private void OnSpawn(Entity<XenosocializedTraitComponent> entity, ref ComponentInit args)
+    {
+
+        if (!TryComp<LanguageKnowledgeComponent>(entity, out var knowledge))
+        {
+            Log.Warning($"Entity {entity.Owner} does not have a LanguageKnowledge but has a XenosocializedTrait!");
+            return;
+        }
+        if (!TryComp(entity, out MetaDataComponent? metadata))
+        {
+            Log.Warning($"Entity {entity.Owner} does not have a MetaDataComponent?!");
+            return;
+        }
+        if (metadata.EntityPrototype == null)
+        {
+            Log.Warning($"Entity {entity.Owner} does not have an EntityPrototype?!");
+            return;
+        }
+        if (!metadata.EntityPrototype.Components.TryGetComponent("LanguageKnowledge", out var component))
+        {
+            Log.Warning($"Entity {entity.Owner}'s prototype does not have a LanguageKnowledgeComponent?!");
+            return;
+        }
+        var prototypeLanguages = ((LanguageKnowledgeComponent)component).Speaks;
+
+        var nativeLanguage = prototypeLanguages.Find(it => it != SharedLanguageSystem.FallbackLanguagePrototype && it != entity.Comp.NeocyteLanguage);
+        if (nativeLanguage == default) prototypeLanguages.Find(it => it != SharedLanguageSystem.FallbackLanguagePrototype); // Try again (IPC, I don't see any other case where this happens and nativeLanguage changes.)
+        if (nativeLanguage == default)
+        {
+            Log.Warning($"Entity {entity.Owner} does not have an native language to choose from (must have at least one non-GC for XenosocializedTrait!");
+            return;
+        }
+
+        _languages.RemoveLanguage(entity.Owner, nativeLanguage, true, true);
+    }
+}

--- a/Resources/Locale/en-US/_Starlight/traits/language-traits.ftl
+++ b/Resources/Locale/en-US/_Starlight/traits/language-traits.ftl
@@ -6,6 +6,9 @@ trait-language-foreigner-light-desc = You understand the common language, but yo
 trait-language-foreigner-name = Foreigner
 trait-language-foreigner-desc = You can't understand the common language, and you require a translator at all times to talk. You have a translator to help you with your understanding and speaking. Make sure to keep it charged.
 
+trait-language-xenosocialized-name = Xenosocialized
+trait-language-xenosocialized-desc = You were raised without being taught the language your species normaly uses.
+
 trait-language-signlanguage-name = Sign Language
 trait-language-signlanguage-desc = A sign language commonly used for those who are deaf or mute. Especially popular with spacers, due to practicality in airless environments.
 

--- a/Resources/Locale/en-US/_Starlight/traits/language-traits.ftl
+++ b/Resources/Locale/en-US/_Starlight/traits/language-traits.ftl
@@ -7,7 +7,7 @@ trait-language-foreigner-name = Foreigner
 trait-language-foreigner-desc = You can't understand the common language, and you require a translator at all times to talk. You have a translator to help you with your understanding and speaking. Make sure to keep it charged.
 
 trait-language-xenosocialized-name = Xenosocialized
-trait-language-xenosocialized-desc = You were raised without being taught the language your species normaly uses.
+trait-language-xenosocialized-desc = You were raised without being taught the language your species normally uses.
 
 trait-language-signlanguage-name = Sign Language
 trait-language-signlanguage-desc = A sign language commonly used for those who are deaf or mute. Especially popular with spacers, due to practicality in airless environments.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -60,6 +60,7 @@
     # Languages - Starlight
   - LanguageSpeaker
   - ForeignerTrait
+  - XenosocializedTrait
     # TTS - Starlight
   - TextToSpeech
   eventComponents:

--- a/Resources/Prototypes/_Starlight/Traits/languages.yml
+++ b/Resources/Prototypes/_Starlight/Traits/languages.yml
@@ -51,6 +51,7 @@
     - !type:SpeciesRequirement
       species:
         - Neocyte
+        - IPC
       inverted: true
     - !type:TraitsRequirement
       traits:

--- a/Resources/Prototypes/_Starlight/Traits/languages.yml
+++ b/Resources/Prototypes/_Starlight/Traits/languages.yml
@@ -37,6 +37,33 @@
         - Iterator
       inverted: true
 
+- type: trait
+  id: Xenosocialized
+  name: trait-language-xenosocialized-name
+  description: trait-language-xenosocialized-desc
+  category: LanguageTraits
+  cost: -2
+  effects:
+    - !type:AddCompsEffect
+      components:
+        - type: XenosocializedTrait
+  requirements:
+    - !type:SpeciesRequirement
+      species:
+        - Neocyte
+      inverted: true
+    - !type:TraitsRequirement
+      traits:
+        - Iterator
+      inverted: true
+    - !type:TraitsRequirement
+      traits:
+        - Foreigner
+      inverted: true
+    - !type:TraitsRequirement
+      traits:
+        - ForeignerLight
+      inverted: true
 # Galactic Languages // Should cost: 1
 
 - type: trait


### PR DESCRIPTION
## Short description
Adds the "Xenosocialized" trait, which removes the species native language from a given character, and the corresponding system/component code to make it work.

## Why we need to add this

Provides a new, gameplay oriented way to express character background. Players can give up the language that comes with their character's species to pick another.
[PR Workshop Thread](https://discord.com/channels/1272545509562777621/1548474509512810688)
<sub><sub>also a reference to [RTTS](https://www.runawaytothestars.com/comic/rtts-page-1-and-2/) :)</sub></sub>

## Media (Video/Screenshots)

<img width="333" height="141" alt="huh" src="https://github.com/user-attachments/assets/2e02d060-cca2-41d8-9888-d05fe7ae4140" />
<img width="657" height="64" alt="trait-in-menu" src="https://github.com/user-attachments/assets/575fe7f3-0a2b-480c-902b-e0e7d1a6d38e" />


## Checks

- [x] I do not require assistance to complete the PR.
- [x] Before posting/requesting review of a PR, I have verified that the changes work.
- [x] I have added screenshots/videos of the changes, or this PR does not change in-game mechanics.
- [x] I affirm that my changes are licensed under the [MIT License](https://github.com/ss14Starlight/space-station-14/blob/Starlight/LICENSE.TXT) and grant permission for use in this repository under its conditions.

**Changelog**

:cl: dove15567
- add: Added the Xenosocialized trait, a language trait costing -2 points that removes the species' native language from the character.

